### PR TITLE
add name prop type to Dropdown.js and Dropdown.d.ts

### DIFF
--- a/src/components/dropdown/Dropdown.d.ts
+++ b/src/components/dropdown/Dropdown.d.ts
@@ -3,6 +3,7 @@ import TooltipOptions from '../tooltip/TooltipOptions';
 
 interface DropdownProps {
     id?: string;
+    name?: string;
     value?: any;
     options?: any[];
     optionLabel?: string;

--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -11,6 +11,7 @@ export class Dropdown extends Component {
 
     static defaultProps = {
         id: null,
+        name: null,
         value: null,
         options: null,
         optionLabel: null,
@@ -44,6 +45,7 @@ export class Dropdown extends Component {
 
     static propTypes = {
         id: PropTypes.string,
+        name: PropTypes.string,
         value: PropTypes.any,
         options: PropTypes.array,
         optionLabel: PropTypes.string,


### PR DESCRIPTION
opened issue: [Dropdown missing prop "name" #1022](https://github.com/primefaces/primereact/issues/1022)