### PR TITLE
#891 Add onEditorSubmit and  onEditorCancel callbacks for Column & BodyCell

### DIFF
--- a/src/components/column/Column.js
+++ b/src/components/column/Column.js
@@ -36,6 +36,8 @@ export class Column extends Component {
         editor: null,
         editorValidator: null,
         editorValidatorEvent: 'click',
+        onEditorSubmit: null,
+        onEditorCancel: null,
         excludeGlobalFilter: false,
         rowReorder: false,
         rowReorderIcon: 'pi pi-bars'
@@ -73,6 +75,8 @@ export class Column extends Component {
         rowSpan: PropTypes.number,
         editor: PropTypes.func,
         editorValidator: PropTypes.func,
+        onEditorSubmit: PropTypes.func,
+        onEditorCancel: PropTypes.func,
         editorValidatorEvent: PropTypes.string,
         excludeGlobalFilter: PropTypes.bool,
         rowReorder: PropTypes.bool,

--- a/src/components/datatable/BodyCell.js
+++ b/src/components/datatable/BodyCell.js
@@ -29,8 +29,12 @@ export class BodyCell extends Component {
     }
     
     onKeyDown(event) {
-        if (event.which === 13 || event.which === 9) {
-            this.switchCellToViewMode();
+        if (event.which === 13 || event.which === 9) { // tab || enter
+            this.switchCellToViewMode(true);
+        }
+        if (event.which === 27) // escape
+        {
+            this.switchCellToViewMode(false);
         }
     }
     
@@ -50,7 +54,7 @@ export class BodyCell extends Component {
 
     onBlur() {
         if (this.state.editing && this.props.editorValidatorEvent === 'blur') {
-            this.switchCellToViewMode();
+            this.switchCellToViewMode(true);
         }
     }
     
@@ -62,7 +66,7 @@ export class BodyCell extends Component {
         if (!this.documentEditListener) {
             this.documentEditListener = (event) => {
                 if (!this.editingCellClick) {
-                    this.switchCellToViewMode();
+                    this.switchCellToViewMode(true);
                 }
 
                 this.editingCellClick = false;
@@ -81,15 +85,24 @@ export class BodyCell extends Component {
 
         this.unbindDocumentEditListener();
     }
-    
-    switchCellToViewMode() {
-        if (this.props.editorValidator) {
+
+    switchCellToViewMode(submit) {
+        if (this.props.editorValidator && submit) {
             let valid = this.props.editorValidator(this.props);
             if (valid) {
+                if (this.props.onEditorSubmit) {
+                    this.props.onEditorSubmit(this.props)
+                }
                 this.closeCell();
-            }
+            } // as per previous version if not valid and another editor is open, keep invalid data editor open.
         }
         else {
+            if (submit && this.props.onEditorSubmit) {
+                this.props.onEditorSubmit(this.props)
+            }
+            else if (this.props.onEditorCancel) {
+                this.props.onEditorCancel(this.props);
+            }
             this.closeCell();
         }
     }
@@ -118,7 +131,7 @@ export class BodyCell extends Component {
                         this.keyHelper.removeAttribute('tabindex');
                     }
                 }, 50);
-            }    
+            }
         }
     }
 


### PR DESCRIPTION
Minor Feature Request.

Added onEditorSubmit onEditorCancel callbacks for Column BodyCell.

Does not disturb any existing logic. 

Esc closes editor and calls onCancel, otherwise when switching to ViewMode calls onSubmit.  

Studying the existing logic for editorValidatorEvent and editorValidator is odd. 
If you tab to the next editable cell, the previous editor will never close. And the behavior, is the same regardless of "click" or "blur", if you click away, it's switched to view via the click event, or blur, which is also triggered at the same point. 

Main point is there's no way to trigger a cancel to an edit. The closeEditingCell() in DataTable.js is helpful, but just triggers a close. There's no way for a user to **not** submit typed data unless you use the editorValidator method to revert the data in the case of invalid data, but that's not good, as that method should be for validation only, not submitting.

Also in the case that you've opened more than one editor via invalid data + tab, you can't edit the previous cell because whenever the grid-data updates it focuses on the last open editor due to:

``` 
    componentDidUpdate() {
        if (this.container && this.props.editor) {
            if (this.state.editing) {
                let focusable = DomHandler.findSingle(this.container, 'input');
                if (focusable) {
                    focusable.setAttribute('data-isCellEditing', true);
                    focusable.focus();
                }
                ...
````