### PR TITLE
calendar component  type null issue

### DIFF
--- a/src/components/calendar/Calendar.d.ts
+++ b/src/components/calendar/Calendar.d.ts
@@ -11,7 +11,7 @@ interface CalendarChangeTargetOptions {
 
 interface CalendarChangeParams {
     originalEvent: React.SyntheticEvent;
-    value: Date | Date[] | undefined | null;
+    value: Date | Date[] | undefined;
     stopPropagation(): void;
     preventDefault(): void;
     target: CalendarChangeTargetOptions;


### PR DESCRIPTION
 I m following this demo    [https://codesandbox.io/s/hejhs?file=/src/demo/CalendarDemo.tsx:2121-2154](url)   which contains some errors  in all    setDate hooks  like this one  setDate8(e.value) 

 here is the error description 

 CalendarChangeParams.value: Date | Date[] | null | undefined
Argument of type 'Date | Date[] | null | undefined' is not assignable to parameter of type 'SetStateAction<Date | Date[] | undefined>'.
  Type 'null' is not assignable to type 'SetStateAction<Date | Date[] | undefined>'.ts(2345)

when I check the declaration file of the calendar component I found that the interface CalendarChangeParams contains the value propriety which may have a null I tried to change this and I removed the null option it works fine so thank you,  for verifying this issue.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.