### PR TITLE
Refactor #1112 - Add prop to support customisable Multiselect header

### DIFF
--- a/src/components/multiselect/MultiSelect.js
+++ b/src/components/multiselect/MultiSelect.js
@@ -18,6 +18,7 @@ export class MultiSelect extends Component {
         options: null,
         optionLabel: null,
         optionValue: null,
+        optionHeader: null,
         style: null,
         className: null,
         scrollHeight: '200px',
@@ -53,6 +54,7 @@ export class MultiSelect extends Component {
         options: PropTypes.array,
         optionLabel: PropTypes.string,
         optionValue: PropTypes.string,
+        optionHeader: PropTypes.string,
         style: PropTypes.object,
         className: PropTypes.string,
         scrollHeight: PropTypes.string,
@@ -471,7 +473,7 @@ export class MultiSelect extends Component {
 
     renderHeader(items) {
         return (
-            <MultiSelectHeader filter={this.props.filter} filterValue={this.state.filter} onFilter={this.onFilter} filterPlaceholder={this.props.filterPlaceholder}
+            <MultiSelectHeader title={this.props.optionHeader} filter={this.props.filter} filterValue={this.state.filter} onFilter={this.onFilter} filterPlaceholder={this.props.filterPlaceholder}
                 onClose={this.onCloseClick} onToggleAll={this.onToggleAll} allChecked={this.isAllChecked(items)} />
         );
     }

--- a/src/components/multiselect/MultiSelectHeader.js
+++ b/src/components/multiselect/MultiSelectHeader.js
@@ -6,6 +6,7 @@ import {Checkbox} from '../checkbox/Checkbox';
 export class MultiSelectHeader extends Component {
 
     static defaultProps = {
+        title: null,
         filter: false,
         filterValue: null,
         filterPlaceholder: null,
@@ -16,6 +17,7 @@ export class MultiSelectHeader extends Component {
     }
 
     static propTypes = {
+        title: PropTypes.string,
         filter: PropTypes.bool,
         filterValue: PropTypes.string,
         filterPlaceholder: PropTypes.string,
@@ -59,9 +61,12 @@ export class MultiSelectHeader extends Component {
                 </div>
             );
         }
-        else {
-            return null;
+        if (this.props.title) {
+            return (
+                <label>{this.props.title}</label>
+            );
         }
+        return null;
     }
 
     render() {


### PR DESCRIPTION
Refactor #1112 

Added `optionHeader` prop to take customisable header text.
Default text will be null, same as in current scenario.
If filter is enabled, header text will be overridden. 
