### PR TITLE
deprecated installation option --save npm removed and included  yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,14 @@ See [PrimeReact homepage](https://www.primefaces.org/react) for live showcase an
 PrimeReact is available at npm, if you have an existing application run the following command to download it to your project.
 
 ```
-npm install primereact --save
-npm install primeicons --save
+npm install primereact
+npm install primeicons
+```
+or
+
+```
+yarn add primereact
+yarn add primeicons
 ```
 
 ## Import


### PR DESCRIPTION
`npm install` no longer has a --save option, and as of version 5 of npm this option is no longer needed as it is performed by default!

more details [NPM v5.0.0](https://blog.npmjs.org/post/161081169345/v500 "NPM v5.0.0")

This PR removes --save from the suggested npm install command
and add the yarn equivalent command