### PR TITLE
Fix #2346: Yarn package.json correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
     "sass": "^1.32.8",
     "xlsx": "^0.15.1"
   },
+  "peerDependencies": {
+    "react-transition-group": "^4.4.1"
+  },
+  "peerDependenciesMeta": {
+    "react-transition-group": {
+      "optional": true
+    }
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
Fixed #2346 When using Yarn PnP with e.g. webpack it results in an error because primereact attempts to import react-transition-group, but does not declare it in its dependencies. Yarn PnP requires that a package explicitly declares all packages it uses.