### PR TITLE
Fixed issue where hiding columns after reordering them crashes application

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -649,7 +649,9 @@ export class DataTable extends Component {
                 ObjectUtils.reorderArray(columns, dragIndex, dropIndex);
                 let columnOrder = [];
                 for(let column of columns) {
-                    columnOrder.push(column.props.columnKey||column.props.field);
+                    if(column !== null) {
+                        columnOrder.push(column.props.columnKey || column.props.field);
+                    }
                 }
                 
                 this.setState({

--- a/src/components/datatable/TableBody.js
+++ b/src/components/datatable/TableBody.js
@@ -276,8 +276,10 @@ export class TableBody extends Component {
         else {
             if(Array.isArray(this.props.children)) {
                 for(let i = 0; i < this.props.children.length; i++) {
-                    if(this.props.children[i].props.selectionMode) {
-                        return true;
+                    if(this.props.children[i] !== null) {
+                        if(this.props.children[i].props.selectionMode) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
###Defect Fixes
After reordering columns, disabling columns would throw errors and crash the application.