### PR TITLE
Fix #668

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -955,7 +955,9 @@ export class DataTable extends Component {
         if(this.props.reorderableColumns && this.state.columnOrder) {
             let orderedColumns = [];
             for(let columnKey of this.state.columnOrder) {
-                orderedColumns.push(this.findColumnByKey(columns, columnKey));
+                let column = this.findColumnByKey(columns, columnKey)
+                if(column)
+                    orderedColumns.push();
             }
                         
             return orderedColumns;


### PR DESCRIPTION
fix dataTable throws exception when user hide a column after reordering columns

### Defect Fixes
I can't toggle columns when reorderableColumns props is enabled and the columns has been reordered