### PR TITLE
fix PanelMenu show an icon when property is set

### DIFF
--- a/src/components/panelmenu/PanelMenu.js
+++ b/src/components/panelmenu/PanelMenu.js
@@ -204,7 +204,7 @@ export class PanelMenu extends Component {
     renderPanelIcon(item) {
         const className = classNames('p-menuitem-icon', item.icon);
 
-        if (item.items) {
+        if (item.icon) {
             return (
                 <span className={className}></span>
             );


### PR DESCRIPTION
Fixing:
https://github.com/primefaces/primereact/issues/1121
