### PR TITLE
Fix file selection not working after validation fails

### DIFF
--- a/src/components/fileupload/FileUpload.js
+++ b/src/components/fileupload/FileUpload.js
@@ -182,7 +182,7 @@ export class FileUpload extends Component {
             this.clearInputElement();
         }
 
-        if(this.props.mode === 'basic') {
+        if(this.props.mode === 'basic' && this.files.length > 0) {
             this.fileInput.style.display = 'none';
         }
     }

--- a/src/components/fileupload/FileUpload.js
+++ b/src/components/fileupload/FileUpload.js
@@ -100,7 +100,7 @@ export class FileUpload extends Component {
     isImage(file) {
         return /^image\//.test(file.type);
     }
- 
+ 　　　
     remove(event, index) {
         this.clearInputElement();
         let currentFiles = [...this.state.files];

--- a/src/components/fileupload/FileUpload.js
+++ b/src/components/fileupload/FileUpload.js
@@ -100,7 +100,7 @@ export class FileUpload extends Component {
     isImage(file) {
         return /^image\//.test(file.type);
     }
-
+ 
     remove(event, index) {
         this.clearInputElement();
         let currentFiles = [...this.state.files];


### PR DESCRIPTION
**I'm submitting a ...**  (check one with "x")
```
[x] bug report
[ ] feature request
[ ] support request => Please do not submit support request here, instead see https://forum.primefaces.org/viewforum.php?f=57
```

**Current behavior**
If the mode property is "basic", file selection will not work after validation fails.

**Expected behavior**
Disable file selection only if the validation is successful.

**Minimal reproduction of the problem with instructions**
It is possible to reproduce the problem using an example for "Basic" in showcase.(Upload of a file larger than 1,000,000 bytes reproduces this problem.)

https://www.primefaces.org/primereact/showcase/#/fileupload

* **React version:**
16.13.1

* **PrimeReact version:**
4.2.2

* **Browser:** [all | Chrome XX | Firefox XX | IE XX | Safari XX | Mobile Chrome XX | Android X.X Web Browser | iOS XX Safari | iOS XX UIWebView | iOS XX WKWebView ]
Browser: Chrome  83.0.4103.106 but I think it will happen in any other browser
 
* **Language:** [all | TypeScript X.X | ES6/7 | ES5]
JS