### PR TITLE
ProgressSpinner css broken

### DIFF
--- a/src/components/progressspinner/ProgressSpinner.css
+++ b/src/components/progressspinner/ProgressSpinner.css
@@ -4,12 +4,12 @@
     width: 100px;
     height: 100px;
     display: inline-block;
+}
 
-&:before {
+.ui-progress-spinner::before {
      content: '';
      display: block;
      padding-top: 100%;
- }
 }
 
 .ui-progress-spinner-svg {


### PR DESCRIPTION
Hi, 

This quickfix resolve a bug ([which was already fixed/not appeared in primeng](https://github.com/primefaces/primeng/blob/master/src/app/components/progressspinner/progressspinner.css#L1-L13)), which cause breaking CSSO (and potentially other css-analysis tool, since the target piece of css is not valid) with this specific CSS.

Hope you will merge this soon (had some code depends on it 😉 ).

Thanks 👍