### PR TITLE
Fix #1129: fix displaying TreeTable filters set using ref

### DIFF
--- a/src/components/treetable/TreeTableHeader.js
+++ b/src/components/treetable/TreeTableHeader.js
@@ -168,7 +168,7 @@ export class TreeTableHeader extends Component {
         });
 
         if(column.props.filter) {
-            filterElement = column.props.filterElement||<InputText onInput={(e) => this.onFilterInput(e, column)} type={this.props.filterType} defaultValue={this.props.filters && this.props.filters[this.props.field] ? this.props.filters[this.props.field].value : null}
+            filterElement = column.props.filterElement||<InputText onInput={(e) => this.onFilterInput(e, column)} type={this.props.filterType} defaultValue={this.props.filters && this.props.filters[column.props.field] ? this.props.filters[column.props.field].value : null}
                     className="p-column-filter" placeholder={column.props.filterPlaceholder} maxLength={column.props.filterMaxLength}/>;
         }
 


### PR DESCRIPTION
Fix setting default filter value in the TreeTable filter element

Fix #1129