### PR TITLE
Fix #2349: Dropdown do not consider 0 a falsy value for options

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -921,7 +921,7 @@ export class Dropdown extends Component {
     }
 
     renderLabel(selectedOption) {
-        const label = selectedOption ? this.getOptionLabel(selectedOption) : null;
+        const label = ObjectUtils.isNotEmpty(selectedOption) ? this.getOptionLabel(selectedOption) : null;
 
         if (this.props.editable) {
             let value = label || this.props.value || '';


### PR DESCRIPTION
###Defect Fixes
Fix #2349 considers primitive 0 a valid value and not a falsy one.  All other falsy values like `""` will continue to be falsy