### PR TITLE
Fix positioning of month navigation buttons when `headerTemplate` is used.

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -1667,8 +1667,8 @@ export class Calendar extends Component {
 
         return (
             <div key={monthMetaData.month} className="p-datepicker-group">
+                {header}
                 <div className="p-datepicker-header">
-                    {header}
                     {backwardNavigator}
                     {forwardNavigator}
                     {title}


### PR DESCRIPTION
Fixes https://github.com/primefaces/primereact/issues/1086