### PR TITLE
Resetting the file input style to be able to select another file.

### DIFF
--- a/src/components/fileupload/FileUpload.js
+++ b/src/components/fileupload/FileUpload.js
@@ -202,6 +202,9 @@ export class FileUpload extends Component {
                     if(this.props.onUpload) {
                         this.props.onUpload({xhr: xhr, files: this.files});
                     }
+                    if(this.props.mode === 'basic') {
+                        this.fileInput.style.display = 'none';
+                    }
                 }
                 else {
                     if(this.props.onError) {


### PR DESCRIPTION
###Defect Fixes
In basic mode, the file upload component does not allow to select another file if auto is set to true.
This should reset the display style once the upload is complete, so that the file input can be clacked another time.
