### PR TITLE
Fixed Message className property not working

### DIFF
--- a/src/components/message/Message.js
+++ b/src/components/message/Message.js
@@ -27,7 +27,7 @@ export class Message extends Component {
             'p-message-error': this.props.severity === 'error',
             'p-message-success': this.props.severity === 'success',
             'p-message-icon-only': !this.props.text
-        });
+        }, this.props.className);
 
         let icon = classNames('p-message-icon pi pi-fw', {
             'pi-info-circle': this.props.severity === 'info',


### PR DESCRIPTION
### Defect Fixes
The ``className`` property of the ``Message`` component was not being included in the method that generates the actual ``className``,  so it was not being included in the generated HTML by the ``render`` method. Quite simple, fixes #1076, basically the same as #1069 