### PR TITLE
Fix Dialog to allow dialog inside other dialog.

### DIFF
--- a/src/components/calendar/Calendar.d.ts
+++ b/src/components/calendar/Calendar.d.ts
@@ -53,7 +53,7 @@ interface CalendarProps {
     stepSecond?: number;
     shortYearCutoff?: string;
     hideOnDateTimeSelect?: boolean;
-    showWeek: PropTypes.bool,
+    showWeek: boolean,
     locale?: LocaleSettings;
     dateFormat?: string;
     panelStyle?: object;

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -145,7 +145,7 @@ export class Dialog extends Component {
 
                 this.mask.addEventListener('click', this.maskClickListener);
             }
-            document.body.appendChild(this.mask);
+            this.container.parentNode.appendChild(this.mask);
 
             if (this.props.blockScroll) {
                 DomHandler.addClass(document.body, 'p-overflow-hidden');
@@ -157,7 +157,7 @@ export class Dialog extends Component {
         if (this.mask) {
             this.unbindMaskClickListener();
 
-            document.body.removeChild(this.mask);
+            this.container.parentNode.removeChild(this.mask);
             if (this.props.blockScroll) {
                 DomHandler.removeClass(document.body, 'p-overflow-hidden');
             }


### PR DESCRIPTION
When you need a modal dialog within another dialog, the overlay created in document.body does not allow access to the content.

###Defect Fixes
Calendar compile error.

###Feature Requests
The overlay was created in the parentNode of the dialog container.