### PR TITLE
DataTable: fix typing for rowClassName prop

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -50,7 +50,7 @@ interface DataTableProps {
     exportFilename?: string;
     contextMenu?: any;
     rowGroupMode?: string;
-    rowClassName?(): void;
+    rowClassName?(rowData: any): object;
     rowGroupHeaderTemplate?(): void;
     rowGroupFooterTemplate?(): void;
     onColumnResizeEnd?(element: any, delta: number): void;


### PR DESCRIPTION
According to the documentation, the rowClassName prop is a function taking a parameter of rowData of type any and returning an object, which would be:

rowClassName?(rowData: any): object

The current typing is incorrect:

rowClassName?(): void