### PR TITLE
Ability to pass a non-string based label through

### DIFF
--- a/src/components/selectbutton/SelectButton.js
+++ b/src/components/selectbutton/SelectButton.js
@@ -147,7 +147,7 @@ export class SelectButton extends Component {
         if(this.props.options && this.props.options.length) {
             return this.props.options.map((option, index) => {
                 let optionLabel = this.getOptionLabel(option);
-                
+                let key = option.key ? option.key : `selb_${index}`
                 return <SelectButtonItem key={optionLabel} label={optionLabel} option={option} onClick={this.onOptionClick}
                             selected={this.isSelected(option)} tabIndex={this.props.tabIndex} disabled={this.props.disabled} />;
             });

--- a/src/components/selectbutton/SelectButtonItem.js
+++ b/src/components/selectbutton/SelectButtonItem.js
@@ -15,7 +15,7 @@ export class SelectButtonItem extends Component {
 
     static propTypes = {
         option: PropTypes.object,
-        label: PropTypes.string,
+        label: PropTypes.node,
         selected: PropTypes.bool,
         tabIndex: PropTypes.number,
         onClick: PropTypes.func


### PR DESCRIPTION
###Defect Fixes
When using the Select button with a custom Label type, proptypes throws errors around label needing to be a string and keys being equal.
this allows us to now pass through a renderable to the label and an optional key / better generated key
