### PR TITLE
Export hide() for ContextMenu in type definition file

### DIFF
--- a/src/components/contextmenu/ContextMenu.d.ts
+++ b/src/components/contextmenu/ContextMenu.d.ts
@@ -17,4 +17,5 @@ interface ContextMenuProps {
 
 export class ContextMenu extends React.Component<ContextMenuProps,any> {
     public show(event:SyntheticEvent):void;
+    public hide(event:SyntheticEvent):void;
 }


### PR DESCRIPTION
###Defect Fixes
In primereact documentation for ``ContextMenu`` (https://www.primefaces.org/primereact/#/contextmenu) said that there are 2 methods exposed: ``show()`` and ``hide()``. But in type definition file for ContextMenu there is only 1 method ``show()`` declared.
In this PR ``hide()`` declared in type definition file
