### PR TITLE
Added className to MultiSelectItem

### DIFF
--- a/src/components/multiselect/MultiSelect.js
+++ b/src/components/multiselect/MultiSelect.js
@@ -387,6 +387,10 @@ export class MultiSelect extends Component {
         return this.props.optionLabel ? ObjectUtils.resolveFieldData(option, this.props.optionLabel) : option.label;
     }
 
+    getOptionClassName(option) {
+        return this.props.optionLabel ? ObjectUtils.resolveFieldData(option, this.props.className) : option.className;
+    }
+
     isEmpty() {
         return !this.props.value || this.props.value.length === 0;
     }
@@ -488,9 +492,10 @@ export class MultiSelect extends Component {
 
             items = items.map((option, index) => {
                 let optionLabel = this.getOptionLabel(option);
+                let optionClassName = this.getOptionClassName(option);
 
                 return (
-                    <MultiSelectItem key={optionLabel + '_' + index} label={optionLabel} option={option} template={this.props.itemTemplate}
+                    <MultiSelectItem key={optionLabel + '_' + index} label={optionLabel} option={option} className={optionClassName} template={this.props.itemTemplate}
                     selected={this.isSelected(option)} onClick={this.onOptionClick} onKeyDown={this.onOptionKeyDown} tabIndex={this.props.tabIndex} />
                 );
             });

--- a/src/components/multiselect/MultiSelectItem.js
+++ b/src/components/multiselect/MultiSelectItem.js
@@ -7,6 +7,7 @@ export class MultiSelectItem extends Component {
     static defaultProps = {
         option: null,
         label: null,
+        className: null,
         selected: false,
         tabIndex: null,
         template: null,
@@ -17,6 +18,7 @@ export class MultiSelectItem extends Component {
     static propTypes = {
         option: PropTypes.object,
         label: PropTypes.string,
+        className: PropTypes.string,
         selected: PropTypes.bool,
         tabIndex: PropTypes.string,
         template: PropTypes.func,
@@ -51,7 +53,7 @@ export class MultiSelectItem extends Component {
     }
 
     render() {
-        const className = classNames('p-multiselect-item', {'p-highlight': this.props.selected});
+        const className = classNames('p-multiselect-item', {'p-highlight': this.props.selected}, this.props.className);
         const checkboxClassName = classNames('p-checkbox-box p-component', {'p-highlight': this.props.selected});
         const checkboxIcon = classNames('p-checkbox-icon p-c', {'pi pi-check': this.props.selected});
         const content = this.props.template ? this.props.template(this.props.option) : this.props.label;


### PR DESCRIPTION
Added className to MultiSelectItem, so classNames as specified in the SelectItem api work on MultiSelect.

###Defect Fixes
I believe this Fixes:
https://github.com/primefaces/primereact/issues/1175

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.