### PR TITLE
The datatable is broken with scrollable and no columns settings

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -1214,7 +1214,7 @@ export class DataTable extends Component {
             }
         }
 
-        return null;
+        return [];
     }
     
     findColumnByKey(columns, key) {


### PR DESCRIPTION
**Issue description:**
If user sets the datatable scrollable and uncheck all columns, the datatable will be broken.

DataTable.js:1093 Uncaught TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
    at DataTable.getFrozenColumns (DataTable.js:1093)
    at DataTable.render (DataTable.js:1494)
    at finishClassComponent (react-dom.development.js:14741)
    at updateClassComponent (react-dom.development.js:14696)
    at beginWork (react-dom.development.js:15644)

![column_toggle](https://user-images.githubusercontent.com/12716802/66739560-93e74d00-eea3-11e9-87c6-09373fb5f0ad.PNG)
![datatable_broken](https://user-images.githubusercontent.com/12716802/66739567-977ad400-eea3-11e9-920f-8d01792b9df2.PNG)

**Fix solution:**
The datatable broken reason is that the function getColumns return null, but not [].
Then function getFrozenColumns(columns) will be run, inside this function, the loop "for (let col of columns){}" ran failed.

**Issue reproduce steps:**
Step 1: Copying datatable code example from link: https://www.primefaces.org/primereact/#/datatable/coltoggle
Step 2: Adding 'scrollable' and 'scrollHeight="250px"'
<DataTable value={this.state.cars} header={header} scrollable scrollHeight="250px">
  {columns}
</DataTable>
Step 3: Opening MultiSelect, and uncheck all columns.
The datatable is broken.
