### PR TITLE
Fix Enter behavior when the AutoComplete is a DataTable cell editor

### DIFF
--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -361,6 +361,8 @@ export class AutoComplete extends Component {
                     if (highlightItem) {
                         this.selectItem(event, this.props.suggestions[DomHandler.index(highlightItem)]);
                         this.hidePanel();
+                    } else {
+                        event.stopPropagation();
                     }
                     
                     event.preventDefault();


### PR DESCRIPTION
In case we're in a datable editor, do not close the editor if no suggestion is highlighted.
This will reproduce the same behavior that applies when used out of a DataTable.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
https://github.com/primefaces/primereact/issues/1054
