### PR TITLE
Add template to MenuItem interface

### DIFF
--- a/src/components/menuitem/MenuItem.d.ts
+++ b/src/components/menuitem/MenuItem.d.ts
@@ -9,4 +9,5 @@ export interface MenuItem {
     style?: any;
     className?: string;
     command?(e: {originalEvent: Event, item: MenuItem}): void;
+    template: JSX.Element;
 }


### PR DESCRIPTION
Interface was missing this definition, making it difficult to use with Typescript.

###Defect Fixes
#1823 