### PR TITLE
Fix display incompatibility between 4.2.2 and 5.0.0-rc.1 - #1575

### DIFF
--- a/src/components/button/Button.css
+++ b/src/components/button/Button.css
@@ -4,7 +4,6 @@
     cursor: pointer;
     user-select: none;
     align-items: center;
-    vertical-align: bottom;
     text-align: center;
     overflow: hidden;
     position: relative;
@@ -12,6 +11,7 @@
 
 .p-button-label {
     flex: 1 1 auto;
+    line-height: normal;
 }
 
 .p-button-icon-right {


### PR DESCRIPTION
Fix #1575
 
### Cause
In 4.2.2, "line-height:normal" is set in the renderLabel() span tag, but it is not set in 5.0.0-rc.1.
Therefore, the line-height value is browser-dependent in 5.0.0-rc.1, so it may look differently in 5.0.0-rc.1.
In 5.0.0-rc.1, the button tag is set to "vertical-align: bottom", so the button may look different between 4.2.2 and 5.0.0-rc.1.

### Defect Fixes
Set "line-height: normal" for the span tag of renderLabel().
Remove the "vertical-align: bottom" from the button tag.