### PR TITLE
added null check for panel on dropdown

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -450,7 +450,7 @@ export class Dropdown extends Component {
     }
 
     hide() {
-        if (this.panel.element && this.panel.element.offsetParent) {
+        if (this.panel && this.panel.element && this.panel.element.offsetParent) {
             DomHandler.addClass(this.panel.element, 'p-input-overlay-hidden');
             DomHandler.removeClass(this.panel.element, 'p-input-overlay-visible');
     


### PR DESCRIPTION
###Defect Fixes
This is #178 - it looks like it wasn't fixed with the first PR. It looks like "panel" was the null variable, not panel.element.

@mertsincan - mind to take a look?