### PR TITLE
Calling clearTimeout is required before unmounting AutoComplete

### DIFF
--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -501,6 +501,10 @@ export class AutoComplete extends Component {
             this.tooltip.destroy();
             this.tooltip = null;
         }
+
+        if (this.timeout) {
+            clearTimeout(this.timeout);
+        }
     }
 
     componentDidUpdate(prevProps) {


### PR DESCRIPTION
###Defect Fixes
If AutoComplete is unmounted before the delay property's time has elapsed, an error occurs.
The length of the delay property is up to the user and should be considered.
For example, Dropdown and GrowlMessage are implemented correctly.

[codesandbox](https://codesandbox.io/s/primereact-test-y9ywx?file=/src/index.js)

**error output**
Uncaught TypeError: Cannot read property 'style' of null
    at AutoComplete.showLoader (eval at xo (eval.ts:63), <anonymous>:528:19)
    at AutoComplete.search (eval at xo (eval.ts:63), <anonymous>:151:14)
    at eval (eval at xo (eval.ts:63), <anonymous>:122:20)
