### PR TITLE
Fix value check of props on Spinner - #787

### DIFF
--- a/src/components/spinner/Spinner.js
+++ b/src/components/spinner/Spinner.js
@@ -103,7 +103,7 @@ export class Spinner extends Component {
         else
             newValue = currentValue + step;
 
-        if (this.props.maxlength !== null && this.value.toString().length > this.props.maxlength) {
+        if (this.props.maxlength !== null && this.props.value.toString().length > this.props.maxlength) {
             newValue = currentValue;
         }
 


### PR DESCRIPTION
Currently the prop `maxlength` of `<Spinner />` cannot be used as it crashes the component. This fix will make sure that the correct value is being checked.

See issue  #787 