### PR TITLE
Add missing Menu methods to type declaration

### DIFF
--- a/src/components/menu/Menu.d.ts
+++ b/src/components/menu/Menu.d.ts
@@ -19,4 +19,6 @@ export interface MenuProps {
 
 export declare class Menu extends React.Component<MenuProps, any> {
     public toggle(event: React.SyntheticEvent): void;
+    public show(event: React.SyntheticEvent): void;
+    public hide(event: React.SyntheticEvent): void;
 }


### PR DESCRIPTION
The `show` and `hide` methods are documented in https://www.primefaces.org/primereact/showcase/#/menu but were missing from the declared `Menu` class.

### Defect Fixes

Tracking issue: https://github.com/primefaces/primereact/issues/2295
