### PR TITLE
Clear method of messages is broken

### DIFF
--- a/src/components/messages/Messages.js
+++ b/src/components/messages/Messages.js
@@ -51,7 +51,7 @@ export class Messages extends Component {
 
     clear() {
         this.setState({
-            messages: null
+            messages: []
         })
     }
 


### PR DESCRIPTION
Clear method was setting messages to null and breaking the render. I saw on the last commit that the initial value of messages was changed to an empty list, but clear wasn't change.