### PR TITLE
uses correct case for path to components/common/Common.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ primereact/resources/themes/omega/theme.css
 primereact/resources/primereact.min.css
 ```
 
-primereact.min.css is a bundle that contains styles of all components, if you require a style of a specific component import the css from the folder of the component along with the common.css.
+primereact.min.css is a bundle that contains styles of all components, if you require a style of a specific component import the css from the folder of the component along with the Common.css.
 
 ```
 primereact/resources/themes/omega/theme.css
-primereact/components/common/common.css
+primereact/components/common/Common.css
 primereact/components/autocomplete/AutoComplete.css
 ```
 

--- a/src/showcase/setup/SetupPage.js
+++ b/src/showcase/setup/SetupPage.js
@@ -99,11 +99,11 @@ primeicons/primeicons.css
 `}
 </CodeHighlight>
 
-                    <p>primereact.min.css is a bundle that contains styles of all components, if you require a style of a specific component import the css from the folder of the component along with the common.css.</p>
+                    <p>primereact.min.css is a bundle that contains styles of all components, if you require a style of a specific component import the css from the folder of the component along with the Common.css.</p>
 <CodeHighlight className="language-javascript">
 {`
 primereact/resources/themes/omega/theme.css
-primereact/components/common/common.css
+primereact/components/common/Common.css
 primereact/components/autocomplete/AutoComplete.css
 
 `}


### PR DESCRIPTION
###Defect Fixes
Path to `primereact/components/common/common.css` is `primereact/components/common/Common.css` (correct case). 

Fixes #500 