### PR TITLE
Fixed renderItem uses wrong [first] on lazy DataView.

### DIFF
--- a/src/components/dataview/DataView.js
+++ b/src/components/dataview/DataView.js
@@ -101,7 +101,8 @@ export class DataView extends Component {
         style: null,
         className: null,
         itemTemplate: null,
-        onPage: null
+        onPage: null,
+        lazy: false
     }
 
     static propTypes = {
@@ -128,7 +129,8 @@ export class DataView extends Component {
         style: PropTypes.object,
         className: PropTypes.string,
         itemTemplate: PropTypes.func.isRequired,
-        onPage: PropTypes.func
+        onPage: PropTypes.func,
+        lazy: PropTypes.bool
     }
 
     constructor(props) {
@@ -257,7 +259,7 @@ export class DataView extends Component {
         if (value && value.length) {
             if (this.props.paginator) {
                 const rows = this.props.onPage ? this.props.rows : this.state.rows;
-                const first = this.props.onPage ? this.props.first : this.state.first;
+                const first = this.props.lazy ? 0 : this.props.onPage ? this.props.first : this.state.first;
                 const last = rows + first;
                 let items = [];
 


### PR DESCRIPTION
###Defect Fixes
When using same lazy implementation with DataTable and applied on DataView, the rendering of data does not seems to work correctly when switching between pages. It was caused by the renderItems method in the DataView.js, let say rows = 10, it always took the data[first] which the variable first is followed with the offset of the page, which made the variable first as 10 on the second page, hence, data[10] is undefined, because each lazy load of the data has a maximum number of 10. So by fixing it, I put the props lazy so that it won't affect the implementation without lazyload. 
 