### PR TITLE
AutoComplete should accept array of objects

### DIFF
--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -24,6 +24,8 @@ interface AutoCompleteProps {
     size?: number;
     appendTo?: any;
     tabindex?: number;
+    objectsInList?: boolean;
+    displayField?: string;
     completeMethod?(e: {originalEvent: Event, query: string}): void;
     itemTemplate?(data: any): JSX.Element | undefined;
     selectedItemTemplate?(data: any): JSX.Element | undefined;

--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -34,6 +34,8 @@ export class AutoComplete extends Component {
         size: null,
         appendTo: null,
         tabindex: null,
+        objectsInList: false,
+        displayField: 'label',
         completeMethod: null,
         itemTemplate: null,
         selectedItemTemplate: null,
@@ -76,6 +78,8 @@ export class AutoComplete extends Component {
         size: PropTypes.number,
         appendTo: PropTypes.any,
         tabindex: PropTypes.number,
+        objectsInList: PropTypes.bool,
+        displayField: PropTypes.string,
         completeMethod: PropTypes.func,
         itemTemplate: PropTypes.func,
         selectedItemTemplate: PropTypes.func,
@@ -96,7 +100,7 @@ export class AutoComplete extends Component {
 
     constructor(props) {
         super(props);
-        
+
         this.onInputChange = this.onInputChange.bind(this);
         this.onInputFocus = this.onInputFocus.bind(this);
         this.onInputBlur = this.onInputBlur.bind(this);
@@ -181,18 +185,38 @@ export class AutoComplete extends Component {
     }
 
     selectItem(event, option) {
-        if(this.props.multiple) {
-            this.inputEl.value = '';
-            if(!this.isSelected(option)) {
-                let newValue = this.props.value ? [...this.props.value, option] : [option];
-                this.updateModel(event, newValue);
+        if (option === undefined) return;
+        if (this.props.multiple) {
+            let newValue='';
+            if(this.props.objectsInList) {
+                this.inputEl.value = '';
+                if (option.value === '' ) { 
+                    return;
+                }
+                if (!this.isSelectedObject(option.value)) {
+                    newValue = this.props.value ? [...this.props.value, option.value] : [option.value];
+                    this.updateModel(event, newValue);
+                } 
             }
-        }
+            else {
+                this.inputEl.value = '';
+                if (!this.isSelected(option)) {
+                    newValue = this.props.value ? [...this.props.value, option] : [option];
+                    this.updateModel(event, newValue);
+                }
+            }
+        } 
         else {
-            this.updateInputField(option);
-            this.updateModel(event, option);
+            if(this.props.objectsInList) {                         
+                if (option.value === '' ) return;                       
+                const field = this.props.displayField ? this.props.displayField : 'label';
+                this.updateInputField(option[field]);
+            }
+            else {
+                this.updateInputField(option);                        
+            } 
+            this.updateModel(event, option);            
         }
-
         if(this.props.onSelect) {
             this.props.onSelect({
                 originalEvent: event,
@@ -455,9 +479,17 @@ export class AutoComplete extends Component {
 
     findOptionIndex(option) {
         let index = -1;
-        if(this.suggestions) {
+        if (this.suggestions && this.props.objectsInList === false) {
             for(let i = 0; i < this.suggestions.length; i++) {
                 if(ObjectUtils.equals(option, this.suggestions[i])) {
+                    index = i;
+                    break;
+                }
+            }
+        }
+        else {
+            for(let i = 0; i < this.suggestions.length; i++) {
+                if(ObjectUtils.equals(option.value, this.suggestions[i].value)) {
                     index = i;
                     break;
                 }
@@ -565,14 +597,27 @@ export class AutoComplete extends Component {
             <i ref={(el) => this.loader = el} className="ui-autocomplete-loader pi pi-spinner pi-spin" style={{visibility: 'hidden'}}></i>
         );
     }
-    
+    isSelectedObject(val) {
+        var selected = false;
+        if (this.props.value && this.props.value.length) {
+            for (var i = 0; i < this.props.value.length; i++) {
+                if (ObjectUtils.equals(this.props.value[i].value, val)) {
+                    selected = true;
+                    break;
+                }
+            }
+        }
+        return selected;
+    }
     bindDocumentClickListener() {
         if(!this.documentClickListener) {
             this.documentClickListener = (event) => {
                 if(event.which === 3) {
                     return;
+                } 
+                if (event.target && event.target.className && event.target.className.indexOf('novalue4autocomplete') > -1 ) { 
+                    return;
                 }
-                
                 if(!this.inputClick && !this.dropdownClick) {
                     this.hidePanel();
                 }
@@ -616,14 +661,14 @@ export class AutoComplete extends Component {
         if(this.props.dropdown) {
             dropdown = this.renderDropdown();
         }
-
         return (
             <span ref={(el) => this.container = el} id={this.props.id} style={this.props.style} className={className} >
                 {input}
                 {loader}
                 {dropdown}
                 <AutoCompletePanel ref={(el) => this.panel = el} suggestions={this.props.suggestions} field={this.props.field} 
-                            appendTo={this.props.appendTo} itemTemplate={this.props.itemTemplate} onItemClick={this.selectItem}/>
+                    objectsInList = {this.props.objectsInList}
+                    appendTo={this.props.appendTo} itemTemplate={this.props.itemTemplate} onItemClick={this.selectItem}/>
             </span>
         );
     }

--- a/src/components/autocomplete/AutoCompletePanel.js
+++ b/src/components/autocomplete/AutoCompletePanel.js
@@ -11,7 +11,8 @@ export class AutoCompletePanel extends Component {
         appendTo: null,
         itemTemplate: null,
         onItemClick: null,
-        scrollHeight: '200px'
+        scrollHeight: '200px',
+        objectsInList: false
     }
 
     static propTypes = {
@@ -20,13 +21,14 @@ export class AutoCompletePanel extends Component {
         appendTo: PropTypes.any,
         itemTemplate: PropTypes.func,
         onItemClick: PropTypes.func,
-        scrollHeight: PropTypes.string
+        scrollHeight: PropTypes.string,
+        objectsInList: PropTypes.bool,
     };
 
     renderElement() {
         let items;
 
-        if (this.props.suggestions) {
+        if (this.props.suggestions && this.props.objectsInList === false) {
             items = this.props.suggestions.map((suggestion, index) => {
                 let itemContent = this.props.itemTemplate ? this.props.itemTemplate(suggestion) : this.props.field ? ObjectUtils.resolveFieldData(suggestion, this.props.field) : suggestion;
 
@@ -35,7 +37,31 @@ export class AutoCompletePanel extends Component {
                 );
             });
         }
+        if (this.props.suggestions && this.props.objectsInList) {
+            items = this.props.suggestions.map((suggestion, index) => {
+                let itemContent = this.props.itemTemplate ? this.props.itemTemplate(suggestion.label) 
+                    : this.props.field ? ObjectUtils.resolveFieldData(suggestion.label, this.props.field) : suggestion.label;
 
+                if (suggestion.shift && suggestion.shift === 1) 
+                    { itemContent = "\u2514\u2500\u0020" + itemContent;}  
+                else {
+                    if (suggestion.category && 
+                        (suggestion.level === undefined || (suggestion.level && suggestion.level==='0' ))) 
+                        { itemContent +=' : ' + suggestion.category;}
+                }                              
+                var clickHandler = (e) => {
+                    return this.props.onItemClick(e, suggestion);
+                };
+                var className = 'ui-autocomplete-list-item ui-corner-all';
+                if (suggestion.value === '') {
+                    clickHandler = void(0);
+                    className +=' novalue4autocomplete'
+                }
+                return (
+                    <li key={index + '_item'} className={className} onClick={clickHandler}>{itemContent}</li>        
+                ); 
+            });
+        }
         return (
             <div ref={(el) => this.element = el} className="ui-autocomplete-panel ui-widget-content ui-corner-all ui-input-overlay ui-shadow" style={{ maxHeight: this.props.scrollHeight }}>
                 <ul className="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">


### PR DESCRIPTION
Suggested changes to AutoComplete: 
- accept array of objects instead of array of strings as data feed
- allow user to choose what object's property to display in the field when the item is selected (default is 'label')

It's a very common use case.

New properties added:
```
        objectsInList: PropTypes.bool,
        displayField: PropTypes.string,
```

Example of data:
```
this.icd9codes=[
      {'value':'102','label':'YAWS'},
      {'value':'1020','label':'INITIAL LESIONS, YAWS'},
      {'value':'1021','label':'MULTIPLE PAPILLOMATA AND WET CRAB YAWS, YAWS'}];
```
Instantiating of the control:
```
<AutoComplete id="ICD9Codes"  value={this.state.code} onChange={(e) => this.setState({code: e.value})}
                suggestions={this.state.suggestedICD9} completeMethod={this.suggestICD9Data}  
                objectsInList = {true} displayField='value' multiple={true} 
                dropdown={true} dropdownMode='current' placeholder=''/>   
```


