### PR TITLE
Fix File Upload Deleting Emails

### DIFF
--- a/src/components/fileupload/FileUpload.js
+++ b/src/components/fileupload/FileUpload.js
@@ -399,6 +399,7 @@ export class FileUpload extends Component {
 
     onDragEnter(event) {
         if (!this.props.disabled) {
+            event.dataTransfer.dropEffect = "copy";
             event.stopPropagation();
             event.preventDefault();
         }
@@ -406,6 +407,7 @@ export class FileUpload extends Component {
 
     onDragOver(event) {
         if (!this.props.disabled) {
+            event.dataTransfer.dropEffect = "copy";
             DomHandler.addClass(this.content, 'p-fileupload-highlight');
             event.stopPropagation();
             event.preventDefault();
@@ -414,6 +416,7 @@ export class FileUpload extends Component {
 
     onDragLeave(event) {
         if (!this.props.disabled) {
+            event.dataTransfer.dropEffect = "copy";
             DomHandler.removeClass(this.content, 'p-fileupload-highlight');
         }
     }


### PR DESCRIPTION
###Defect Fixes
[See here for issue submitted to the forum last year.](https://forum.primefaces.org/viewtopic.php?t=64337)
When dragging and dropping an email into the file upload component it sends the email to the deleted folder.
The fix is simple and detailed in the same forum post, I've just implemented it and submitted a PR.