### PR TITLE
Outlined buttons

### DIFF
--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -116,5 +116,4 @@ button.p-button::-moz-focus-inner {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     background-color: transparent !important;
-    color: black !important;
 }

--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -109,3 +109,12 @@ button.p-button::-moz-focus-inner {
         width: 100%;
     }
 }
+
+/** Outlined **/
+.p-button.p-button-outlined {
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    background-color: transparent !important;
+    color: black !important;
+}

--- a/src/components/button/Button.js
+++ b/src/components/button/Button.js
@@ -6,6 +6,11 @@ import ObjectUtils from '../utils/ObjectUtils';
 
 export class Button extends Component {
 
+    constructor(props) {
+        super(props);
+        this.state = {}
+    }
+
     static defaultProps = {
         label: null,
         icon: null,
@@ -35,15 +40,25 @@ export class Button extends Component {
             else
                 this.renderTooltip();
         }
+
+        if (
+            !this.element.style.color &&
+            this.element.classList.contains('p-button-outlined')
+        ) {
+            const borderColor = getComputedStyle(this.element).borderColor;
+            if (borderColor && this.state.textColor !== borderColor) {
+                this.setState({ textColor: borderColor })
+            }
+        }
     }
- 
+
     componentWillUnmount() {
         if (this.tooltip) {
             this.tooltip.destroy();
             this.tooltip = null;
         }
     }
- 
+
     renderTooltip() {
         this.tooltip = new Tooltip({
             target: this.element,
@@ -88,6 +103,10 @@ export class Button extends Component {
         let label = this.renderLabel();
 
         let buttonProps = ObjectUtils.findDiffKeys(this.props, Button.defaultProps);
+
+        if (this.state.textColor) {
+            buttonProps.style = { ...buttonProps.style, color: this.state.textColor }
+        }
 
         return (
             <button ref={(el) => this.element = el} {...buttonProps} className={className}>

--- a/src/showcase/button/ButtonDemo.js
+++ b/src/showcase/button/ButtonDemo.js
@@ -152,8 +152,8 @@ import {Button} from 'primereact/button';
 `}
 </CodeHighlight>
 
-                        <h3>Raised and Rounded Buttons</h3>
-                        <p>A button can be raised by having "p-button-raised" style class and similarly borders can be made rounded using "p-button-rounded" class.</p>
+                        <h3>Raised, Rounded and Outlined Buttons</h3>
+                        <p>A button can be raised by having "p-button-raised" style class and similarly borders can be made rounded using "p-button-rounded" class. There are also outlined buttons that can be made by adding the class "p-button-outlined".</p>
                         <CodeHighlight className="language-jsx">
 {`
 <Button label="Proceed" className="p-button-raised p-button-rounded" />
@@ -305,6 +305,14 @@ export class ButtonDemo extends Component {
                     <Button label="Info" className="p-button-rounded p-button-info" />
                     <Button label="Warning" className="p-button-rounded p-button-warning" />
                     <Button label="Danger" className="p-button-rounded p-button-danger" />
+
+                    <h3>Outlined Buttons</h3>
+                    <Button label="Primary" className="p-button-outlined" />
+                    <Button label="Secondary" className="p-button-outlined p-button-secondary" />
+                    <Button label="Success" className="p-button-outlined p-button-success" />
+                    <Button label="Info" className="p-button-outlined p-button-info" />
+                    <Button label="Warning" className="p-button-outlined p-button-warning" />
+                    <Button label="Danger" className="p-button-outlined p-button-danger" />
                 </div>
             </div>
         )

--- a/src/showcase/button/ButtonDemo.js
+++ b/src/showcase/button/ButtonDemo.js
@@ -52,6 +52,14 @@ export class ButtonDemo extends Component {
                     <Button label="Info" className="p-button-rounded p-button-info" />
                     <Button label="Warning" className="p-button-rounded p-button-warning" />
                     <Button label="Danger" className="p-button-rounded p-button-danger" />
+
+                    <h3>Outlined Buttons</h3>
+                    <Button label="Primary" className="p-button-outlined" />
+                    <Button label="Secondary" className="p-button-outlined p-button-secondary" />
+                    <Button label="Success" className="p-button-outlined p-button-success" />
+                    <Button label="Info" className="p-button-outlined p-button-info" />
+                    <Button label="Warning" className="p-button-outlined p-button-warning" />
+                    <Button label="Danger" className="p-button-outlined p-button-danger" />
                 </div>
 
                 <ButtonDoc />


### PR DESCRIPTION
I'm not a designer but I personally love outlined buttons. I was in need of this feature while building a personal project and I noticed PrimeReact does not have such feature, so I implemented it. Everything is already documented and the showcase is done!

![Screenshot_20200214_003341](https://user-images.githubusercontent.com/18128642/74499173-aa3cfe00-4ec1-11ea-840d-b0534a4c3b99.png)

The colors in the "Secondary" button aren't working very well, and I honestly don't know what to do because its theme based. I'm asking for help if someone know how to improve this.

There is a little trick to set the text color of the button, because the themes doesn't provide any kind of global CSS variable to tell the rest of the framework its color scheme (if it does please tell me and I will improve, but I couldn't manage to find such behavior). The tricky consists in getting the computed styles of the element after its rendered for the first time, and then providing the computed ``border-color`` property to the component's state, creating the need of re-render the component to change the text color.

To make outline buttons its required to provide a ``p-button-outlined`` class into the component's ``className``. It also works well with the other styles.

![Screenshot_20200214_004324](https://user-images.githubusercontent.com/18128642/74499593-05232500-4ec3-11ea-8770-db025c3ccab5.png)

Well, hope it helps the project. I understand if the PR couldn't get accepted because of the company bureaucracy, but if it doesn't get accepted due bad practices of my code please tell me what, so I can improve it and possibly help other new contributors.

Thank you
