### PR TITLE
CalendarProps  value type  undefined et null

### DIFF
--- a/src/components/calendar/Calendar.d.ts
+++ b/src/components/calendar/Calendar.d.ts
@@ -40,7 +40,7 @@ export interface CalendarProps {
     id?: string;
     inputRef?: React.Ref<HTMLInputElement>;
     name?: string;
-    value?: Date | Date[];
+    value?: Date | Date[]|undefined | null;;
     viewDate?: Date;
     style?: object;
     className?: string;


### PR DESCRIPTION
i propose to change the value type of the calendar Props interface  to  avoid this Error 
verload 1 of 2, '(props: CalendarProps | Readonly<CalendarProps>): Calendar', gave the following error.
    Type 'Date | Date[] | null | undefined' is not assignable to type 'Date | Date[] | undefined'.
  Overload 2 of 2, '(props: CalendarProps, context: any): Calendar', gave the following error.
    Type 'Date | Date[] | null | undefined' is not assignable to type 'Date | Date[] | undefined'

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.