### PR TITLE
Expandable row selection fix

### DIFF
--- a/src/components/datatable/TableBody.js
+++ b/src/components/datatable/TableBody.js
@@ -65,13 +65,16 @@ export class TableBody extends Component {
                         if(this.isSingleSelectionMode()) {
                             selection = rowData;
                         }
-                        else if(this.isMultipleSelectionMode()) {
+                        else if(this.isMultipleSelectionMode() && !this.props.expandableRowGroups) {
                             if(metaKey)
                                 selection = this.props.selection ? [...this.props.selection] : [];
                             else
                                 selection = [];
-
                             selection = [...selection, rowData];
+                        }
+                        else if(this.isMultipleSelectionMode() && this.props.expandableRowGroups)
+                        {
+                            selection = this.props.selection.length > 0 ? [...this.props.selection, rowData] : [rowData];
                         }
 
                         if(this.props.onRowSelect) {
@@ -264,7 +267,13 @@ export class TableBody extends Component {
 
     equals(data1, data2) {
         let dataKey = this.getDataKeyOnRowToggle();
+
+        if(this.props.expandableRowGroups && this.props.selectionMode)
+            return this.props.compareSelectionBy === 'equals' ? (data1 === data2) : ObjectUtils.deepEquals(data1, data2);
+        else
         return this.props.compareSelectionBy === 'equals' ? (data1 === data2) : ObjectUtils.equals(data1, data2, dataKey);
+
+      
     }
 
     findIndexInSelection(rowData) {


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
https://github.com/primefaces/primereact/issues/1206

I tried to take a light touch on fixing this issue.

There are two problems

1.  When the selection attempts to do a comparison it uses only the field set in data key which will be equal for all grouped items.
2. If using checkboxes with multiple selections there won't be a metakey, so this update is needed to keep the multiselections spread correctly.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.