### PR TITLE
Update DataTable.js to fix IE csv filename export

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -712,7 +712,7 @@ export class DataTable extends Component {
         });
         
         if(window.navigator.msSaveOrOpenBlob) {
-            navigator.msSaveOrOpenBlob(blob, this.exportFilename + '.csv');
+            navigator.msSaveOrOpenBlob(blob, this.props.exportFilename + '.csv');
         }
         else {
             let link = document.createElement("a");


### PR DESCRIPTION
fix navigator.msSaveOrOpenBlob(blob, this.props.exportFilename + '.csv'); so that IE can define CSV export filename correctly

###Defect Fixes
https://github.com/primefaces/primereact/issues/433
