### PR TITLE
changed type definition of itemTemplate

### DIFF
--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -22,8 +22,8 @@ interface AutoCompleteProps {
     appendTo?: any;
     tabindex?: number;
     completeMethod?(e: {originalEvent: Event, query: any}): void;
-    itemTemplate?(data: any): void;
-    selectedItemTemplate?(): void;
+    itemTemplate?(data: any): JSX.Element | undefined;
+    selectedItemTemplate?(item: any): JSX.Element | undefined;
     onChange?(e: {originalEvent: Event, value: any}): void;
     onFocus?(event: Event): void;
     onBlur?(event: Event): void;

--- a/src/components/chips/Chips.d.ts
+++ b/src/components/chips/Chips.d.ts
@@ -11,7 +11,7 @@ interface ChipsProps {
     className?: string;
     onAdd?(e: {originalEvent: Event, value: any}): void;
     onRemove?(e: {originalEvent: Event, value: any}): void;
-    itemTemplate?(): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
 }
 
 export class Chips extends React.Component<ChipsProps,any> {}

--- a/src/components/datagrid/DataGrid.d.ts
+++ b/src/components/datagrid/DataGrid.d.ts
@@ -15,7 +15,7 @@ interface DataGridProps {
     paginatorPosition?: string,
     paginatorTemplate?: string,
     onLazyLoad?(e: {first: number, rows:number}): void,
-    itemTemplate?(): void,
+    itemTemplate?(item: any): JSX.Element | undefined,
     header?:string,
     footer?:string;
 }

--- a/src/components/datalist/DataList.d.ts
+++ b/src/components/datalist/DataList.d.ts
@@ -15,7 +15,7 @@ interface DataListProps {
     paginatorPosition?: string;
     paginatorTemplate?: string;
     onLazyLoad?({first: number, rows:number}): void;
-    itemTemplate?(): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     header?:string;
     footer?:string;
 }

--- a/src/components/datascroller/DataScroller.d.ts
+++ b/src/components/datascroller/DataScroller.d.ts
@@ -11,7 +11,7 @@ interface DataScrollerProps {
     style?: object;
     className?: string;
     onLazyLoad?(p: {first: number, rows: number}): void;
-    itemTemplate?(): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     header?: string;
     footer?: string;
     lazy?: boolean;

--- a/src/components/dataview/DataView.d.ts
+++ b/src/components/dataview/DataView.d.ts
@@ -22,7 +22,7 @@ interface DataViewProps {
     onLazyLoad?(e: {first: number, rows:number}): void,
     onPage?(e: {first: number, rows:number}): void,
     onSort?(e: {field: number, order:number}): void,
-    itemTemplate?(): void,
+    itemTemplate?(item: any, layout: "grid" | "list"): JSX.Element | undefined,
 }
 
 export class DataView extends React.Component<DataViewProps,any> {}

--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -5,7 +5,7 @@ interface DropdownProps {
     value?: any;
     options?: Array<any>;
     optionLabel?: string;
-    itemTemplate?(option:any): any;
+    itemTemplate?(option:any): JSX.Element | undefined;
     style?: object;
     className?: string;
     autoWidth?: boolean;

--- a/src/components/dropdown/DropdownItem.d.ts
+++ b/src/components/dropdown/DropdownItem.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface DropdownItemProps {
     option?: object;
-    template?(option:any): any;
+    template?(option:any): JSX.Element | undefined;
     selected?: boolean;
     onClick?(e: {originalEvent: Event, option: object}): void;
 }

--- a/src/components/listbox/ListBox.d.ts
+++ b/src/components/listbox/ListBox.d.ts
@@ -5,7 +5,7 @@ interface ListBoxProps {
     value?: any,
     options?: Array<any>,
     optionLabel?: string,
-    itemTemplate?(): void,
+    itemTemplate?(item: any): JSX.Element | undefined,
     style?: object,
     listStyle?: object,
     className?: string,

--- a/src/components/listbox/ListBoxItem.d.ts
+++ b/src/components/listbox/ListBoxItem.d.ts
@@ -5,7 +5,7 @@ interface ListBoxItemProps {
     selected?: boolean;
     onClick?(e: {originalEvent: Event, option: any}): void;
     onTouchEnd?(e: {originalEvent: Event, option: any}): void;
-    template?(): void;
+    template?(item: any): JSX.Element | undefined;
 }
 
 export class ListBoxItem extends React.Component<ListBoxItemProps,any> {}

--- a/src/components/multiselect/MultiSelect.d.ts
+++ b/src/components/multiselect/MultiSelect.d.ts
@@ -12,7 +12,7 @@ interface MultiSelectProps {
     disabled?: boolean;
     filter?: boolean;
     key?: string;
-    itemTemplate?(): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     onChange?(e: {originalEvent: Event, value: any}): void;
     appendTo?: HTMLElement;
 }

--- a/src/components/multiselect/MultiSelectItem.d.ts
+++ b/src/components/multiselect/MultiSelectItem.d.ts
@@ -3,7 +3,7 @@ import React = require("react");
 interface MultiSelectItemProps {
     option?: object;
     selected?: boolean;
-    template?(): void;
+    template?(item: any): JSX.Element | undefined;
     onClick?(e: {originalEvent: Event, option: object}): void;
 }
 

--- a/src/components/orderlist/OrderList.d.ts
+++ b/src/components/orderlist/OrderList.d.ts
@@ -10,7 +10,7 @@ interface OrderListProps {
     responsive?: boolean;
     dragdrop?: boolean;
     onChange?(e: {originalEvent: Event, value: any}): void;
-    itemTemplate?(item: any): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
 }
 
 export class OrderList extends React.Component<OrderListProps,any> {}

--- a/src/components/orderlist/OrderListSubList.d.ts
+++ b/src/components/orderlist/OrderListSubList.d.ts
@@ -7,7 +7,7 @@ interface OrderListSubListProps {
     listStyle?: object;
     dragdrop?: boolean;
     onItemClick?(e: {originalEvent: Event, value: any, index: number}): void;
-    itemTemplate?(item: any): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     onChange?(e: {originalEvent: Event, value: any}): void;
 }
 

--- a/src/components/picklist/PickList.d.ts
+++ b/src/components/picklist/PickList.d.ts
@@ -14,7 +14,7 @@ interface PickListProps {
     showSourceControls?: boolean;
     showTargetControls?: boolean;
     metaKeySelection?: boolean;
-    itemTemplate?(item: any): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     onChange?(e: {event: Event, source: any, target: any}): void;
     onMoveToSource?(e: {originalEvent: Event, value: any}): void;
     onMoveAllToSource?(e: {originalEvent: Event, value: any}): void;

--- a/src/components/picklist/PickListItem.d.ts
+++ b/src/components/picklist/PickListItem.d.ts
@@ -3,7 +3,7 @@ import React = require("react");
 interface PickListItemProps {
     value?: any;
     className?: string;
-    template?(item: any): void;
+    template?(item: any): JSX.Element | undefined;
     selected?: boolean;
     onClick?(e: {originalEvent: Event, value: any}): void;
 }

--- a/src/components/picklist/PickListSubList.d.ts
+++ b/src/components/picklist/PickListSubList.d.ts
@@ -9,7 +9,7 @@ interface PickListSubListProps {
     style?: object;
     showControls?: boolean;
     metaKeySelection?: boolean;
-    itemTemplate?(item: any): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
     onItemClick?(): void;
     onSelectionChange?({event: Event, value: any}): void;
 }


### PR DESCRIPTION
This PR fixes the wrong type definition of the itemTemplate prop in some components mentioned in issue #454.

I mainly changed two things:
1. added a parameter to the function (also added the layout parameter in DataView)
2. changed the return value of the function to be either a JSX.Element or undefinded (some code of your showcase is returning undefined).

type definitions in the following components are changed:
 - AutoComplete.d.ts
 - Chips.d.ts
 - DataGrid.d.ts
 - DataList.d.ts
 - DataScroller.d.ts
 - DataView.d.ts
 - Dropdown.d.ts
 - DropdownItem.d.ts
 - ListBox.d.ts
 - ListBoxItem.d.ts
 - MultiSelect.d.ts
 - MultiSelectItem.d.ts
 - OrderList.d.ts
 - OrderListSubList.d.ts
 - PickList.d.ts
 - PickListItem.d.ts
 - PickListSubList.d.ts