### PR TITLE
Add shortened label to multi select when 4 or more items are selected…

### DIFF
--- a/src/components/multiselect/MultiSelect.js
+++ b/src/components/multiselect/MultiSelect.js
@@ -390,11 +390,16 @@ export class MultiSelect extends Component {
 
         if (!this.isEmpty() && !this.props.fixedPlaceholder) {
             label = '';
-            for(let i = 0; i < this.props.value.length; i++) {
-                if(i !== 0) {
-                    label += ',';
+            let length = this.props.value.length;
+            if (length > 3) {
+                label = `${length} items selected`;
+            } else {
+                for (let i = 0; i < length; i++) {
+                    if(i !== 0) {
+                        label += ',';
+                    }
+                    label += this.findLabelByValue(this.props.value[i]);
                 }
-                label += this.findLabelByValue(this.props.value[i]);
             }
         }
 


### PR DESCRIPTION
This lines up with issue #1063 that I created.

Before:
<img width="825" alt="Screen Shot 2019-10-22 at 9 54 44 AM" src="https://user-images.githubusercontent.com/7696809/67310307-60637e80-f4b2-11e9-9aa0-294d462d834a.png">
After:
<img width="324" alt="Screen Shot 2019-10-22 at 9 55 27 AM" src="https://user-images.githubusercontent.com/7696809/67310308-60637e80-f4b2-11e9-8eb0-bbf98ffd2073.png">

… to match primeng implementation: 'n items selected'

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.