### PR TITLE
Fixed #843 by restoring tabindex when tabing out of editor

### DIFF
--- a/src/components/datatable/BodyCell.js
+++ b/src/components/datatable/BodyCell.js
@@ -103,6 +103,7 @@ export class BodyCell extends Component {
         
     componentDidUpdate() {
         if (this.container && this.props.editor) {
+            clearTimeout(this.tabindexTimeout);
             if (this.state.editing) {
                 let focusable = DomHandler.findSingle(this.container, 'input');
                 if (focusable) {
@@ -113,9 +114,9 @@ export class BodyCell extends Component {
                 this.keyHelper.tabIndex = -1;
             }
             else {
-                setTimeout(() => {
+                this.tabindexTimeout = setTimeout(() => {
                     if (this.keyHelper) {
-                        this.keyHelper.removeAttribute('tabindex');
+                        this.keyHelper.setAttribute('tabindex', 0);
                     }
                 }, 50);
             }    


### PR DESCRIPTION
Fixed issue #843
When tabbing out of editor, we don't want to remove the tabindex attr, as that will make it so it is impossible to open the editor with tab ever again.

Also set the timeout var to this.tabindexTimeout and clear it on the start of the method.
Reason being in my env sometimes the method is run twice, as when entering the editor the data changes, causing two updates, and due to the timeout the tab-index of 0 is restored, this making it impossible to shift-tab out of the editor as it will always open the current editor.