### PR TITLE
Fix: export to csv adding separator header to file

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -913,7 +913,7 @@ export class DataTable extends Component {
 
     exportCSV() {
         let data = this.processData();
-        let csv = '\ufeff';
+        var csv = `sep=${_this5.props.csvSeparator}\n`;
         let columns = React.Children.toArray(this.props.children);
         
         //headers
@@ -941,7 +941,7 @@ export class DataTable extends Component {
             }
         });
         
-        let blob = new Blob([csv],{
+        var blob = new Blob(['\ufeff', csv], {
             type: 'text/csv;charset=utf-8;'
         });
         


### PR DESCRIPTION
###Defect Fixes
When exporting a CSV file, no header is added to the exported file with the separator.
Now, the chosen separator is added to the file and programs like Excel detect it automatically instead of having to import the data and chose the separator.