### PR TITLE
Fixed #1535

### DIFF
--- a/src/components/dropdown/DropdownPanel.js
+++ b/src/components/dropdown/DropdownPanel.js
@@ -23,10 +23,38 @@ export class DropdownPanel extends Component {
         onClick: PropTypes.func
     };
 
+    isInsideDropdown() {
+        let component = ReactDOM.findDOMNode(this);
+        while (component) {
+            if (component.className?.includes('p-dialog-content')) {
+                return true;
+            }
+            component = component.parentNode;
+        }
+        return false;
+    }
+
     renderElement() {
         let className = classNames('p-dropdown-panel p-component', this.props.panelClassName);
+        const isInsideDropdown = this.isInsideDropdown()
+        function wrapIfNeeded(dom) {
+            if (isInsideDropdown) {
+                return (
+                    <div>
+                        <div style={{ position: 'absolute', zIndex: 999 }}>
+                            <div style={{ position: 'fixed' }}>
+                                { dom }
+                            </div>
+                        </div>
+                    </div>
+                )
+            } else {
+                return dom;
+            }
+        }
 
-        return (
+
+        return wrapIfNeeded(
             <div ref={(el) => this.element = el} className={className} style={this.props.panelStyle} onClick={this.props.onClick}>
                 {this.props.filter}
                 <div ref={(el) => this.itemsWrapper = el} className="p-dropdown-items-wrapper" style={{ maxHeight: this.props.scrollHeight || 'auto' }}>
@@ -35,7 +63,7 @@ export class DropdownPanel extends Component {
                     </ul>
                 </div>
             </div>
-        );
+        )
     }
 
     render() {


### PR DESCRIPTION
### Defect Fixes
Fixed #1535 

This is a very common CSS limitation, unfortunately I couldn't find a more elegant solution of doing this other by wrapping the Dropdown's overlay in a chain of ``div``, ``div`` again (with position absolute), and another ``div`` (with position fixed).

The overlay is only wrapped when the component is inside a Dialog, and this is known by iterating down the DOM tree searching for a parent element with the class ``p-dialog-content``. If found, the overlay will be wrapped into that 3 div chain I mentioned.

Not an elegant solution, but now I'm able to see the entire dropdown content when inside a dialog, and the behavior when its not is just the same as before

https://github.com/w3c/csswg-drafts/issues/4092