### PR TITLE
fix name types to slidemenu

### DIFF
--- a/src/components/slidemenu/package.json
+++ b/src/components/slidemenu/package.json
@@ -2,5 +2,5 @@
     "main": "./slidemenu.cjs.js",
     "module": "./slidemenu.esm.js",
     "unpkg": "./slidemenu.min.js",
-    "types": "./slideMenu.d.ts"
+    "types": "./slidemenu.d.ts"
 }


### PR DESCRIPTION
this bug there is a problem in the slidemenu type, the import is breaking the component's usage
