### PR TITLE
Added warnings to columnKeys in reorderable DataTables

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -230,6 +230,10 @@ export class DataTable extends Component {
         this.onColumnDrop = this.onColumnDrop.bind(this);
         this.onVirtualScroll = this.onVirtualScroll.bind(this);
         this.frozenSelectionMode = null;
+
+        if (this.props.reorderableColumns && !this.props.children.every(it => it.columnKey)) {
+            console.warn('Omitting columnKey property of Column child in a column reorderable DataTable may imply in duplication of the Columns if they have the same field.')
+        }
     }
 
     getFirst() {


### PR DESCRIPTION
I was investigating #1193 and found out that there is a mess in the column identifiers, because it can be both ``columnKey`` (that can be omitted) or ``field`` (that can be duplicated), and the duplication **and** omission of the cited properties at the same ``Column`` cause the duplication of the column array on reorder actions, at the following line: https://github.com/primefaces/primereact/blob/ce2d51a6469d5e240e4c199d924f67b71e96ac37/src/components/datatable/DataTable.js#L1274

I just added a warning when a ``DataTable`` is constructed with ``reorderableColumns`` as ``true`` **and** some ``Column`` has a omitted ``dataKey``.

I don't know about PrimeReact's plans with this behavior, but I suggest removing the functionality of ``field`` property to act as a identifier, it's just too problematic.

https://github.com/primefaces/primereact/blob/ce2d51a6469d5e240e4c199d924f67b71e96ac37/src/components/datatable/DataTable.js#L948