### PR TITLE
Add new messages to Growl in the same render cycle

### DIFF
--- a/src/components/growl/Growl.js
+++ b/src/components/growl/Growl.js
@@ -40,21 +40,21 @@ export class Growl extends Component {
 
     show(value) {
         if (value) {
-            let newMessages;
+            this.setState(prevState => {
+                let newMessages;
 
-            if (Array.isArray(value)) {
-                for (let i = 0; i < value.length; i++) {
-                    value[i].id = messageIdx++;
-                    newMessages = [...this.state.messages, ...value];
+                if (Array.isArray(value)) {
+                    for (let i = 0; i < value.length; i++) {
+                        value[i].id = messageIdx++;
+                        newMessages = [...prevState.messages, ...value];
+                    }
                 }
-            }
-            else {
-                value.id = messageIdx++;
-                newMessages = this.state.messages ? [...this.state.messages, value] : [value];
-            }
+                else {
+                    value.id = messageIdx++;
+                    newMessages = prevState.messages ? [...prevState.messages, value] : [value];
+                }
 
-            this.setState({
-                messages: newMessages
+                return { messages: newMessages }
             });
 
             this.container.style.zIndex = String(this.props.baseZIndex + DomHandler.generateZIndex());


### PR DESCRIPTION
Function show in Growl is using old state values when adding new messages.

This will ignore messages previously added in the same render cycle.