### PR TITLE
Usage of FindDOMNode removed

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -217,6 +217,9 @@ export class Calendar extends Component {
         this.reFocusInputField = this.reFocusInputField.bind(this);
 
         this.id = this.props.id || UniqueComponentId();
+        
+        this.inputRef = React.createRef();
+        this.calendarRef = React.createRef();
     }
 
     componentDidMount() {
@@ -2858,7 +2861,7 @@ export class Calendar extends Component {
     renderInputElement() {
         if (!this.props.inline) {
             return (
-                <InputText ref={(el) => this.inputElement = ReactDOM.findDOMNode(el)} id={this.props.inputId} name={this.props.name} type="text" className={this.props.inputClassName} style={this.props.inputStyle}
+                <InputText ref={this.inputRef} id={this.props.inputId} name={this.props.name} type="text" className={this.props.inputClassName} style={this.props.inputStyle}
                            readOnly={this.props.readOnlyInput} disabled={this.props.disabled} required={this.props.required} autoComplete="off" placeholder={this.props.placeholder}
                            onInput={this.onUserInput} onFocus={this.onInputFocus} onBlur={this.onInputBlur} onKeyDown={this.onInputKeyDown} aria-labelledby={this.props.ariaLabelledBy} inputMode="none"/>
             );
@@ -2936,7 +2939,7 @@ export class Calendar extends Component {
                 {button}
                 <CSSTransition classNames="p-connected-overlay" in={this.props.inline || this.state.overlayVisible} timeout={{ enter: 120, exit: 100 }}
                     unmountOnExit onEnter={this.onOverlayEnter} onEntered={this.onOverlayEntered} onExit={this.onOverlayExit}>
-                    <CalendarPanel ref={(el) => this.panel = ReactDOM.findDOMNode(el)} className={panelClassName} style={this.props.panelStyle}
+                    <CalendarPanel ref={this.calendarRef} className={panelClassName} style={this.props.panelStyle}
                                appendTo={this.props.appendTo}>
                         {datePicker}
                         {timePicker}


### PR DESCRIPTION
Warning that findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of CalendarPanel and Input which are inside StrictMode fixed. Used CreateRef instead of FindDOMNode

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.