### PR TITLE
Fix invisible ProgressSpinner in IE11

### DIFF
--- a/src/components/progressspinner/ProgressSpinner.css
+++ b/src/components/progressspinner/ProgressSpinner.css
@@ -26,8 +26,9 @@
 }
 
 .p-progress-spinner-circle {
-    stroke-dasharray: 1, 200;
+    stroke-dasharray: 39, 200;
     stroke-dashoffset: 0;
+    stroke: #d62d20;
     animation: p-progress-spinner-dash 1.5s ease-in-out infinite, p-progress-spinner-color 6s ease-in-out infinite;
     stroke-linecap: round;
 }


### PR DESCRIPTION
Fixes the invisible progress spinner explained in #908