### PR TITLE
Fix #2168

### DIFF
--- a/src/components/panelmenu/PanelMenu.css
+++ b/src/components/panelmenu/PanelMenu.css
@@ -28,3 +28,7 @@
 .p-panelmenu .p-menuitem-text {
     line-height: 1;
 }
+
+html[dir='rtl'] .p-panelmenu-icon {
+    transform: scaleX(-1);
+}


### PR DESCRIPTION
Follow-up to my previous pull request. Fixed the direction of the arrow icon by making it correspond to the page direction. Until the RTL support update, this seems to provide a temporary solution to #2168.