### PR TITLE
Improve typescript definitions

### DIFF
--- a/src/components/accordion/Accordion.d.ts
+++ b/src/components/accordion/Accordion.d.ts
@@ -22,4 +22,6 @@ interface AccordionProps {
     onTabChange?(e: {originalEvent: Event, index: number}): void;
 }
 
+// tslint:disable-next-line:max-classes-per-file
 export class Accordion extends React.Component<AccordionProps,any> {}
+

--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -4,7 +4,7 @@ interface AutoCompleteProps {
     id?: string;
     value?: any;
     name?: string;
-    suggestions?: Array<any>;
+    suggestions?: any[];
     field?: string;
     scrollHeight?: string;
     dropdown?: boolean;

--- a/src/components/breadcrumb/BreadCrumb.d.ts
+++ b/src/components/breadcrumb/BreadCrumb.d.ts
@@ -3,7 +3,7 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface BreadCrumbProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     home?: any;
     style?: object;
     className?: string;

--- a/src/components/button/Button.d.ts
+++ b/src/components/button/Button.d.ts
@@ -1,6 +1,7 @@
 import React = require("react");
+import {Omit} from "../util";
 
-interface ButtonProps extends React.HTMLProps<HTMLButtonElement> {
+interface ButtonProps extends Omit<React.HTMLProps<HTMLButtonElement>, 'ref'> {
     label?: string;
     icon?: string;
     iconPos?: string;

--- a/src/components/calendar/Calendar.d.ts
+++ b/src/components/calendar/Calendar.d.ts
@@ -71,7 +71,8 @@ interface CalendarProps {
     autoZIndex?: boolean;
     baseZIndex?: number;
     appendTo?: any;
-    dateTemplate?(dateMeta:DateMetaData): JSX.Element | undefined;
+    yearRange?: string;
+    dateTemplate?(dateMeta:DateMetaData): React.ReactNode;
     onFocus?(event: Event): void;
     onBlur?(event: Event): void;
     onInput?(event: Event): void;

--- a/src/components/checkbox/Checkbox.d.ts
+++ b/src/components/checkbox/Checkbox.d.ts
@@ -5,7 +5,7 @@ interface CheckboxProps {
     inputId?: string;
     value?: any;
     name?: string;
-    checked: boolean;
+    checked?: boolean;
     style?: object;
     className?: string;
     disabled?: boolean;

--- a/src/components/chips/Chips.d.ts
+++ b/src/components/chips/Chips.d.ts
@@ -4,7 +4,7 @@ interface ChipsProps {
     id?: string;
     name?: string;
     placeholder?: string;
-    value?: Array<any>;
+    value?: any[];
     max?: number;
     disabled?: boolean;
     style?: object;

--- a/src/components/column/Column.d.ts
+++ b/src/components/column/Column.d.ts
@@ -8,14 +8,12 @@ interface ColumnProps {
     body?: any;
     footer?: any;
     sortable?: boolean;
-    sortFunction?(): void;
     filter?: boolean;
     filterMatchMode?: string;
     filterPlaceholder?: string;
     filterType?: string;
     filterMaxLength?: number;
     filterElement?: object;
-    filterFunction?(value: any, filter: any): void;
     style?: object;
     className?: string;
     headerStyle?: object;
@@ -29,10 +27,12 @@ interface ColumnProps {
     selectionMode?: string;
     colSpan?: number;
     rowSpan?: number;
-    editor?(props: any): JSX.Element | undefined;
-    editorValidator?(props: any): boolean;
     rowReorder?: boolean;
     rowReorderIcon?: string;
+    sortFunction?(): void;
+    filterFunction?(value: any, filter: any): void;
+    editor?(props: any): JSX.Element | undefined;
+    editorValidator?(props: any): boolean;
 }
 
 export class Column extends React.Component<ColumnProps,any> {}

--- a/src/components/columngroup/ColumnGroup.d.ts
+++ b/src/components/columngroup/ColumnGroup.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface ColumnGroupProps {
 }
 

--- a/src/components/contextmenu/ContextMenu.d.ts
+++ b/src/components/contextmenu/ContextMenu.d.ts
@@ -1,9 +1,10 @@
 import React = require("react");
 import {MenuItem} from '../menuitem/MenuItem';
+import {SyntheticEvent} from "react";
 
 interface ContextMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     style?: object;
     className?: string;
     global?: boolean;
@@ -14,4 +15,6 @@ interface ContextMenuProps {
     onHide?(e: Event): void;
 }
 
-export class ContextMenu extends React.Component<ContextMenuProps,any> {}
+export class ContextMenu extends React.Component<ContextMenuProps,any> {
+    public show(event:SyntheticEvent):void;
+}

--- a/src/components/datagrid/DataGrid.d.ts
+++ b/src/components/datagrid/DataGrid.d.ts
@@ -2,22 +2,22 @@ import React = require("react");
 
 interface DataGridProps {
     id?: string,
-    value?: Array<any>,
+    value?: any[],
     rows?: number,
     first?:number,
     paginator?: boolean,
     totalRecords?: number,
     pageLinks?: number,
-    rowsPerPageOptions?: Array<any>,
+    rowsPerPageOptions?: any[],
     lazy?: boolean,
     style?: string,
     className?: string,
     paginatorPosition?: string,
     paginatorTemplate?: string,
-    onLazyLoad?(e: {first: number, rows:number}): void,
-    itemTemplate?(item: any): JSX.Element | undefined,
     header?:string,
     footer?:string;
+    onLazyLoad?(e: {first: number, rows:number}): void,
+    itemTemplate?(item: any): JSX.Element | undefined,
 }
 
 export class DataGrid extends React.Component<DataGridProps,any> {}

--- a/src/components/datalist/DataList.d.ts
+++ b/src/components/datalist/DataList.d.ts
@@ -2,22 +2,22 @@ import React = require("react");
 
 interface DataListProps {
     id?: string;
-    value?: Array<any>;
+    value?: any[];
     rows?: number;
     first?:number;
     paginator?: boolean;
     totalRecords?: number;
     pageLinks?: number;
-    rowsPerPageOptions?: Array<any>;
+    rowsPerPageOptions?: any[];
     lazy?: boolean;
     style?: object;
     className?: string;
     paginatorPosition?: string;
     paginatorTemplate?: string;
-    onLazyLoad?({first: number, rows:number}): void;
-    itemTemplate?(item: any): JSX.Element | undefined;
     header?:string;
     footer?:string;
+    onLazyLoad?(e: {first: number, rows:number}): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
 }
 
 export class DataList extends React.Component<DataListProps,any> {}

--- a/src/components/datascroller/DataScroller.d.ts
+++ b/src/components/datascroller/DataScroller.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface DataScrollerProps {
     id?: string;
-    value?: Array<any>;
+    value?: any[];
     rows?: number;
     inline?: boolean;
     scrollHeight?: any;
@@ -10,11 +10,11 @@ interface DataScrollerProps {
     buffer?: number;
     style?: object;
     className?: string;
-    onLazyLoad?(e: {first: number, rows: number}): void;
-    itemTemplate?(item: any): JSX.Element | undefined;
     header?: any;
     footer?: any;
     lazy?: boolean;
+    onLazyLoad?(e: {first: number, rows: number}): void;
+    itemTemplate?(item: any): JSX.Element | undefined;
 }
 
 export class DataScroller extends React.Component<DataScrollerProps,any> {}

--- a/src/components/datatable/BodyCell.d.ts
+++ b/src/components/datatable/BodyCell.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface BodyCellProps {
 }
 

--- a/src/components/datatable/BodyRow.d.ts
+++ b/src/components/datatable/BodyRow.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface BodyRowProps {
 }
 

--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface DataTableProps {
     id?: string;
-    value?: Array<any>;
+    value?: any[];
     header?: any;
     footer?: any;
     style?: object;
@@ -23,12 +23,11 @@ interface DataTableProps {
     lazy?: boolean;
     sortField?: string;
     sortOrder?: number;
-    multiSortMeta?: Array<any>;
+    multiSortMeta?: any[];
     sortMode?: string;
     emptyMessage?: string;
     selectionMode?: string;
     selection?: any;
-    onSelectionChange?(e: {originalEvent: Event, data: any}): void;
     compareSelectionBy?: string;
     dataKey?: string;
     metaKeySelection?: boolean;
@@ -36,9 +35,7 @@ interface DataTableProps {
     footerColumnGroup?: JSX.Element;
     frozenHeaderColumnGroup?: JSX.Element;
     frozenFooterColumnGroup?: JSX.Element;
-    rowExpansionTemplate?(data: any): JSX.Element | undefined;
-    expandedRows?: Array<any>;
-    onRowToggle?(data: Array<any>): void;
+    expandedRows?: any[];
     responsive?: boolean;
     resizableColumns?: boolean;
     columnResizeMode?: string;
@@ -51,21 +48,25 @@ interface DataTableProps {
     virtualScrollDelay?: number;
     frozenWidth?: string;
     unfrozenWidth?: string;
-    frozenValue?: Array<any>;
+    frozenValue?: any[];
     csvSeparator?: string;
     exportFilename?: string;
     contextMenu?: any;
     rowGroupMode?: string;
     autoLayout?:boolean;
-    rowClassName?(rowData: any): object;
-    rowGroupHeaderTemplate?(data: any, index: number): JSX.Element | undefined;
-    rowGroupFooterTemplate?(data: any, index: number): JSX.Element | undefined;
     loading?:boolean;
     loadingIcon?:string;
+    groupField?:string;
+    onSelectionChange?(e: {originalEvent: Event, data: any}): void;
+    rowExpansionTemplate?(data: any): JSX.Element | undefined;
+    onRowToggle?(e: {data: any[]}): void;
+    rowClassName?(rowData: any): object;
+    rowGroupHeaderTemplate?(data: any, index: number): React.ReactNode | undefined;
+    rowGroupFooterTemplate?(data: any, index: number): React.ReactNode | undefined;
     onColumnResizeEnd?(e: {element: HTMLElement, delta: number}): void;
     onSort?(e: {sortField: string, sortOrder: number, multiSortMeta: any}): void;
     onPage?(e: {first: number, rows: number}): void;
-    onFilter?(filters: Array<any>): void;
+    onFilter?(filters: any[]): void;
     onVirtualScroll?(e: {first: number, rows: number}): void;
     onRowClick?(e: Event): void;
     onRowDoubleClick?(e: {originalEvent: Event, data: any, index: number}): void;
@@ -78,4 +79,7 @@ interface DataTableProps {
     onRowReorder?(e: {originalEvent: Event, value: any, dragIndex: number, dropIndex: number}): void;
 }
 
-export class DataTable extends React.Component<DataTableProps,any> {}
+export class DataTable extends React.Component<DataTableProps,any> {
+    public exportCSV():void;
+    public filter<T>(value:T, field:string, mode:string):void;
+}

--- a/src/components/datatable/FooterCell.d.ts
+++ b/src/components/datatable/FooterCell.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface FooterCellProps {
 }
 

--- a/src/components/datatable/HeaderCell.d.ts
+++ b/src/components/datatable/HeaderCell.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface HeaderCellProps {
 }
 

--- a/src/components/datatable/RowRadioButton.d.ts
+++ b/src/components/datatable/RowRadioButton.d.ts
@@ -2,8 +2,8 @@ import React = require("react");
 
 interface RowRadioButtonProps {
     rowData?: object;
-    onClick?(e: {originalEvent: Event, data: object}): void;
     selected?: boolean;
+    onClick?(e: {originalEvent: Event, data: object}): void;
 }
 
 export class RowRadioButton extends React.Component<RowRadioButtonProps,any> {}

--- a/src/components/datatable/TableBody.d.ts
+++ b/src/components/datatable/TableBody.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface TableBodyProps {
 }
 

--- a/src/components/datatable/TableFooter.d.ts
+++ b/src/components/datatable/TableFooter.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface TableFooterProps {
 }
 

--- a/src/components/datatable/TableHeader.d.ts
+++ b/src/components/datatable/TableHeader.d.ts
@@ -1,5 +1,6 @@
 import React = require("react");
 
+// tslint:disable-next-line:no-empty-interface
 interface TableHeaderProps {
 }
 

--- a/src/components/dataview/DataView.d.ts
+++ b/src/components/dataview/DataView.d.ts
@@ -5,7 +5,7 @@ interface DataViewLayoutOptionsProps {
     layout?: string,
     style?: string,
     className?: string,
-    onChange(e: {originalEvent: event, value: string}): void
+    onChange(e: {originalEvent: Event, value: string}): void
 }
 
 export class DataViewLayoutOptions extends React.Component<DataViewLayoutOptionsProps,any> {}
@@ -14,22 +14,23 @@ interface DataViewProps {
     id?: string,
     header?: JSX.Element | string,
     footer?: JSX.Element | string,
-    value?: Array<any>,
+    value?: any[],
     layout?: string,
     paginator?: boolean,
     rows?: number,
     first?: number,
     totalRecords?: number,
     pageLinks?: number,
-    rowsPerPageOptions?: Array<any>,
+    rowsPerPageOptions?: any[],
     paginatorPosition?: string,
     emptyMessage?: string,
     sortField?: string,
     sortOrder?: number,
     style?: string,
     className?: string,
-    onPage?(e: {originalEvent: event, first: number, rows: number}): void,
+    onPage?(e: {originalEvent: Event, first: number, rows: number}): void,
     itemTemplate?(item: any, layout: "grid" | "list"): JSX.Element | undefined
 }
 
+// tslint:disable-next-line:max-classes-per-file
 export class DataView extends React.Component<DataViewProps,any> {}

--- a/src/components/dialog/Dialog.d.ts
+++ b/src/components/dialog/Dialog.d.ts
@@ -8,8 +8,6 @@ interface DialogProps {
     width?: string;
     height?: string;
     modal?: boolean;
-    onHide(): void;
-    onShow?(): void;
     draggable?: boolean;
     resizable?: boolean;
     minWidth?: number;
@@ -31,6 +29,8 @@ interface DialogProps {
     minX?: number;
     minY?: number;
     maximizable?: boolean;
+    onHide(): void;
+    onShow?(): void;
 }
 
 export class Dialog extends React.Component<DialogProps,any> {}

--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -3,14 +3,14 @@ import React = require("react");
 interface DropdownProps {
     id?: string;
     value?: any;
-    options?: Array<any>;
+    options?: any[];
     optionLabel?: string;
-    itemTemplate?(option:any): JSX.Element | undefined;
     style?: object;
     className?: string;
     autoWidth?: boolean;
     scrollHeight?: string;
     filter?: boolean;
+    filterBy?: string;
     filterPlaceholder?: string;
     editable?:boolean;
     placeholder?: string;
@@ -25,6 +25,7 @@ interface DropdownProps {
     dataKey?: string;
     inputId?: string;
     showClear?: boolean;
+    itemTemplate?(option:any): React.ReactNode;
     onChange?(e: {originalEvent: Event, value: any}): void;
     onMouseDown?(event: Event): void;
     onContextMenu?(event: Event): void;

--- a/src/components/dropdown/DropdownItem.d.ts
+++ b/src/components/dropdown/DropdownItem.d.ts
@@ -2,8 +2,8 @@ import React = require("react");
 
 interface DropdownItemProps {
     option?: object;
-    template?(option:any): JSX.Element | undefined;
     selected?: boolean;
+    template?(option:any): JSX.Element | undefined;
     onClick?(e: {originalEvent: Event, option: object}): void;
 }
 

--- a/src/components/editor/Editor.d.ts
+++ b/src/components/editor/Editor.d.ts
@@ -3,14 +3,15 @@ import React = require("react");
 interface EditorProps {
     id?: string,
     value?: string,
-    style?: string,
+    style?: object,
     className?: string,
     placeholder?: string,
     readonly?: boolean,
-    formats?: Array<any>,
+    formats?: any[],
     headerTemplate?: JSX.Element | undefined,
-    onTextChange?({htmlValue: HTMLElement, textValue: string, delta: any, source: string}): void,
-    onSelectionChange?({range: any, oldRange: any, source: string}): void;
+    onTextChange?(e: { htmlValue: string|null, textValue: string, delta: any, source: string }): void,
+    onSelectionChange?(e: { range: any, oldRange: any, source: string }): void;
 }
 
-export class Editor extends React.Component<EditorProps,any> {}
+export class Editor extends React.Component<EditorProps, any> {
+}

--- a/src/components/gmap/GMap.d.ts
+++ b/src/components/gmap/GMap.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface GMapProps {
     options?: object;
-    overlays?: Array<any>;
+    overlays?: any[];
     style?: object;
     className?: string;
     onMapReady?(map: any): void;

--- a/src/components/growl/Growl.d.ts
+++ b/src/components/growl/Growl.d.ts
@@ -1,12 +1,12 @@
 import React = require("react");
 
 export interface GrowlMessage {
-    severity: 'success' | 'info' | 'warn' | 'error',
-    summary: Element | string;
-    detail: Element | string;
-    closable: boolean;
-    sticky: boolean;
-    life: number;
+    severity?: 'success' | 'info' | 'warn' | 'error',
+    summary?: React.ReactNode;
+    detail?: React.ReactNode;
+    closable?: boolean;
+    sticky?: boolean;
+    life?: number;
 }
 
 interface GrowlProps {
@@ -19,4 +19,7 @@ interface GrowlProps {
     onClose?(message: GrowlMessage): void;
 }
 
-export class Growl extends React.Component<GrowlProps,any> {}
+export class Growl extends React.Component<GrowlProps, any> {
+    public show(message: GrowlMessage | GrowlMessage[]): void;
+    public clear():void;
+}

--- a/src/components/inplace/Inplace.d.ts
+++ b/src/components/inplace/Inplace.d.ts
@@ -4,11 +4,17 @@ interface InplaceProps {
     style?: object;
     className?: string;
     active?: boolean;
-    closble?: boolean;
+    closable?: boolean;
     disabled?: boolean;
     onOpen?(event: Event): void;
     onClose?(event: Event): void;
-    onToggle?(e:{event: originalEvent, value: boolean}): void;
+    onToggle?(e:{originalEvent: Event, value: boolean}): void;
 }
 
 export class Inplace extends React.Component<InplaceProps,any> {}
+
+// tslint:disable-next-line:max-classes-per-file
+export class InplaceDisplay extends React.Component{}
+
+// tslint:disable-next-line:max-classes-per-file
+export class InplaceContent extends React.Component {}

--- a/src/components/inputtext/InputText.d.ts
+++ b/src/components/inputtext/InputText.d.ts
@@ -2,10 +2,10 @@ import React = require("react");
 
 interface InputTextProps extends React.HTMLProps<HTMLInputElement> {
     [key: string]: any;
-    onInput?(event: Event): void;
-    onKeyPress?(event: Event): void;
     keyfilter?: any;
     validateOnly?: boolean;
+    onInput?(event: React.FormEvent<HTMLInputElement>): void;
+    onKeyPress?(event: React.KeyboardEvent<HTMLInputElement>): void;
 }
 
 export class InputText extends React.Component<InputTextProps,any> {}

--- a/src/components/lightbox/Lightbox.d.ts
+++ b/src/components/lightbox/Lightbox.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface LightboxProps {
     id?: string;
-    images?: Array<any>;
+    images?: any[];
     type?: string;
     style?: object;
     className?: string;

--- a/src/components/listbox/ListBox.d.ts
+++ b/src/components/listbox/ListBox.d.ts
@@ -3,9 +3,8 @@ import React = require("react");
 interface ListBoxProps {
     id?: string,
     value?: any,
-    options?: Array<any>,
+    options?: any[],
     optionLabel?: string,
-    itemTemplate?(item: any): JSX.Element | undefined,
     style?: object,
     listStyle?: object,
     className?: string,
@@ -14,6 +13,7 @@ interface ListBoxProps {
     multiple?: boolean,
     metaKeySelection?: boolean,
     filter?: boolean,
+    itemTemplate?(item: any): JSX.Element | undefined,
     onChange?(e: {originalEvent: Event, value: any}): void;
 }
 

--- a/src/components/megamenu/MegaMenu.d.ts
+++ b/src/components/megamenu/MegaMenu.d.ts
@@ -3,7 +3,7 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface MegaMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     style?: object;
     className?: string;
     orientation?: string;

--- a/src/components/menu/Menu.d.ts
+++ b/src/components/menu/Menu.d.ts
@@ -1,9 +1,10 @@
 import React = require("react");
 import {MenuItem} from '../menuitem/MenuItem';
+import {SyntheticEvent} from "react";
 
 interface MenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     popup?: boolean;
     style?: object;
     className?: string;
@@ -13,4 +14,6 @@ interface MenuProps {
     onHide?(e: Event): void;
 }
 
-export class Menu extends React.Component<MenuProps ,any> {}
+export class Menu extends React.Component<MenuProps ,any> {
+    public toggle(event:SyntheticEvent):void;
+}

--- a/src/components/menubar/Menubar.d.ts
+++ b/src/components/menubar/Menubar.d.ts
@@ -3,7 +3,7 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface MenubarProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     style?: object;
     className?: string;
     autoZIndex?: boolean;

--- a/src/components/menuitem/MenuItem.d.ts
+++ b/src/components/menuitem/MenuItem.d.ts
@@ -1,7 +1,6 @@
 export interface MenuItem {
     label?: string;
     icon?: string;
-    command?(e: {originalEvent: Event, item: MenuItem}): void;
     url?: string;
     items?: MenuItem[]|MenuItem[][];
     disabled?: boolean;
@@ -9,4 +8,5 @@ export interface MenuItem {
     separator?: boolean;
     style?: any;
     className?: string;
+    command?(e: {originalEvent: Event, item: MenuItem}): void;
 }

--- a/src/components/messages/Messages.d.ts
+++ b/src/components/messages/Messages.d.ts
@@ -1,11 +1,24 @@
 import React = require("react");
 
+interface Message {
+    id?: string;
+    severity?: 'success' | 'info' | 'warn' | 'error',
+    summary?: React.ReactNode;
+    detail?: React.ReactNode;
+    closable?: boolean;
+    sticky?: boolean;
+    life?: number;
+}
+
 interface MessagesProps {
     id?: string;
     className?: string;
     style?: object;
-    onRemove?(message:any): void;
-    onClick?(message:any): void;
+    onRemove?(message: Message): void;
+    onClick?(message: Message): void;
 }
 
-export class Messages extends React.Component<MessagesProps,any> {}
+export class Messages extends React.Component<MessagesProps, any> {
+    public show(message: Message | Message[]): void;
+    public clear(): void;
+}

--- a/src/components/multiselect/MultiSelect.d.ts
+++ b/src/components/multiselect/MultiSelect.d.ts
@@ -3,7 +3,7 @@ import React = require("react");
 interface MultiSelectProps {
     id?: string;
     value?: any;
-    options?: Array<any>;
+    options?: any[];
     optionLabel?: string;
     style?: object;
     className?: string;

--- a/src/components/orderlist/OrderList.d.ts
+++ b/src/components/orderlist/OrderList.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface OrderListProps {
     id?: string;
-    value?: Array<any>;
+    value?: any[];
     header?: any;
     style?: object;
     className?: string;

--- a/src/components/organizationchart/OrganizationChart.d.ts
+++ b/src/components/organizationchart/OrganizationChart.d.ts
@@ -1,16 +1,25 @@
 import React = require("react");
 
+export interface OrganizationChartNodeData {
+    className?: string,
+    expanded?: boolean,
+    children?: OrganizationChartNodeData[]
+    selectable?: boolean
+    label?: string,
+}
+
 interface OrganizationChartProps {
     id?: string;
-    value?: any;
+    value?: OrganizationChartNodeData[];
     style?: object;
     className?: string;
     selectionMode?: string;
     selection?: any;
-    nodeTemplate?: any;
+    nodeTemplate?(node: OrganizationChartNodeData): React.ReactNode;
     selectionChange?(data: any): void;
-    onNodeSelect?(e: {originalEvent: Event, node: any}): void;
-    onNodeUnselect?(e: {originalEvent: Event, node: any}): void;
+    onNodeSelect?(e: { originalEvent: Event, node: any }): void;
+    onNodeUnselect?(e: { originalEvent: Event, node: any }): void;
 }
 
-export class OrganizationChart extends React.Component<OrganizationChartProps,any> {}
+export class OrganizationChart extends React.Component<OrganizationChartProps, any> {
+}

--- a/src/components/overlaypanel/OverlayPanel.d.ts
+++ b/src/components/overlaypanel/OverlayPanel.d.ts
@@ -1,4 +1,5 @@
 import React = require("react");
+import {SyntheticEvent} from "react";
 
 interface OverlayPanelProps {
     id?: string;
@@ -9,4 +10,6 @@ interface OverlayPanelProps {
     appendTo?: any;
 }
 
-export class OverlayPanel extends React.Component<OverlayPanelProps,any> {}
+export class OverlayPanel extends React.Component<OverlayPanelProps,any> {
+    public toggle(event:SyntheticEvent):void;
+}

--- a/src/components/paginator/Paginator.d.ts
+++ b/src/components/paginator/Paginator.d.ts
@@ -1,17 +1,24 @@
 import React = require("react");
 
+export interface PageState{
+    first: number,
+    rows: number,
+    page: number,
+    pageCount: number
+}
+
 interface PaginatorProps {
     totalRecords?: number;
     rows?: number;
     first?: number;
     pageLinkSize?: number;
-    rowsPerPageOptions?: Array<any>;
+    rowsPerPageOptions?: any[];
     style?: object;
     className?: string;
     template?: string;
-    onPageChange?(event: Event): void;
-    leftContent: JSX.Element | undefined;
-    rightContent: JSX.Element | undefined;
+    leftContent?: JSX.Element | undefined;
+    rightContent?: JSX.Element | undefined;
+    onPageChange?(event: PageState): void;
 }
 
 export class Paginator extends React.Component<PaginatorProps,any> {}

--- a/src/components/panelmenu/PanelMenu.d.ts
+++ b/src/components/panelmenu/PanelMenu.d.ts
@@ -3,7 +3,7 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface PanelMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     style?: object;
     className?: string;
 }

--- a/src/components/picklist/PickList.d.ts
+++ b/src/components/picklist/PickList.d.ts
@@ -2,8 +2,8 @@ import React = require("react");
 
 interface PickListProps {
     id?: string;
-    source?: Array<any>;
-    target?: Array<any>;
+    source?: any[];
+    target?: any[];
     sourceHeader?: any;
     targetHeader?: any;
     style?: object;

--- a/src/components/picklist/PickListControls.d.ts
+++ b/src/components/picklist/PickListControls.d.ts
@@ -2,8 +2,8 @@ import React = require("react");
 
 interface PickListControlsProps {
     className?: string;
-    list?: Array<any>;
-    selection?: Array<any>;
+    list?: any[];
+    selection?: any[];
     onReorder?(e: {originalEvent: Event, value: any, direction: string}): void;
 }
 

--- a/src/components/picklist/PickListItem.d.ts
+++ b/src/components/picklist/PickListItem.d.ts
@@ -3,8 +3,8 @@ import React = require("react");
 interface PickListItemProps {
     value?: any;
     className?: string;
-    template?(item: any): JSX.Element | undefined;
     selected?: boolean;
+    template?(item: any): JSX.Element | undefined;
     onClick?(e: {originalEvent: Event, value: any}): void;
 }
 

--- a/src/components/picklist/PickListSubList.d.ts
+++ b/src/components/picklist/PickListSubList.d.ts
@@ -1,8 +1,8 @@
 import React = require("react");
 
 interface PickListSubListProps {
-    list?: Array<any>;
-    selection?: Array<any>;
+    list?: any[];
+    selection?: any[];
     header?: string;
     className?: string;
     listClassName?: string;
@@ -11,7 +11,7 @@ interface PickListSubListProps {
     metaKeySelection?: boolean;
     itemTemplate?(item: any): JSX.Element | undefined;
     onItemClick?(): void;
-    onSelectionChange?({event: Event, value: any}): void;
+    onSelectionChange?(e: {event: Event, value: any}): void;
 }
 
 export class PickListSubList extends React.Component<PickListSubListProps,any> {}

--- a/src/components/picklist/PickListTransferControls.d.ts
+++ b/src/components/picklist/PickListTransferControls.d.ts
@@ -1,11 +1,11 @@
 import React = require("react");
 
 interface PickListTransferControlsProps {
-    source?: Array<any>;
-    target?: Array<any>;
-    sourceSelection?: Array<any>;
-    targetSelection?: Array<any>;
-    onTransfer?: Array<any>;
+    source?: any[];
+    target?: any[];
+    sourceSelection?: any[];
+    targetSelection?: any[];
+    onTransfer?: any[];
 }
 
 export class PickListTransferControls extends React.Component<PickListTransferControlsProps,any> {}

--- a/src/components/radiobutton/RadioButton.d.ts
+++ b/src/components/radiobutton/RadioButton.d.ts
@@ -5,11 +5,11 @@ interface RadioButtonProps {
     inputId?: string;
     name?: string;
     value?: any;
-    checked: boolean;
+    checked?: boolean;
     style?: object;
     className?: string;
     disabled?: boolean;
-    onChange({originalEvent: Event, value: any, checked: boolean}): void;
+    onChange(e: {originalEvent: Event, value: any, checked: boolean}): void;
 }
 
 export class RadioButton extends React.Component<RadioButtonProps,any> {}

--- a/src/components/rating/Rating.d.ts
+++ b/src/components/rating/Rating.d.ts
@@ -2,14 +2,14 @@ import React = require("react");
 
 interface RatingProps {
     id?: string;
-    value?: string;
+    value?: number;
     disabled?: boolean;
     readonly?: boolean;
     stars?: number;
     cancel?: boolean;
     style?: object;
     className?: string;
-    onChange?(e: {originalEvent: Event, value: string}): void;
+    onChange?(e: {originalEvent: Event, value: number}): void;
 }
 
 export class Rating extends React.Component<RatingProps,any> {}

--- a/src/components/schedule/Schedule.d.ts
+++ b/src/components/schedule/Schedule.d.ts
@@ -2,13 +2,13 @@ import React = require("react");
 
 interface ScheduleProps {
     id?: string;
-    events?: Array<any>;
+    events?: any[];
     header?: any;
     style?: object;
     className?: string;
     isRTL?: boolean;
     weekends?: boolean;
-    hiddenDays?: Array<any>;
+    hiddenDays?: any[];
     fixedWeekCount?: boolean;
     weekNumbers?: boolean;
     businessHours?: any;
@@ -37,11 +37,11 @@ interface ScheduleProps {
     dragScroll?: boolean;
     eventOverlap?: any;
     eventConstraint?: any;
-    eventRender?(): void;
-    dayRender?(): void;
     locale?: object;
     timezone?: any;
     options?: object;
+    eventRender?(): void;
+    dayRender?(): void;
     onDayClick?(): void;
     onEventClick?(): void;
     onEventMouseover?(): void;

--- a/src/components/selectbutton/SelectButton.d.ts
+++ b/src/components/selectbutton/SelectButton.d.ts
@@ -3,7 +3,7 @@ import React = require("react");
 interface SelectButtonProps {
     id?: string;
     value?: any;
-    options?: Array<any>;
+    options?: any[];
     optionLabel?: string;
     tabIndex?: string;
     multiple?: boolean;

--- a/src/components/slidemenu/SlideMenu.d.ts
+++ b/src/components/slidemenu/SlideMenu.d.ts
@@ -1,9 +1,10 @@
 import React = require("react");
 import {MenuItem} from '../menuitem/MenuItem';
+import {SyntheticEvent} from "react";
 
 interface SlideMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     popup?: boolean;
     style?: object;
     className?: string;
@@ -18,4 +19,8 @@ interface SlideMenuProps {
     onHide?(e: Event): void;
 }
 
-export class SlideMenu extends React.Component<SlideMenuProps,any> {}
+export class SlideMenu extends React.Component<SlideMenuProps,any> {
+    public show(event:SyntheticEvent):void;
+    public hide(event:SyntheticEvent):void;
+    public toggle(event:SyntheticEvent):void;
+}

--- a/src/components/slider/Slider.d.ts
+++ b/src/components/slider/Slider.d.ts
@@ -2,7 +2,7 @@ import React = require("react");
 
 interface SliderProps {
     id?: string;
-    value?: number;
+    value?: number|[number, number];
     animate?: boolean;
     min?: number;
     max?: number;
@@ -11,7 +11,7 @@ interface SliderProps {
     range?: boolean;
     style?: object;
     className?: string;
-    onChange?(e: {originalEvent: Event, value: any}): void;
+    onChange?(e: {originalEvent: Event, value: number|[number, number]}): void;
 }
 
 export class Slider extends React.Component<SliderProps,any> {}

--- a/src/components/splitbutton/SplitButton.d.ts
+++ b/src/components/splitbutton/SplitButton.d.ts
@@ -4,7 +4,7 @@ interface SplitButtonProps {
     id?: string;
     label?: string;
     icon?: string;
-    model?: Array<any>;
+    model?: any[];
     disabled?: boolean;
     style?: object;
     className?: string;

--- a/src/components/steps/Steps.d.ts
+++ b/src/components/steps/Steps.d.ts
@@ -3,12 +3,12 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface StepsProps {
     id?: string;
-    model: Array<MenuItem>;
+    model: MenuItem[];
     activeIndex?:  number;
     readOnly?: boolean;
     style?: object;
     className?: string;
-    onSelect?(e: {originalEvent: Event, item: any, index: any}): void;
+    onSelect?(e: {originalEvent: Event, item: MenuItem, index: number}): void;
 }
 
 export class Steps extends React.Component<StepsProps,any> {}

--- a/src/components/tabmenu/TabMenu.d.ts
+++ b/src/components/tabmenu/TabMenu.d.ts
@@ -3,7 +3,7 @@ import {MenuItem} from '../menuitem/MenuItem';
 
 interface TabMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     activeItem?: any;
     style?: any;
     className?: string;

--- a/src/components/tabview/TabView.d.ts
+++ b/src/components/tabview/TabView.d.ts
@@ -11,13 +11,16 @@ interface TabPanelProps {
     contentClassName?: string;
 }
 
+export class TabPanel extends React.Component<TabPanelProps,any> {}
+
 interface TabViewProps {
     id?: string;
     activeIndex?: number;
     style?: any;
     className?: string;
-    onTabChange?(e: {event: originalEvent, index: number}): void;
+    effect?: string;
+    onTabChange?(e: {originalEvent: Event, index: number}): void;
 }
 
-export class TabPanel extends React.Component<TabPanelProps,any> {}
+// tslint:disable-next-line:max-classes-per-file
 export class TabView extends React.Component<TabViewProps,any> {}

--- a/src/components/tieredmenu/TieredMenu.d.ts
+++ b/src/components/tieredmenu/TieredMenu.d.ts
@@ -1,9 +1,10 @@
 import React = require("react");
 import {MenuItem} from '../menuitem/MenuItem';
+import {SyntheticEvent} from "react";
 
 interface TieredMenuProps {
     id?: string;
-    model?: Array<MenuItem>;
+    model?: MenuItem[];
     popup?: boolean;
     style?: object;
     className?: string;
@@ -13,4 +14,6 @@ interface TieredMenuProps {
     onHide?(e: Event): void;
 }
 
-export class TieredMenu extends React.Component<TieredMenuProps,any> {}
+export class TieredMenu extends React.Component<TieredMenuProps, any> {
+    public toggle(event: SyntheticEvent): void;
+}

--- a/src/components/tooltip/Tooltip.d.ts
+++ b/src/components/tooltip/Tooltip.d.ts
@@ -1,4 +1,5 @@
 import React = require("react");
+import {SyntheticEvent} from "react";
 
 interface TooltipProps {
     for?: any;
@@ -12,7 +13,7 @@ interface TooltipProps {
     escape?: boolean;
     hideDelay?: number;
     showDelay?: number;
-    onBeforeShow?(e: Event): void;
+    onBeforeShow?(e: SyntheticEvent): void;
 }
 
 export class Tooltip extends React.Component<TooltipProps,any> {}

--- a/src/components/tree/Tree.d.ts
+++ b/src/components/tree/Tree.d.ts
@@ -5,17 +5,17 @@ interface TreeProps {
     value: any;
     selectionMode?: string;
     selection?: any;
-    selectionChange(e: {originalEvent: Event, selection: any}): void;
     layout?: string;
-    onNodeSelect?(e: {originalEvent: Event, node: any}): void;
-    onNodeUnselect?(e: {originalEvent: Event, node: any}): void;
-    onNodeExpand?(): void;
-    onNodeCollapse?(): void;
     style?: object;
     className?: string;
     metaKeySelection?: boolean;
     propagateSelectionUp?: boolean;
     propagateSelectionDown?: boolean;
+    selectionChange?(e: {originalEvent: Event, selection: any}): void;
+    onNodeSelect?(e: {originalEvent: Event, node: any}): void;
+    onNodeUnselect?(e: {originalEvent: Event, node: any}): void;
+    onNodeExpand?(): void;
+    onNodeCollapse?(): void;
 }
 
 export class Tree extends React.Component<TreeProps,any> {}

--- a/src/components/treetable/TreeTable.d.ts
+++ b/src/components/treetable/TreeTable.d.ts
@@ -1,13 +1,17 @@
 import React = require("react");
 
+interface Node {
+    data: any,
+    children: Node[]
+}
+
 interface TreeTableProps {
     id?: string;
-    value?: any;
+    value: Node | Node[];
     labelExpand?: string;
     labelCollapse?: string;
     selectionMode?: string;
     selection?: any;
-    selectionChange(e: {originalEvent: Event, selection: any}): void;
     style?: object;
     className?: string;
     metaKeySelection?: boolean;
@@ -17,11 +21,13 @@ interface TreeTableProps {
     sortOrder?: number;
     multiSortMeta?: string;
     sortMode?: string;
-    onSort?(e: {sortField: string, sortOrder: number, multiSortMeta: any}): void;
-    onNodeSelect?(e: {originalEvent: Event, node: any}): void;
-    onNodeUnselect?(e: {originalEvent: Event, node: any}): void;
-    onNodeExpand?(e: {originalEvent: Event, node: any}): void;
-    onNodeCollapse?(e: {originalEvent: Event, node: any}): void;
+    selectionChange?(e: { originalEvent: Event, selection: any }): void;
+    onSort?(e: { sortField: string, sortOrder: number, multiSortMeta: any }): void;
+    onNodeSelect?(e: { originalEvent: Event, node: any }): void;
+    onNodeUnselect?(e: { originalEvent: Event, node: any }): void;
+    onNodeExpand?(e: { originalEvent: Event, node: any }): void;
+    onNodeCollapse?(e: { originalEvent: Event, node: any }): void;
 }
 
-export class TreeTable extends React.Component<TreeTableProps,any> {}
+export class TreeTable extends React.Component<TreeTableProps, any> {
+}

--- a/src/components/tristatecheckbox/TriStateCheckbox.d.ts
+++ b/src/components/tristatecheckbox/TriStateCheckbox.d.ts
@@ -3,7 +3,7 @@ import React = require("react");
 interface TriStateCheckboxProps {
     id?: string;
     inputId?: string;
-    value?: boolean;
+    value?: boolean | null;
     name?: string;
     style?: object;
     className?: string;

--- a/src/components/util.d.ts
+++ b/src/components/util.d.ts
@@ -1,0 +1,1 @@
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
The typescript definitions of this lib appear to leave something to be desired. I took a first step to improve them by making them at least compatible with the showcase. That is, I ported the showcase to Typescript in my own repo and fixed the issues that I found in the definitions. 

This PR fixes several issues:
- Syntax errors (e.g. in Editor.d.ts)
- Missing members (e.g. in Growl.d.ts)
- Typos (e.g. in Inplace.d.ts)
- Minor issues discovered by tslint (mostly converting Array<T> to T[] for simple T and ordering, ie. methods after properties)

Note that this are only the basic changes to get at least the showcase working in Typescript. There's *a lot* that can be improved, e.g.:
- All template methods should return React.ReactNode, not JSX.Element
- Events should probably be React.SyntheticEvent with or without a template argument
- Many components would benefit from generics (think `<AutoComplete<Car>..../>`)
- Check which props are actually optional
- In general, most of those `any`s can be taken care of.

I'm willing to polish the definitions, but obviously I need to know if you'll accept and merge such a PR. 