### PR TITLE
fix (Datatable): Set the emptyMessage default 'No records found' instead of null fixes #2094

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -43,7 +43,7 @@ export class DataTable extends Component {
         sortMode: 'single',
         defaultSortOrder: 1,
         removableSort: false,
-        emptyMessage: null,
+        emptyMessage: 'No records found',
         selectionMode: null,
         dragSelection: false,
         cellSelection: false,


### PR DESCRIPTION
###Defect Fixes
#2094 