### PR TITLE
fix InputText reset value issue

### DIFF
--- a/src/components/inputtext/InputText.js
+++ b/src/components/inputtext/InputText.js
@@ -97,6 +97,9 @@ export class InputText extends Component {
         });
 
         let inputProps = ObjectUtils.findDiffKeys(this.props, InputText.defaultProps);
+        if (typeof inputProps.value === 'undefined' || inputProps.value === null) {
+          inputProps.value = '';
+        }
 
         return <input ref={(el) => this.element = el} {...inputProps} className={className} onInput={this.onInput} onKeyPress={this.onKeyPress}/>;
     }


### PR DESCRIPTION
###Defect Fixes
![image](https://user-images.githubusercontent.com/12716802/71402020-af6e9100-2666-11ea-942e-af0cbad1b09a.png)

PrimeReact DataTable Column filters work right after user input name "tomy".
While user presses 'reset' button to clear all column filters, the datatable clear all column filters, the table will show all rows without filters. But the column filter InputText element still show the string 'tomy'.

###Feature Requests
    const columnElements = visibleColumns.map(col => (
      <Column
        key={col.field}
        field={col.field}
        header={col.header}
        style={{ width: `${col.width}px`, minWidth: '50px' }}
        filter={col.filterable === 'true'}
        filterElement={
          <InputText
            type="search"
            value={filters[col.field]}
            onInput={e => this.colFilter(e, col.field)}
          />
        }
        body={this.bodyTemplate}
        sortable
      />
    ));

  colFilter = (e, tag) => {
    const { dispatch, filters } = this.props;
    filters[tag] = e.target.value;
    dispatch({
      type: 'xxx/updateFilters',
      payload: {
        filters,
      },
    });
  };