### PR TITLE
Enhancement #636 Add currentPageReportTemplate property to Paginator

### DIFF
--- a/src/components/paginator/Paginator.d.ts
+++ b/src/components/paginator/Paginator.d.ts
@@ -16,6 +16,7 @@ interface PaginatorProps {
     style?: object;
     className?: string;
     template?: string;
+	currentPageReportTemplate?: string; 
     leftContent?: JSX.Element | undefined;
     rightContent?: JSX.Element | undefined;
     onPageChange?(event: PageState): void;

--- a/src/components/paginator/Paginator.js
+++ b/src/components/paginator/Paginator.js
@@ -20,6 +20,7 @@ export class Paginator extends Component {
         style: null,
         className: null,
         template: 'FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown',
+		currentPageReportTemplate: '({currentPage} of {totalPages})', 
         onPageChange: null,
         leftContent: null,
         rightContent: null
@@ -34,6 +35,7 @@ export class Paginator extends Component {
         style: PropTypes.object,
         className: PropTypes.string,
         template: PropTypes.string,
+		currentPageReportTemplate: PropTypes.string, 
         onPageChange: PropTypes.func,
         leftContent: PropTypes.any,
         rightContent: PropTypes.any
@@ -172,7 +174,7 @@ export class Paginator extends Component {
                 break;
                 
                 case 'CurrentPageReport':
-                    element = <CurrentPageReport key={key} page={this.getPage()} pageCount={this.getPageCount()} />;
+                    element = <CurrentPageReport key={key} page={this.getPage()} pageCount={this.getPageCount()} template={this.props.currentPageReportTemplate} />;
                 break;
                 
                 default:

--- a/src/showcase/paginator/PaginatorDemo.js
+++ b/src/showcase/paginator/PaginatorDemo.js
@@ -183,6 +183,12 @@ import {Paginator} from 'primereact/paginator';
                             <td>Template of the paginator.</td>
                         </tr>
                         <tr>
+                            <td>currentPageReportTemplate</td>
+                            <td>string</td>
+                            <td>{'({currentPage} of {totalPages})'}</td>
+                            <td>Template of current page report. Two possible indicators: {'{'}currentPage{'}'} and {'{'}totalPages{'}'}. CurrentPageReport key has to be set in template property. </td>
+                        </tr>
+                        <tr>
                             <td>leftContent</td>
                             <td>any</td>
                             <td>null</td>


### PR DESCRIPTION
**I'm submitting an ...** 
```
[x] enhancement request 
```
for Paginator component https://www.primefaces.org/primereact/#/paginator 

**Current behavior**
It is not possible to provide/change CurrentPageReport template which is currently hardcoded as '({currentPage} of {totalPages})'. This enhancement is needed for two cases: 1) when a different presentation way of current page report is needed, 2) when a site is multilingual and a word 'of' has to be translated. 

**Expected behavior**
It should be possible to provide/change template by providing a new currentPageReportTemplate property to Paginator component like this: 
<Paginator ... currentPageReportTemplate='({currentPage} of {totalPages})'></Paginator>