### PR TITLE
fixed condition used to determine size of splitter container

### DIFF
--- a/src/components/splitter/Splitter.js
+++ b/src/components/splitter/Splitter.js
@@ -135,7 +135,7 @@ export class Splitter extends Component {
 
     onResizeStart(event, index) {
         this.gutterElement = event.currentTarget;
-        this.size = this.horizontal ? DomHandler.getWidth(this.container) : DomHandler.getHeight(this.container);
+        this.size = this.props.layout === 'horizontal' ? DomHandler.getWidth(this.container) : DomHandler.getHeight(this.container);
         this.dragging = true;
         this.startPos = this.props.layout === 'horizontal' ? event.pageX : event.pageY;
         this.prevPanelElement = this.gutterElement.previousElementSibling;


### PR DESCRIPTION
###Defect Fixes
Fixes #2067 

There is a small bug in the Splitter code. The splitter always computes the size of the panel based on the height of the container due to the use of a undefined variable for conditional check. 

This PR adds the proper variable for conditional check and fixes the issue.