### PR TITLE
Fixed an issue where the input element was not updated when the props…

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -264,7 +264,7 @@ export class Calendar extends Component {
             this.updateFocus();
         }
 
-        if (prevProps.value !== this.props.value && (!this.viewStateChanged || this.state.overlayVisible)) {
+        if (prevProps.value !== this.props.value && (!this.viewStateChanged || !this.state.overlayVisible)) {
             this.updateInputfield(this.props.value);
         }
     }


### PR DESCRIPTION
###Defect Fixes
Fixed an issue where the input element was not updated when the props changed.
The conditions were reversed in 5.0.0-rc.1.

4.2.2
if (prevProps.value !== this.props.value && (!this.viewStateChanged || **!this.panel.offsetParent**)) {

5.0.0-rc.1
if (prevProps.value !== this.props.value && (!this.viewStateChanged || **this.state.overlayVisible**)) {
