### PR TITLE
Fix DataTable render issue when receiving arrays of array of children

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -619,8 +619,10 @@ export class DataTable extends Component {
             }
             else {
                 if(this.props.children instanceof Array) {
-                    for(let i = 0; i < this.props.children.length; i++) {
-                        if(this.props.children[i].props.footer) {
+                    var flattened =  ObjectUtils.flattenDeep(this.props.children);
+
+                    for(let i = 0; i < flattened.length; i++) {
+                        if(flattened[i].props.footer) {
                             return true;
                         }
                     }

--- a/src/components/utils/ObjectUtils.js
+++ b/src/components/utils/ObjectUtils.js
@@ -132,6 +132,13 @@ export default class ObjectUtils {
         return index;
     }
 
+    static flattenDeep(list) {
+        if(!list){
+            return [];
+        }
+        return list.reduce((acc, val) => Array.isArray(val) ? acc.concat(this.flattenDeep(val)) : acc.concat(val), []);
+    }
+
     static filterConstraints = {
 
         startsWith(value, filter) {


### PR DESCRIPTION
**Bug**
Fixed bug when a DataTable component receives array of arrays of children and fails to read footer information

**Defect Fixes**
Fixes #959 

**Details**
Currently the component receives the children objects as array of arrays, instead of a single array, containing all the children.
Code recieves:

`[ [ {Column1},  {Column2} ],  {Static Column} ]`
But expects the children to be flattened like this:

`[ {Column1},  {Column2},  {Static Column} ]`

This causes an exception in `src\components\datatable\DataTable.js:622`
```javascript
for(let i = 0; i < this.props.children.length; i++) {
                        if(this.props.children[i].props.footer) {
                                                    ^
```
that the children object is not flattened, so an array object does not have the props property.

**Fix**
The pull request will introduce the flattenDeep method, and will use it to flatten the children, so any mapping logic can be applied to the children objects. 
