### PR TITLE
Adding support for required, pattern and placeholder props on spinner.

### DIFF
--- a/src/components/spinner/Spinner.d.ts
+++ b/src/components/spinner/Spinner.d.ts
@@ -9,6 +9,9 @@ interface SpinnerProps {
     min?: number;
     max?: number;
     disabled?: boolean;
+    required?: boolean;
+    pattern?: string;
+    placeholder?: string;
     readonly?: boolean;
     maxlength?: number;
     size?: number;

--- a/src/components/spinner/Spinner.js
+++ b/src/components/spinner/Spinner.js
@@ -16,6 +16,9 @@ export class Spinner extends Component {
         min: null,
         max: null,
         disabled: false,
+        required: false,
+        pattern: null,
+        placeholder: null,
         readonly: false,
         maxlength: null,
         size: null,
@@ -38,6 +41,9 @@ export class Spinner extends Component {
         min: PropTypes.number,
         max: PropTypes.number,
         disabled: PropTypes.bool,
+        required: PropTypes.bool,
+        pattern: PropTypes.string,
+        placeholder: PropTypes.string,
         readonly: PropTypes.bool,
         maxlength: PropTypes.number,
         size: PropTypes.number,
@@ -321,11 +327,14 @@ export class Spinner extends Component {
 
     renderInputElement() {
         const className = classNames('p-spinner-input', this.props.inputClassName);
-
+                
         return (
-            <InputText ref={(el) => this.inputEl = ReactDOM.findDOMNode(el)} id={this.props.inputId} style={this.props.inputStyle} className={className} value={this.props.value == null ? '' : this.props.value}
-                type="text" size={this.props.size} maxLength={this.props.maxlength} disabled={this.props.disabled} readOnly={this.props.readonly} name={this.props.name}
-                onKeyDown={this.onInputKeyDown} onBlur={this.onInputBlur} onChange={this.onInputChange} onFocus={this.onInputFocus} />
+            <InputText ref={(el) => this.inputEl = ReactDOM.findDOMNode(el)} id={this.props.inputId} style={this.props.inputStyle} 
+              className={className} value={this.props.value == null ? '' : this.props.value} type="text" size={this.props.size} 
+              maxLength={this.props.maxlength} disabled={this.props.disabled} required={this.props.required} pattern={this.props.pattern}
+              placeholder={this.props.placeholder} readOnly={this.props.readonly} name={this.props.name} onKeyDown={this.onInputKeyDown} 
+              onBlur={this.onInputBlur} onChange={this.onInputChange} onFocus={this.onInputFocus} 
+            />
         );
     }
 


### PR DESCRIPTION
We thought it was interesting that there were no pass-throughs for props on the spinner component. Given that the spinner is slightly more complicated than just basic text input, it seemed that there may have been some reasoning for this. We think long term a props pass-through would be a better idea, but that requires more refactoring that necessary right now. 

We needed this for something we're working on so we just decided to submit a PR to help out others that may need it as well.

This PR adds support for the following props on the Spinner component:
- Required (boolean)
- Placeholder (string)
- Pattern (string)

Let me know what issues/questions you may have.
Thanks for the great lib!
