### PR TITLE
Fix #2167

### DIFF
--- a/src/components/dropdown/Dropdown.css
+++ b/src/components/dropdown/Dropdown.css
@@ -87,3 +87,7 @@ input.p-dropdown-label  {
 .p-fluid .p-dropdown .p-dropdown-label {
     width: 1%;
 }
+
+html[dir='rtl'] .p-dropdown-clear-icon {
+    margin-right: 8rem;
+}


### PR DESCRIPTION
I know the will be a RTL support update soon, but since dropdown is a frequently-utilized component, I wanted to provide a local solution to the issue #2167. This fix will place the X icon to the left of the dropdown item, for proper visuality.
