### PR TITLE
Fix #2045

### DIFF
--- a/src/components/colorpicker/ColorPicker.d.ts
+++ b/src/components/colorpicker/ColorPicker.d.ts
@@ -9,11 +9,11 @@ type ColorPickerFormatType = 'hex' | 'rgb' | 'hsb';
 interface ColorPickerChangeTargetOptions {
     name: string;
     id: string;
-    value: string;
+    value: ColorPickerProps['value'];
 }
 
 interface ColorPickerChangeParams {
-    value: string;
+    value: ColorPickerProps['value'];
     stopPropagation(): void;
     preventDefault(): void;
     target: ColorPickerChangeTargetOptions;


### PR DESCRIPTION
#2045
Fixed the issue where values are string in default, whereas now they attain their values from ColorPickerProps' value property.