### PR TITLE
adds event.preventDefault() to onDrop() of BodyRow to prevent redirect bug in Firefox

### DIFF
--- a/src/components/datatable/BodyRow.js
+++ b/src/components/datatable/BodyRow.js
@@ -83,6 +83,7 @@ export class BodyRow extends Component {
                 rowElement: this.container
             });
         }
+        event.preventDefault();
     }
 
     render() {


### PR DESCRIPTION
###Defect Fixes #460 
