### PR TITLE
Use Checkbox in RowCheckbox

### DIFF
--- a/src/components/datatable/RowCheckbox.js
+++ b/src/components/datatable/RowCheckbox.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
+import {Checkbox} from "../checkbox/Checkbox";
 
 export class RowCheckbox extends Component {
 
@@ -32,16 +32,6 @@ export class RowCheckbox extends Component {
     }
     
     render() {
-        let className = classNames('p-checkbox-box p-component', {'p-highlight': this.props.selected, 'p-disabled': this.props.disabled});
-        let iconClassName = classNames('p-checkbox-icon p-clickable', {'pi pi-check': this.props.selected});
-        
-        return <div className="p-checkbox p-component">
-                 <div className="p-hidden-accessible">
-                    <input type="checkbox" />
-                </div>
-                <div className={className} onClick={this.onClick}>
-                    <span className={iconClassName}></span>
-                </div>
-            </div>;
+        return <Checkbox onChange={this.onClick} checked={this.props.selected} disabled={this.props.disabled} />;
     }
 }


### PR DESCRIPTION
Checkboxes in DataTable is not accessible by keyboard
Replacing the checkbox with primereacts own checkbox fixes the issue

Described in: https://github.com/primefaces/primereact/issues/1005