### PR TITLE
Add className to MultiSelectItem and DropdownItem

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -39,6 +39,7 @@ export class Dropdown extends Component {
         tooltipOptions: null,
         ariaLabel: null,
         ariaLabelledBy: null,
+        optionClassName: null,
         onChange: null,
         onMouseDown: null,
         onContextMenu: null
@@ -75,6 +76,7 @@ export class Dropdown extends Component {
         tooltipOptions: PropTypes.object,
         ariaLabel: PropTypes.string,
         ariaLabelledBy: PropTypes.string,
+        optionClassName: PropTypes.string,
         onChange: PropTypes.func,
         onMouseDown: PropTypes.func,
         onContextMenu: PropTypes.func
@@ -596,8 +598,9 @@ export class Dropdown extends Component {
         if(items) {
             return items.map((option) => {
                 let optionLabel = this.getOptionLabel(option);
+                let optionClassName = this.getOptionClassName(option);
                 return (
-                    <DropdownItem key={this.getOptionKey(option)} label={optionLabel} option={option} template={this.props.itemTemplate} selected={selectedOption === option} disabled={option.disabled} onClick={this.onOptionClick} />
+                    <DropdownItem key={this.getOptionKey(option)} label={optionLabel} option={option} template={this.props.itemTemplate} className={optionClassName} selected={selectedOption === option} disabled={option.disabled} onClick={this.onOptionClick} />
                 );
             });
         }
@@ -625,6 +628,10 @@ export class Dropdown extends Component {
 
     getOptionKey(option) {
         return this.props.dataKey ? ObjectUtils.resolveFieldData(option, this.props.dataKey) : this.getOptionLabel(option);
+    }
+
+    getOptionClassName(option) {
+        return this.props.optionClassName ? ObjectUtils.resolveFieldData(option, this.props.optionClassName) : option.className;
     }
 
     checkValidity() {

--- a/src/components/dropdown/DropdownItem.d.ts
+++ b/src/components/dropdown/DropdownItem.d.ts
@@ -4,6 +4,7 @@ interface DropdownItemProps {
     option?: object;
     selected?: boolean;
     template?(option:any): JSX.Element | undefined;
+    className?:  string;
     onClick?(e: {originalEvent: Event, option: object}): void;
 }
 

--- a/src/components/dropdown/DropdownItem.js
+++ b/src/components/dropdown/DropdownItem.js
@@ -10,6 +10,7 @@ export class DropdownItem extends Component {
         template: null,
         selected: false,
         disabled: false,
+        className: null,
         onClick: null
     };
 
@@ -19,6 +20,7 @@ export class DropdownItem extends Component {
         template: PropTypes.func,
         selected: PropTypes.bool,
         disabled: PropTypes.bool,
+        className: PropTypes.string,
         onClick: PropTypes.func
     };
 
@@ -38,7 +40,7 @@ export class DropdownItem extends Component {
     }
 
     render() {
-        let className = classNames('p-dropdown-item', {
+        let className = classNames(this.props.className, 'p-dropdown-item', {
             'p-highlight': this.props.selected,
             'p-disabled': this.props.disabled,
             'p-dropdown-item-empty': (!this.props.label || this.props.label.length === 0)

--- a/src/components/multiselect/MultiSelect.d.ts
+++ b/src/components/multiselect/MultiSelect.d.ts
@@ -23,6 +23,7 @@ interface MultiSelectProps {
     selectedItemsLabel?: string;
     itemTemplate?(item: any): JSX.Element | undefined;
     selectedItemTemplate?(value: any): JSX.Element | undefined;
+    optionClassName?: string;
     onChange?(e: {originalEvent: Event, value: any}): void;
     onFocus?(event: Event): void;
     onBlur?(event: Event): void;

--- a/src/components/multiselect/MultiSelect.js
+++ b/src/components/multiselect/MultiSelect.js
@@ -32,6 +32,7 @@ export class MultiSelect extends Component {
         ariaLabelledBy: null,
         itemTemplate: null,
         selectedItemTemplate: null,
+        optionClassName: null,
         onChange: null,
         onFocus: null,
         onBlur: null
@@ -59,6 +60,7 @@ export class MultiSelect extends Component {
         ariaLabelledBy: PropTypes.string,
         itemTemplate: PropTypes.func,
         selectedItemTemplate: PropTypes.func,
+        optionClassName: PropTypes.string,
         onChange: PropTypes.func,
         onFocus: PropTypes.func,
         onBlur: PropTypes.func
@@ -387,6 +389,10 @@ export class MultiSelect extends Component {
         return this.props.optionLabel ? ObjectUtils.resolveFieldData(option, this.props.optionLabel) : option.label;
     }
 
+    getOptionClassName(option) {
+        return this.props.optionClassName ? ObjectUtils.resolveFieldData(option, this.props.optionClassName) : option.className;
+    }
+
     isEmpty() {
         return !this.props.value || this.props.value.length === 0;
     }
@@ -488,9 +494,10 @@ export class MultiSelect extends Component {
 
             items = items.map((option, index) => {
                 let optionLabel = this.getOptionLabel(option);
+                let optionClassName = this.getOptionClassName(option);
 
                 return (
-                    <MultiSelectItem key={optionLabel + '_' + index} label={optionLabel} option={option} template={this.props.itemTemplate}
+                    <MultiSelectItem key={optionLabel + '_' + index} label={optionLabel} option={option} template={this.props.itemTemplate} className={optionClassName}
                     selected={this.isSelected(option)} onClick={this.onOptionClick} onKeyDown={this.onOptionKeyDown} tabIndex={this.props.tabIndex} />
                 );
             });

--- a/src/components/multiselect/MultiSelectItem.js
+++ b/src/components/multiselect/MultiSelectItem.js
@@ -10,6 +10,7 @@ export class MultiSelectItem extends Component {
         selected: false,
         tabIndex: null,
         template: null,
+        className: null,
         onClick: null,
         onKeyDown: null,
     };
@@ -20,6 +21,7 @@ export class MultiSelectItem extends Component {
         selected: PropTypes.bool,
         tabIndex: PropTypes.string,
         template: PropTypes.func,
+        className: PropTypes.string,
         onClick: PropTypes.func,
         onKeyDown: PropTypes.func,
     };
@@ -51,7 +53,7 @@ export class MultiSelectItem extends Component {
     }
 
     render() {
-        const className = classNames('p-multiselect-item', {'p-highlight': this.props.selected});
+        const className = classNames(this.props.className, 'p-multiselect-item', {'p-highlight': this.props.selected});
         const checkboxClassName = classNames('p-checkbox-box p-component', {'p-highlight': this.props.selected});
         const checkboxIcon = classNames('p-checkbox-icon p-c', {'pi pi-check': this.props.selected});
         const content = this.props.template ? this.props.template(this.props.option) : this.props.label;


### PR DESCRIPTION
Solves #1175 for `MultiSelect` and `Dropdown` components. Each item may now have its own `className`

An other pull request (#1177) already exists but it is incomplete.