### PR TITLE
AutoComplete fix when resolveFieldData(...) return empty string

### DIFF
--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -216,7 +216,12 @@ export class AutoComplete extends Component {
 
     formatValue(value) {
         if(value)
-            return this.props.field ? ObjectUtils.resolveFieldData(value, this.props.field) || value : value;
+            if (this.props.field) {
+                const resolvedFieldData = ObjectUtils.resolveFieldData(value, this.props.field);
+                return resolvedFieldData !== null ? resolvedFieldData : value;
+            }
+            else
+                return value;
         else
             return '';
     }


### PR DESCRIPTION
Hi,

In AutoComplete formatValue(value) function, condition was not properlly written. formatValue was returning full value object if the field attribute was an empty string.

Exemple : 
the value is an object using custom attribute, for exemple : {customValue:'1',customField:''}
AutoComplete has the field props set to "customField".

Regards
