### PR TITLE
Fixed - Fieldset shows empty legend over its border

### DIFF
--- a/src/components/fieldset/Fieldset.js
+++ b/src/components/fieldset/Fieldset.js
@@ -136,12 +136,13 @@ export class Fieldset extends Component {
 
     renderLegend(collapsed) {
         const legendContent = this.renderLegendContent(collapsed);
-
-        return (
-            <legend className="p-fieldset-legend p-unselectable-text" onClick={this.toggle}>
-                {legendContent}
-            </legend>
-        );
+        if (this.props.legend != null || this.props.toggleable) {
+            return (
+                <legend className="p-fieldset-legend p-unselectable-text" onClick={this.toggle}>
+                    {legendContent}
+                </legend>
+            );
+        }
     }
 
     render() {


### PR DESCRIPTION
Fixed [#1433](https://github.com/primefaces/primereact/issues/1433)