### PR TITLE
Adding missing type definition className to ToolTipOptions

### DIFF
--- a/src/components/tooltip/TooltipOptions.d.ts
+++ b/src/components/tooltip/TooltipOptions.d.ts
@@ -3,5 +3,5 @@ export default interface TooltipOptions {
     position?: string;
     showDelay?: number;
     hideDelay?: number;
-	className?: string;
+	  className?: string;
 }

--- a/src/components/tooltip/TooltipOptions.d.ts
+++ b/src/components/tooltip/TooltipOptions.d.ts
@@ -3,4 +3,5 @@ export default interface TooltipOptions {
     position?: string;
     showDelay?: number;
     hideDelay?: number;
+	className?: string;
 }


### PR DESCRIPTION
###Defect Fixes
The TypeDefinitions for ToolTipOptions do not contain className. 
ToolTip.js uses options.className and it is also in the documentation.

