### PR TITLE
Fix rendering of ProgressBar - #783

### DIFF
--- a/src/components/progressbar/ProgressBar.js
+++ b/src/components/progressbar/ProgressBar.js
@@ -24,10 +24,6 @@ export class ProgressBar extends Component {
         mode: PropTypes.string
     };
 
-    shouldComponentUpdate(nextProps) {
-        return this.props.value !== nextProps.value;
-    }
-
     renderLabel() {
         if (this.props.showValue && this.props.value) {
             return (


### PR DESCRIPTION
Fix rendering of ProgressBar upon changing props.

Apparently `shouldComponentUpdate()` was added due to issue #597. However, I disagree with the author as the component will of course render if the parent component is being rendered *(which it is looking at the provided Plunkr in #597)*. 

What was the reason for this implementation?