### PR TITLE
Update the link to 'view on github'

### DIFF
--- a/src/showcase/carousel/CarouselDemo.js
+++ b/src/showcase/carousel/CarouselDemo.js
@@ -426,7 +426,7 @@ const responsiveOptions = [
             </TabPanel>
 
             <TabPanel header="Source">
-                <a href="https://github.com/primefaces/primereact/tree/master/src/showcase/datascroller" className="btn-viewsource" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/primefaces/primereact/tree/master/src/showcase/carousel" className="btn-viewsource" target="_blank" rel="noopener noreferrer">
                     <span>View on GitHub</span>
                 </a>
 <CodeHighlight className="language-javascript">


### PR DESCRIPTION
The link to github was incorrect and led to datascroller instead of carousel component

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.