### PR TITLE
onValueChanged callback receiving outdated filtered data

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -989,9 +989,9 @@ export class DataTable extends Component {
         }
     }
 
-    filterLocal(value) {
+    filterLocal(value, localFilters) {
         let filteredValue = [];
-        let filters = this.getFilters();
+        let filters = localFilters || this.getFilters();
         let columns = React.Children.toArray(this.props.children);
 
         for(let i = 0; i < value.length; i++) {


### PR DESCRIPTION
Fixes #777 

Whenever a filter is applied to the DataTable component, the caller can retrieve the filtered data via the onValueChange callback. However, the filterLocal function (which returns the filtered data) is not using the localFilters computed by the processData function but rather pulls the filter from the getFilters function (which would pull the filters from either the props or the state). In the scenarios where it is pulling from state, the setState call would not have updated with the latest filters (because of its async nature), causing the onValueChange to receive outdated filtered data. The state would eventually get the correct filters but by then the onValueChange function has already been fired. 

We can fix this issue in multiple ways. One way is to make sure that filterLocal is run after the setState function has finished executing. The second way is just to reuse the computed localFilters object created in the processData function. 

Let me know if I missed anything