### PR TITLE
Fixed #1898 - PickList transfer buttons and item selection

### DIFF
--- a/src/components/picklist/PickList.js
+++ b/src/components/picklist/PickList.js
@@ -1,10 +1,10 @@
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types';
 import DomHandler from '../utils/DomHandler';
 import { classNames } from '../utils/ClassNames';
-import {PickListSubList} from './PickListSubList';
-import {PickListControls} from './PickListControls';
-import {PickListTransferControls} from './PickListTransferControls';
+import { PickListSubList } from './PickListSubList';
+import { PickListControls } from './PickListControls';
+import { PickListTransferControls } from './PickListTransferControls';
 
 export class PickList extends Component {
 
@@ -101,31 +101,31 @@ export class PickList extends Component {
         if (listElement) {
             let listContainer = DomHandler.findSingle(listElement, '.p-picklist-list');
 
-            switch(direction) {
+            switch (direction) {
                 case 'up':
                     this.scrollInView(listContainer, -1);
-                break;
+                    break;
 
                 case 'top':
                     listContainer.scrollTop = 0;
-                break;
+                    break;
 
                 case 'down':
                     this.scrollInView(listContainer, 1);
-                break;
+                    break;
 
                 case 'bottom':
                     listContainer.scrollTop = listContainer.scrollHeight;
-                break;
+                    break;
 
                 default:
-                break;
+                    break;
             }
         }
     }
 
     handleChange(event, source, target) {
-        if(this.props.onChange) {
+        if (this.props.onChange) {
             this.props.onChange({
                 event: event.originalEvent,
                 source,
@@ -137,45 +137,45 @@ export class PickList extends Component {
     onTransfer(event) {
         const { originalEvent, source, target, direction } = event;
 
-        switch(direction) {
+        switch (direction) {
             case 'toTarget':
-                if(this.props.onMoveToTarget) {
+                if (this.props.onMoveToTarget) {
                     this.props.onMoveToTarget({
                         originalEvent,
                         value: this.getSourceSelection()
                     })
                 }
-            break;
+                break;
 
             case 'allToTarget':
-                if(this.props.onMoveAllToTarget) {
+                if (this.props.onMoveAllToTarget) {
                     this.props.onMoveAllToTarget({
                         originalEvent,
                         value: this.props.source
                     })
                 }
-            break;
+                break;
 
             case 'toSource':
-                if(this.props.onMoveToSource) {
+                if (this.props.onMoveToSource) {
                     this.props.onMoveToSource({
                         originalEvent,
                         value: this.getTargetSelection()
                     })
                 }
-            break;
+                break;
 
             case 'allToSource':
-                if(this.props.onMoveAllToSource) {
+                if (this.props.onMoveAllToSource) {
                     this.props.onMoveAllToSource({
                         originalEvent,
                         value: this.props.target
                     })
                 }
-            break;
+                break;
 
             default:
-            break;
+                break;
         }
 
         this.onSelectionChange({ originalEvent, value: [] }, 'sourceSelection', this.props.onSourceSelectionChange);
@@ -193,12 +193,19 @@ export class PickList extends Component {
             callback(e);
         }
         else {
-            this.setState({[stateKey]: e.value});
+            this.setState({ [stateKey]: e.value });
+        }
+
+        if (this.state.sourceSelection.length && stateKey === 'targetSelection') {
+            this.setState({ sourceSelection: [] })
+        }
+        else if (this.state.targetSelection.length && stateKey === 'sourceSelection') {
+            this.setState({ targetSelection: [] })
         }
     }
 
     componentDidUpdate() {
-        if(this.reorderedListElement) {
+        if (this.reorderedListElement) {
             this.handleScrollPosition(this.reorderedListElement, this.reorderDirection);
             this.reorderedListElement = null;
             this.reorderDirection = null;
@@ -213,19 +220,19 @@ export class PickList extends Component {
         return (
             <div id={this.props.id} className={className} style={this.props.style}>
                 {this.props.showSourceControls && <PickListControls list={this.props.source} selection={sourceSelection}
-                            onReorder={this.onSourceReorder} className="p-picklist-source-controls" />}
+                    onReorder={this.onSourceReorder} className="p-picklist-source-controls" />}
 
                 <PickListSubList ref={(el) => this.sourceListElement = el} list={this.props.source} selection={sourceSelection} onSelectionChange={(e) => this.onSelectionChange(e, 'sourceSelection', this.props.onSourceSelectionChange)} itemTemplate={this.props.itemTemplate}
-                    header={this.props.sourceHeader} style={this.props.sourceStyle} className="p-picklist-source-wrapper" listClassName="p-picklist-source" metaKeySelection={this.props.metaKeySelection} tabIndex={this.props.tabIndex}/>
+                    header={this.props.sourceHeader} style={this.props.sourceStyle} className="p-picklist-source-wrapper" listClassName="p-picklist-source" metaKeySelection={this.props.metaKeySelection} tabIndex={this.props.tabIndex} />
 
                 <PickListTransferControls onTransfer={this.onTransfer} source={this.props.source} target={this.props.target}
                     sourceSelection={sourceSelection} targetSelection={targetSelection} />
 
-                <PickListSubList ref={(el) => this.targetListElement = el} list={this.props.target} selection={targetSelection} onSelectionChange={(e) => this.onSelectionChange(e, 'targetSelection', this.props.onTargetSelectionChange)}  itemTemplate={this.props.itemTemplate}
-                    header={this.props.targetHeader} style={this.props.targetStyle} className="p-picklist-target-wrapper" listClassName="p-picklist-target" metaKeySelection={this.props.metaKeySelection} tabIndex={this.props.tabIndex}/>
+                <PickListSubList ref={(el) => this.targetListElement = el} list={this.props.target} selection={targetSelection} onSelectionChange={(e) => this.onSelectionChange(e, 'targetSelection', this.props.onTargetSelectionChange)} itemTemplate={this.props.itemTemplate}
+                    header={this.props.targetHeader} style={this.props.targetStyle} className="p-picklist-target-wrapper" listClassName="p-picklist-target" metaKeySelection={this.props.metaKeySelection} tabIndex={this.props.tabIndex} />
 
                 {this.props.showTargetControls && <PickListControls list={this.props.target} selection={targetSelection}
-                            onReorder={this.onTargetReorder} className="p-picklist-target-controls" />}
+                    onReorder={this.onTargetReorder} className="p-picklist-target-controls" />}
 
             </div>
         );

--- a/src/components/picklist/PickListControls.js
+++ b/src/components/picklist/PickListControls.js
@@ -1,6 +1,6 @@
-import React, {Component} from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types';
-import {Button} from '../button/Button';
+import { Button } from '../button/Button';
 import { classNames } from '../utils/ClassNames';
 import ObjectUtils from '../utils/ObjectUtils';
 
@@ -31,14 +31,14 @@ export class PickListControls extends Component {
     moveUp(event) {
         let selectedItems = this.props.selection;
 
-        if(selectedItems && selectedItems.length) {
+        if (selectedItems && selectedItems.length) {
             let list = [...this.props.list];
 
-            for(let i = 0; i < selectedItems.length; i++) {
+            for (let i = 0; i < selectedItems.length; i++) {
                 let selectedItem = selectedItems[i];
                 let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, list);
 
-                if(selectedItemIndex !== 0) {
+                if (selectedItemIndex !== 0) {
                     let movedItem = list[selectedItemIndex];
                     let temp = list[selectedItemIndex - 1];
                     list[selectedItemIndex - 1] = movedItem;
@@ -49,7 +49,7 @@ export class PickListControls extends Component {
                 }
             }
 
-            if(this.props.onReorder) {
+            if (this.props.onReorder) {
                 this.props.onReorder({
                     originalEvent: event,
                     value: list,
@@ -62,15 +62,15 @@ export class PickListControls extends Component {
     moveTop(event) {
         let selectedItems = this.props.selection;
 
-        if(selectedItems && selectedItems.length) {
+        if (selectedItems && selectedItems.length) {
             let list = [...this.props.list];
 
-            for(let i = 0; i < selectedItems.length; i++) {
+            for (let i = 0; i < selectedItems.length; i++) {
                 let selectedItem = selectedItems[i];
                 let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, list);
 
-                if(selectedItemIndex !== 0) {
-                    let movedItem = list.splice(selectedItemIndex,1)[0];
+                if (selectedItemIndex !== 0) {
+                    let movedItem = list.splice(selectedItemIndex, 1)[0];
                     list.unshift(movedItem);
                 }
                 else {
@@ -78,7 +78,7 @@ export class PickListControls extends Component {
                 }
             }
 
-            if(this.props.onReorder) {
+            if (this.props.onReorder) {
                 this.props.onReorder({
                     originalEvent: event,
                     value: list,
@@ -91,17 +91,17 @@ export class PickListControls extends Component {
     moveDown(event) {
         let selectedItems = this.props.selection;
 
-        if(selectedItems && selectedItems.length) {
+        if (selectedItems && selectedItems.length) {
             let list = [...this.props.list];
 
-            for(let i = selectedItems.length - 1; i >= 0; i--) {
+            for (let i = selectedItems.length - 1; i >= 0; i--) {
                 let selectedItem = selectedItems[i];
                 let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, list);
 
-                if(selectedItemIndex !== (list.length - 1)) {
+                if (selectedItemIndex !== (list.length - 1)) {
                     let movedItem = list[selectedItemIndex];
-                    let temp = list[selectedItemIndex+1];
-                    list[selectedItemIndex+1] = movedItem;
+                    let temp = list[selectedItemIndex + 1];
+                    list[selectedItemIndex + 1] = movedItem;
                     list[selectedItemIndex] = temp;
                 }
                 else {
@@ -109,7 +109,7 @@ export class PickListControls extends Component {
                 }
             }
 
-            if(this.props.onReorder) {
+            if (this.props.onReorder) {
                 this.props.onReorder({
                     originalEvent: event,
                     value: list,
@@ -124,15 +124,15 @@ export class PickListControls extends Component {
     moveBottom(event) {
         let selectedItems = this.props.selection;
 
-        if(selectedItems && selectedItems.length) {
+        if (selectedItems && selectedItems.length) {
             let list = [...this.props.list];
 
-            for(let i = selectedItems.length - 1; i >= 0; i--) {
+            for (let i = selectedItems.length - 1; i >= 0; i--) {
                 let selectedItem = selectedItems[i];
                 let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, list);
 
-                if(selectedItemIndex !== (list.length - 1)) {
-                    let movedItem = list.splice(selectedItemIndex,1)[0];
+                if (selectedItemIndex !== (list.length - 1)) {
+                    let movedItem = list.splice(selectedItemIndex, 1)[0];
                     list.push(movedItem);
                 }
                 else {
@@ -140,7 +140,7 @@ export class PickListControls extends Component {
                 }
             }
 
-            if(this.props.onReorder) {
+            if (this.props.onReorder) {
                 this.props.onReorder({
                     originalEvent: event,
                     value: list,
@@ -151,13 +151,14 @@ export class PickListControls extends Component {
     }
 
     render() {
+        let moveDisabled = !this.props.selection.length;
         let className = classNames('p-picklist-buttons', this.props.className);
 
         return <div className={className}>
-                    <Button type="button" icon="pi pi-angle-up" onClick={this.moveUp}></Button>
-                    <Button type="button" icon="pi pi-angle-double-up" onClick={this.moveTop}></Button>
-                    <Button type="button" icon="pi pi-angle-down" onClick={this.moveDown}></Button>
-                    <Button type="button" icon="pi pi-angle-double-down" onClick={this.moveBottom}></Button>
-                </div>;
+            <Button disabled={moveDisabled} type="button" icon="pi pi-angle-up" onClick={this.moveUp}></Button>
+            <Button disabled={moveDisabled} type="button" icon="pi pi-angle-double-up" onClick={this.moveTop}></Button>
+            <Button disabled={moveDisabled} type="button" icon="pi pi-angle-down" onClick={this.moveDown}></Button>
+            <Button disabled={moveDisabled} type="button" icon="pi pi-angle-double-down" onClick={this.moveBottom}></Button>
+        </div>;
     }
 }

--- a/src/components/picklist/PickListTransferControls.js
+++ b/src/components/picklist/PickListTransferControls.js
@@ -114,13 +114,17 @@ export class PickListTransferControls extends Component {
         }
     }
 
+
+
     render() {
+        let moveRightDisabled = !this.props.sourceSelection.length;
+        let moveLeftDisabled = !this.props.targetSelection.length;
         let className = classNames('p-picklist-buttons p-picklist-transfer-buttons', this.props.className);
 
         return <div className={className}>
-                    <Button type="button" icon="pi pi-angle-right" onClick={this.moveRight}></Button>
+                    <Button disabled={moveRightDisabled} type="button" icon="pi pi-angle-right" onClick={this.moveRight}></Button>
                     <Button type="button" icon="pi pi-angle-double-right" onClick={this.moveAllRight}></Button>
-                    <Button type="button" icon="pi pi-angle-left" onClick={this.moveLeft}></Button>
+                    <Button disabled={moveLeftDisabled} type="button" icon="pi pi-angle-left" onClick={this.moveLeft}></Button>
                     <Button type="button" icon="pi pi-angle-double-left" onClick={this.moveAllLeft}></Button>
                 </div>;
     }


### PR DESCRIPTION
PickList transfer buttons are disabled when no item is selected.
When any item is selected on any side the selected item on the other side become unselected.