### PR TITLE
Fix sometimes Dropdown item selection does not work #1544

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -607,7 +607,9 @@ export class Dropdown extends Component {
                 this.alignPanel();
             }
 
-            this.scrollInView();
+            if (prevProps.value !== this.props.value) {
+                this.scrollInView();
+            }
         }
 
         if (prevProps.tooltip !== this.props.tooltip) {


### PR DESCRIPTION
Fix #1544 

### Cause
Since 5.0.0-rc1, the focus state is managed by component state(this.state.focuesd).
Therefore, when the focus state is updated with onBlur, render is executed.
After render, scrolling is performed in componentDidUpdate, which prevents the item click event from firing and prevents item selection from working.

See the link below to see why scrolling inhibits click events.
[https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event](https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event)

### Defect Fixes
The scrolling behavior to the position of the selected item after displaying the DropdownPanel is implemented in onOverlayEntered.
The scrolling process in the componentDidUpdate is implemented for the purpose of scrolling when the up and down keys are pressed or when the props.value is changed.
Based on the above, the scrolling process in componentDidUpdate is modified to be performed only when the props.value changes.