### PR TITLE
Fixed DataScroller initial render fail issue

### DIFF
--- a/src/components/datascroller/DataScroller.js
+++ b/src/components/datascroller/DataScroller.js
@@ -76,7 +76,9 @@ export class DataScroller extends Component {
                     this.dataToRender.push(this.value[i]);
                 }
 
-                this.first = this.first + this.props.rows;
+                if (this.value.length !== 0) {
+                    this.first = this.first + this.props.rows;
+                }
                 this.setState({ dataToRender: this.dataToRender });
             }
         }


### PR DESCRIPTION
**Issues fixed:**
#2155 and #1902

**Explanation:**
Without the following conditional check, first N items fail to display (N = rows). With this if clause, all items render succesfully and independent from any delays/calls.