### PR TITLE
Update MultiSelect.js

### DIFF
--- a/src/components/multiselect/MultiSelect.js
+++ b/src/components/multiselect/MultiSelect.js
@@ -652,7 +652,7 @@ export class MultiSelect extends Component {
     }
 
     hasFilter() {
-        return this.state.filter && this.state.filter.trim().length > 0;
+        return this.state && this.state.filter && this.state.filter.trim().length > 0;
     }
 
     isAllSelected() {


### PR DESCRIPTION
Getting exception

TypeError: Cannot read property 'filter' of undefined
    at Object.value [as hasFilter] (MultiSelect.js:720)
    at i.value (MultiSelectPanel.js:208)
    at i.value (MultiSelectPanel.js:247)
    at i.value (MultiSelectPanel.js:267)
    at i.value (MultiSelectPanel.js:293)
    at Ha (react-dom.production.min.js:187)
    at Ua (react-dom.production.min.js:186)
    at Hl (react-dom.production.min.js:269)
    at ku (react-dom.production.min.js:250)
    at _u (react-dom.production.min.js:250)

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.