### PR TITLE
Fixed className property of Tree component not working (#1068 related)

### DIFF
--- a/src/components/tree/Tree.js
+++ b/src/components/tree/Tree.js
@@ -415,7 +415,7 @@ export class Tree extends Component {
     }
 
     render() {
-        const className = classNames('p-tree p-component', {'p-tree-selectable': this.props.selectionMode, 'p-tree-loading': this.props.loading});
+        const className = classNames('p-tree p-component', {'p-tree-selectable': this.props.selectionMode, 'p-tree-loading': this.props.loading}, this.props.className);
         const loader = this.renderLoader();
         const content = this.renderModel();
         const filter = this.renderFilter();


### PR DESCRIPTION
### Defect Fixes
The ``className`` property of the ``Tree`` component was not being included in the method that generates the actual ``className``,  so it was not being included in the generated HTML by the ``render`` method. Quite simple, fixes #1068.