### PR TITLE
Fix #1093: Control default column sorting mechanism in DataTable component

### DIFF
--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -63,6 +63,7 @@ interface DataTableProps {
     stateStorage?:string;
     groupField?:string;
     editMode?:string;
+    disableDefaultSort?: boolean;
     onSelectionChange?(e: {originalEvent: Event, value: any}): void;
     onContextMenuSelectionChange?(e: {originalEvent: Event, value: any}): void;
     rowExpansionTemplate?(data: any): JSX.Element | undefined;

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -41,7 +41,7 @@ export class DataTable extends Component {
         defaultSortOrder: 1,
         emptyMessage: null,
         selectionMode: null,
-	disableDefaultSort: false,
+	      disableDefaultSort: false,
         selection: null,
         onSelectionChange: null,
         contextMenuSelection: null,
@@ -137,7 +137,7 @@ export class DataTable extends Component {
         compareSelectionBy: PropTypes.string,
         dataKey: PropTypes.string,
         metaKeySelection: PropTypes.bool,
-	disableDefaultSort: PropTypes.bool,
+	      disableDefaultSort: PropTypes.bool,
         headerColumnGroup: PropTypes.any,
         footerColumnGroup: PropTypes.any,
         frozenHeaderColumnGroup: PropTypes.any,
@@ -1102,6 +1102,7 @@ export class DataTable extends Component {
                     data = this.filterLocal(data, localFilters);
                 }
             }
+          }
         }
 
         return data;

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -41,6 +41,7 @@ export class DataTable extends Component {
         defaultSortOrder: 1,
         emptyMessage: null,
         selectionMode: null,
+	disableDefaultSort: false,
         selection: null,
         onSelectionChange: null,
         contextMenuSelection: null,
@@ -136,6 +137,7 @@ export class DataTable extends Component {
         compareSelectionBy: PropTypes.string,
         dataKey: PropTypes.string,
         metaKeySelection: PropTypes.bool,
+	disableDefaultSort: PropTypes.bool,
         headerColumnGroup: PropTypes.any,
         footerColumnGroup: PropTypes.any,
         frozenHeaderColumnGroup: PropTypes.any,
@@ -1084,11 +1086,16 @@ export class DataTable extends Component {
                 let multiSortMeta = (localState && localState.multiSortMeta) || this.getMultiSortMeta();
                 
                 if(sortField || multiSortMeta) {
-                    if(this.props.sortMode === 'single')
-                        data = this.sortSingle(data, sortField, sortOrder);
-                    else if(this.props.sortMode === 'multiple')
-                        data = this.sortMultiple(data, multiSortMeta);
-                }
+                  if(this.props.sortMode === 'single'){
+                    if (!this.props.disableDefaultSort) {
+                      data = this.sortSingle(data, sortField, sortOrder);
+                    }
+                  }  
+                  else if(this.props.sortMode === 'multiple') {
+                    if (!this.props.disableDefaultSort) {
+                      data = this.sortMultiple(data, multiSortMeta);
+                    }
+                  }
 
                 let localFilters = (localState && localState.filters) || this.getFilters();
                 if (localFilters || this.props.globalFilter) {


### PR DESCRIPTION
Exposed new prop called disableDefaultSort to control default column sorting. When it is set to true, it will not consider the default sorting mechanism. This is useful when user has a onSort function and does not want the default sort to mess it up.

Fix: #1093 