### PR TITLE
Add in missing typing property in DataTable

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -60,6 +60,7 @@ interface DataTableProps {
     loadingIcon?:string;
     tabIndex?:string;
     stateKey?:string;
+    stateStorage?:string;
     groupField?:string;
     onSelectionChange?(e: {originalEvent: Event, value: any}): void;
     onContextMenuSelectionChange?(e: {originalEvent: Event, value: any}): void;


### PR DESCRIPTION
## FIX
This PR fixes compile issue when using the stateStorage propety on the DataTable.