### PR TITLE
Fix for column header issue when resizable is enabled

### DIFF
--- a/src/components/datatable/DataTable.css
+++ b/src/components/datatable/DataTable.css
@@ -25,6 +25,11 @@
     border-top: 0 none;
 }
 
+.ui-datatable thead th {
+    display: flex;
+    flex-direction: column;
+}
+
 .ui-datatable thead th, .ui-datatable tfoot td {
     text-align: center;
 }


### PR DESCRIPTION
This should fix the alignment issue on datatable head. Give it a test and let me know what you think, or if you have any suggestions.