### PR TITLE
[Card] Allow React.ReactNode in title and subtitle

### DIFF
--- a/src/components/card/Card.d.ts
+++ b/src/components/card/Card.d.ts
@@ -4,8 +4,8 @@ interface CardProps {
     id?: string;
     header?: any;
     footer?: any;
-    title?: string;
-    subTitle?: string;
+    title?: string|React.ReactNode;
+    subTitle?: string|React.ReactNode;
     style?: object;
     className?: string;
 }

--- a/src/components/card/Card.js
+++ b/src/components/card/Card.js
@@ -18,8 +18,8 @@ export class Card extends Component {
         id: PropTypes.string,
         header: PropTypes.any,
         footer: PropTypes.any,
-        title: PropTypes.string,
-        subTitle: PropTypes.string,
+        title: PropTypes.oneOf([PropTypes.string, PropTypes.node]),
+        subTitle: PropTypes.oneOf([PropTypes.string, PropTypes.node]),
         style: PropTypes.object,
         className: PropTypes.string
     };
@@ -29,7 +29,7 @@ export class Card extends Component {
                     {this.props.header}
                 </div>;
     }
-    
+
     renderBody(){
         let title, subTitle, footer, children;
 


### PR DESCRIPTION
Often it would be nice to embed icons etc inside a card title or subtitle.
Currently these properties are marked as string but would also work fine if they are a ReactNode.

Using ``//@ts-ignore`` works but also generates a warning on the console which is not that great.