### PR TITLE
Added editingRows property to Datatable.

### DIFF
--- a/src/components/datatable/BodyRow.js
+++ b/src/components/datatable/BodyRow.js
@@ -7,9 +7,6 @@ export class BodyRow extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {
-            editing: false
-        };
 
         this.onClick = this.onClick.bind(this);
         this.onDoubleClick = this.onDoubleClick.bind(this);
@@ -177,10 +174,6 @@ export class BodyRow extends Component {
             });
         }
 
-        this.setState({
-            editing: true
-        });
-
         event.preventDefault();
     }
 
@@ -195,13 +188,10 @@ export class BodyRow extends Component {
             this.props.onRowEditSave({
                 originalEvent: event,
                 data: this.props.rowData,
-                index: this.props.rowIndex
+                index: this.props.rowIndex,
+                valid: valid
             });
         }
-
-        this.setState({
-            editing: !valid
-        });
 
         event.preventDefault();
     }
@@ -214,10 +204,6 @@ export class BodyRow extends Component {
                 index: this.props.rowIndex
             });
         }
-
-        this.setState({
-            editing: false
-        });
 
         event.preventDefault();
     }
@@ -256,7 +242,7 @@ export class BodyRow extends Component {
 
             let cell = <BodyCell key={i} {...column.props} value={this.props.value} rowSpan={rowSpan} rowData={this.props.rowData} rowIndex={this.props.rowIndex} onRowToggle={this.props.onRowToggle} expanded={this.props.expanded}
                         onRadioClick={this.props.onRadioClick} onCheckboxClick={this.props.onCheckboxClick} selected={this.props.selected}
-                        editMode={this.props.editMode} editing={this.state.editing} onRowEditInit={this.onRowEditInit} onRowEditSave={this.onRowEditSave} onRowEditCancel={this.onRowEditCancel}
+                        editMode={this.props.editMode} editing={this.props.editing} onRowEditInit={this.onRowEditInit} onRowEditSave={this.onRowEditSave} onRowEditCancel={this.onRowEditCancel}
                         showRowReorderElement={this.props.showRowReorderElement} showSelectionElement={this.props.showSelectionElement}/>;
 
             cells.push(cell);

--- a/src/components/datatable/DataTable.d.ts
+++ b/src/components/datatable/DataTable.d.ts
@@ -65,6 +65,7 @@ interface DataTableProps {
     stateStorage?:string;
     groupField?:string;
     editMode?:string;
+    editingRows?: any[];
     expandableRowGroups?:boolean;
     rowHover?:boolean;
     showSelectionElement?(e: {data: any}): boolean;
@@ -93,7 +94,7 @@ interface DataTableProps {
     onValueChange?(value: any[]): void;
     rowEditorValidator?(rowData: any): boolean;
     onRowEditInit?(e: {originalEvent: Event, data: any, index: number}): void;
-    onRowEditSave?(e: {originalEvent: Event, data: any, index: number}): void;
+    onRowEditSave?(e: {originalEvent: Event, data: any, index: number, valid: boolean}): void;
     onRowEditCancel?(e: {originalEvent: Event, data: any, index: number}): void;
     exportFunction?(e: {data: any, field: string}): any;
     customSaveState?(state: any): void;

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -84,6 +84,7 @@ export class DataTable extends Component {
         stateKey: null,
         stateStorage: 'session',
         editMode: 'cell',
+        editingRows: null,
         expandableRowGroups: false,
         rowHover: false,
         showSelectionElement: null,
@@ -183,6 +184,7 @@ export class DataTable extends Component {
         stateKey: PropTypes.string,
         stateStorage: PropTypes.string,
         editMode: PropTypes.string,
+        editingRows: PropTypes.oneOfType([PropTypes.array,PropTypes.object]),
         expandableRowGroups: PropTypes.bool,
         rowHover: PropTypes.bool,
         showSelectionElement: PropTypes.func,
@@ -1305,7 +1307,7 @@ export class DataTable extends Component {
                         virtualScroll={this.props.virtualScroll} virtualRowHeight={this.props.virtualRowHeight} loading={this.props.loading}
                         groupField={this.props.groupField} rowGroupMode={this.props.rowGroupMode} rowGroupHeaderTemplate={this.props.rowGroupHeaderTemplate} rowGroupFooterTemplate={this.props.rowGroupFooterTemplate}
                         sortField={this.getSortField()} rowClassName={this.props.rowClassName} onRowReorder={this.props.onRowReorder}
-                        editMode={this.props.editMode} rowEditorValidator={this.props.rowEditorValidator} onRowEditInit={this.props.onRowEditInit} onRowEditSave={this.props.onRowEditSave} onRowEditCancel={this.props.onRowEditCancel}
+                        editMode={this.props.editMode} editingRows={this.props.editingRows} rowEditorValidator={this.props.rowEditorValidator} onRowEditInit={this.props.onRowEditInit} onRowEditSave={this.props.onRowEditSave} onRowEditCancel={this.props.onRowEditCancel}
                         expandableRowGroups={this.props.expandableRowGroups} showRowReorderElement={this.props.showRowReorderElement} showSelectionElement={this.props.showSelectionElement}>
                         {columns}
                 </TableBody>;

--- a/src/components/datatable/TableBody.js
+++ b/src/components/datatable/TableBody.js
@@ -359,6 +359,32 @@ export class TableBody extends Component {
         }
     }
 
+    findEditingRowIndex(row) {
+        let index = -1;
+        if (this.props.editingRows) {
+            for (let i = 0; i < this.props.editingRows.length; i++) {
+                if (ObjectUtils.equals(this.props.editingRows[i], row)) {
+                    index = i;
+                    break;
+                }
+            }
+        }
+        return index;
+    }
+
+    isRowEditing(row) {
+        let dataKey = this.props.dataKey;
+
+        if (dataKey) {
+            let dataKeyValue = String(ObjectUtils.resolveFieldData(row, dataKey));
+
+            return this.props.editingRows && this.props.editingRows[dataKeyValue] != null;
+        }
+        else {
+            return this.findEditingRowIndex(row) !== -1
+        }
+    }
+
     isSelectionEnabled() {
         if(this.props.selectionMode || this.props.frozenSelectionMode != null) {
             return true;
@@ -503,6 +529,7 @@ export class TableBody extends Component {
 
                     let rowData = this.props.value[i];
                     let expanded = this.isRowExpanded(rowData);
+                    let editing = this.isRowEditing(rowData);
                     let selected = selectionEnabled ? this.isSelected(this.props.value[i]) : false;
                     let contextMenuSelected = this.isContextMenuSelected(rowData);
                     let groupRowSpan;
@@ -549,7 +576,7 @@ export class TableBody extends Component {
                                             sortField={this.props.sortField} rowGroupMode={this.props.rowGroupMode} groupRowSpan={groupRowSpan}
                                             onDragStart={(e) => this.onRowDragStart(e, i)} onDragEnd={this.onRowDragEnd} onDragOver={(e) => this.onRowDragOver(e, i)} onDragLeave={this.onRowDragLeave}
                                             onDrop={this.onRowDrop} virtualScroll={this.props.virtualScroll} virtualRowHeight={this.props.virtualRowHeight}
-                                            editMode={this.props.editMode} rowEditorValidator={this.props.rowEditorValidator} onRowEditInit={this.props.onRowEditInit} onRowEditSave={this.props.onRowEditSave} onRowEditCancel={this.props.onRowEditCancel}
+                                            editMode={this.props.editMode} editing={editing} rowEditorValidator={this.props.rowEditorValidator} onRowEditInit={this.props.onRowEditInit} onRowEditSave={this.props.onRowEditSave} onRowEditCancel={this.props.onRowEditCancel}
                                             showRowReorderElement={this.props.showRowReorderElement} showSelectionElement={this.props.showSelectionElement}>
                                             {this.props.children}
                                     </BodyRow>


### PR DESCRIPTION
Added editingRows property to Datatable. This allows for setting the rows being in editing state and triggering editing state for rows from outside the Datatable. Added valid state to returns of onRowEditSave. Adjusted Typing.

###Feature Requests
Adds the feature desired in this issue: https://github.com/primefaces/primereact/issues/1135