### PR TITLE
allowCustom prop for AutoComplete - allow custom values in multi-select mode

### DIFF
--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -12,6 +12,7 @@ interface AutoCompleteProps {
     dropdown?: boolean;
     dropdownMode?: string;
     multiple?: boolean;
+    allowCustom?: boolean;
     minLength?: number;
     delay?: number;
     style?: object;

--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -183,7 +183,7 @@ export class AutoComplete extends Component {
         }
     }
 
-    selectItem(event, option) { 
+    selectItem(event, option) {
         if (this.props.multiple) {
             this.inputEl.value = '';
             if (!this.isSelected(option)) {

--- a/src/components/autocomplete/AutoComplete.js
+++ b/src/components/autocomplete/AutoComplete.js
@@ -24,6 +24,7 @@ export class AutoComplete extends Component {
         dropdown: false,
         dropdownMode: 'blank',
         multiple: false,
+        allowCustom: false,
         minLength: 1,
         delay: 300,
         style: null,
@@ -71,6 +72,7 @@ export class AutoComplete extends Component {
         dropdown: PropTypes.bool,
         dropdownMode: PropTypes.string,
         multiple: PropTypes.bool,
+        allowCustom: PropTypes.bool,
         minLength: PropTypes.number,
         delay: PropTypes.number,
         style: PropTypes.object,
@@ -181,7 +183,7 @@ export class AutoComplete extends Component {
         }
     }
 
-    selectItem(event, option) {
+    selectItem(event, option) { 
         if (this.props.multiple) {
             this.inputEl.value = '';
             if (!this.isSelected(option)) {
@@ -350,8 +352,15 @@ export class AutoComplete extends Component {
                 case 13:
                     if (highlightItem) {
                         this.selectItem(event, this.props.suggestions[DomHandler.index(highlightItem)]);
-                        this.hideOverlay();
+                    } else {
+                        if (this.props.allowCustom && this.props.multiple) {
+                            this.selectItem(event, {
+                                name: event.target.value,
+                                code: event.target.value
+                            });
+                        }
                     }
+                    this.hideOverlay();
 
                     event.preventDefault();
                 break;
@@ -513,7 +522,8 @@ export class AutoComplete extends Component {
 
     componentDidUpdate(prevProps) {
         if (prevProps.suggestions !== this.props.suggestions && this.state.searching) {
-            if (this.props.suggestions && this.props.suggestions.length)
+            if (this.props.suggestions && this.props.suggestions.length ||
+                this.props.allowCustom && this.props.multiple && this.inputEl.value.length)
                 this.showOverlay();
             else
                 this.hideOverlay();

--- a/src/showcase/autocomplete/AutoCompleteDemo.js
+++ b/src/showcase/autocomplete/AutoCompleteDemo.js
@@ -70,7 +70,7 @@ export class AutoCompleteDemo extends Component {
 
                         <h5>Multiple</h5>
                         <span className="p-fluid">
-                            <AutoComplete value={this.state.selectedCountries} suggestions={this.state.filteredCountries} completeMethod={this.searchCountry} field="name" multiple onChange={(e) => this.setState({ selectedCountries: e.value })} />
+                            <AutoComplete value={this.state.selectedCountries} suggestions={this.state.filteredCountries} completeMethod={this.searchCountry} field="name" multiple allowCustom onChange={(e) => this.setState({ selectedCountries: e.value })} />
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Added allowCustom prop and related logic to AutoComplete component to enable functionality similar to https://www.telerik.com/kendo-react-ui/components/dropdowns/multiselect/custom-values/