### PR TITLE
Added dynamic sub menu rendering capability to the slidemenu component

### DIFF
--- a/src/components/slidemenu/SlideMenu.js
+++ b/src/components/slidemenu/SlideMenu.js
@@ -18,7 +18,8 @@ export class SlideMenuSub extends Component {
         effectDuration: 250,
         menuWidth: 190,
         parentActive: false,
-        onForward: null
+        onForward: null,
+        dynamicRendering: false,
     }
 
     static propTypes = {
@@ -28,17 +29,19 @@ export class SlideMenuSub extends Component {
         effectDuration: PropTypes.number,
         menuWidth: PropTypes.number,
         parentActive: PropTypes.bool,
-        onForward: PropTypes.func
+        onForward: PropTypes.func,
+        dynamicRendering: PropTypes.bool,
     }
 
     constructor(props) {
         super(props);
         this.state = {
-            activeItem: null
+            activeItem: null,
+            renderSubMenu: {},
         };
     }
 
-    onItemClick(event, item) {
+    onItemClick(event, item, index) {
         if (item.disabled) {
             event.preventDefault();
             return;
@@ -56,7 +59,9 @@ export class SlideMenuSub extends Component {
         }
 
         if (item.items) {
+            let key = item.label + '_' + index
             this.setState({
+                renderSubMenu: { ...this.state.renderSubMenu, [key]: true },
                 activeItem: item
             });
             this.props.onForward();
@@ -69,11 +74,12 @@ export class SlideMenuSub extends Component {
         );
     }
 
-    renderSubmenu(item) {
-        if (item.items) {
+    renderSubmenu(item, index) {
+        let renderPermitted = !this.props.dynamicRendering || this.state.renderSubMenu[item.label + '_' + index]
+        if (item.items && renderPermitted) {
             return (
                 <SlideMenuSub model={item.items} index={this.props.index + 1} menuWidth={this.props.menuWidth} effectDuration={this.props.effectDuration}
-                    onForward={this.props.onForward} parentActive={item === this.state.activeItem} />
+                    onForward={this.props.onForward} parentActive={item === this.state.activeItem} dynamicRendering={this.props.dynamicRendering} />
             );
         }
 
@@ -88,7 +94,7 @@ export class SlideMenuSub extends Component {
         const icon = item.icon && <span className={iconClassName}></span>;
         const label = item.label && <span className="p-menuitem-text">{item.label}</span>;
         const submenuIcon = item.items && <span className={submenuIconClassName}></span>;
-        const submenu = this.renderSubmenu(item);
+        const submenu = this.renderSubmenu(item, index);
         let content = (
             <a href={item.url || '#'} className="p-menuitem-link" target={item.target} onClick={(event) => this.onItemClick(event, item, index)} aria-disabled={item.disabled}>
                 {icon}
@@ -175,7 +181,8 @@ export class SlideMenu extends Component {
         appendTo: null,
         transitionOptions: null,
         onShow: null,
-        onHide: null
+        onHide: null,
+        dynamicRendering: false
     }
 
     static propTypes = {
@@ -194,7 +201,8 @@ export class SlideMenu extends Component {
         appendTo: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
         transitionOptions: PropTypes.object,
         onShow: PropTypes.func,
-        onHide: PropTypes.func
+        onHide: PropTypes.func,
+        dynamicRendering: PropTypes.bool
     }
 
     constructor(props) {
@@ -392,7 +400,7 @@ export class SlideMenu extends Component {
                     <div className="p-slidemenu-wrapper" style={{ height: this.props.viewportHeight + 'px' }}>
                         <div className="p-slidemenu-content" ref={el => this.slideMenuContent = el}>
                             <SlideMenuSub model={this.props.model} root index={0} menuWidth={this.props.menuWidth} effectDuration={this.props.effectDuration}
-                                level={this.state.level} parentActive={this.state.level === 0} onForward={this.navigateForward} />
+                                level={this.state.level} parentActive={this.state.level === 0} onForward={this.navigateForward} dynamicRendering={this.props.dynamicRendering} />
                         </div>
                         {backward}
                     </div>

--- a/src/showcase/slidemenu/SlideMenuDoc.js
+++ b/src/showcase/slidemenu/SlideMenuDoc.js
@@ -494,11 +494,11 @@ const SlideMenuDemo = () => {
                 <TabView>
                     <TabPanel header="Documentation">
                         <h5>Import</h5>
-<CodeHighlight lang="js">
-{`
+                        <CodeHighlight lang="js">
+                            {`
 import { SlideMenu } from 'primereact/slidemenu';
 `}
-</CodeHighlight>
+                        </CodeHighlight>
 
                         <h5>MenuItem API</h5>
                         <p>Menu uses the common menumodel api to define its items, visit <Link to="/menumodel"> MenuModel API</Link> for details.</p>
@@ -506,8 +506,8 @@ import { SlideMenu } from 'primereact/slidemenu';
                         <h5>Getting Started</h5>
                         <p>Menu requires a collection of menuitems as its model.</p>
 
-<CodeHighlight lang="js">
-{`
+                        <CodeHighlight lang="js">
+                            {`
 const items = [
     {
        label:'File',
@@ -640,34 +640,34 @@ const items = [
     }
 ];
 `}
-</CodeHighlight>
+                        </CodeHighlight>
 
-<CodeHighlight>
-{`
+                        <CodeHighlight>
+                            {`
 <SlideMenu model={items} />
 `}
-</CodeHighlight>
+                        </CodeHighlight>
 
 
                         <h5>Popup Mode</h5>
                         <p>SlideMenu is inline by default whereas popup mode is supported by enabling popup property and calling toggle method with an event of the target.</p>
-<CodeHighlight>
-{`
+                        <CodeHighlight>
+                            {`
 <SlideMenu ref={menu} model={items} popup />
 
 <Button type="button" icon="pi pi-bars" label="Show" onClick={(event) => menu.current.toggle(event)}></Button>
 `}
-</CodeHighlight>
+                        </CodeHighlight>
 
                         <h5>Effects</h5>
                         <p>The easing function to use is "ease-out" by default which can be customized using easing property.
                             See <a href="http://www.w3schools.com/cssref/css3_pr_transition-timing-function.asp">here</a> for possible alternative values.</p>
 
-<CodeHighlight>
-{`
+                        <CodeHighlight>
+                            {`
 <SlideMenu model={items} effectDuration={1000} easing="ease-in" />
 `}
-</CodeHighlight>
+                        </CodeHighlight>
 
                         <h5>Properties</h5>
                         <div className="doc-tablewrapper">
@@ -698,6 +698,12 @@ const items = [
                                         <td>boolean</td>
                                         <td>false</td>
                                         <td>Defines if menu would displayed as a popup.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>dynamicRendering</td>
+                                        <td>boolean</td>
+                                        <td>false</td>
+                                        <td>If dynamicRendering is True, submenu components rendered only when the parent menu item is clicked. Prefer this if the model is too long to render at once.</td>
                                     </tr>
                                     <tr>
                                         <td>style</td>
@@ -769,7 +775,7 @@ const items = [
                             </table>
                         </div>
 
-                       <h5>Methods</h5>
+                        <h5>Methods</h5>
                         <div className="doc-tablewrapper">
                             <table className="doc-table">
                                 <thead>
@@ -829,10 +835,10 @@ const items = [
                         <div className="doc-tablewrapper">
                             <table className="doc-table">
                                 <thead>
-                                <tr>
-                                    <th>Name</th>
-                                    <th>Element</th>
-                                </tr>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th>Element</th>
+                                    </tr>
                                 </thead>
                                 <tbody>
                                     <tr>


### PR DESCRIPTION
First of all, thank you for developing this great project! 

As I mentioned in [here](https://github.com/primefaces/primereact/issues/2060), rendering SlideMenu component becomes cumbersome when the size of the menu item is too large. For this reason, I've added dynamic rendering capability to the SlideMenuSub component. With the help of this, the sub menu will be rendered only when the parent menu item is clicked. I've also updated the related doc. 

I've tested this new feature manually and integrated it into my website. It works pretty well. Let me know if I missed anything.