### PR TITLE
BodyCell className using headerClassName prop

### DIFF
--- a/src/components/datatable/BodyCell.js
+++ b/src/components/datatable/BodyCell.js
@@ -112,7 +112,7 @@ export class BodyCell extends Component {
 
     render() {
         let content, header;
-        let cellClassName = classNames(this.props.headerClassName||this.props.className, {
+        let cellClassName = classNames(this.props.bodyClassName||this.props.className, {
                                 'ui-selection-column': this.props.selectionMode,
                                 'ui-editable-column': this.props.editor,
                                 'ui-cell-editing': this.state.editing


### PR DESCRIPTION
Fixed typo in BodyCell className from using prop headerClassName to bodyClassName. Seemed like copy/paste typo.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.