### PR TITLE
Made spinner formatInput related types optional.

### DIFF
--- a/src/components/spinner/Spinner.d.ts
+++ b/src/components/spinner/Spinner.d.ts
@@ -8,9 +8,9 @@ interface SpinnerProps {
     step?: number;
     min?: number;
     max?: number;
-    formatInput: boolean;
-    decimalSeparator: string;
-    thousandSeparator: string;
+    formatInput?: boolean;
+    decimalSeparator?: string;
+    thousandSeparator?: string;
     disabled?: boolean;
     required?: boolean;
     pattern?: string;


### PR DESCRIPTION
###Defect Fixes
Updated TypeScript typings for Spinner. **formatInput**, **decimalSeparator** and **thousandSeparator** made optional as it comes from Spinner's sources. All of them are described in 
defaultProps and backed by fallbacks during execution, so there is no need to require them.