### PR TITLE
fix: don't always add p-splitter-panel-nested class

### DIFF
--- a/src/components/splitter/Splitter.js
+++ b/src/components/splitter/Splitter.js
@@ -215,7 +215,7 @@ export class Splitter extends Component {
 
     componentDidMount() {
         if (this.panelElement) {
-            if (this.panelElement.childNodes && DomHandler.find(this.panelElement, '.p-splitter')) {
+            if (this.panelElement.childNodes && DomHandler.find(this.panelElement, '.p-splitter').length) {
                 DomHandler.addClass(this.panelElement, 'p-splitter-panel-nested');
             }
         }


### PR DESCRIPTION
p-splitter-panel-nested class is always added no matter whether the panel element contains children with 'p-splitter' or not.
[DomHandler.find](https://github.com/primefaces/primereact/blob/e9137c63eaa44a3e1037c5775b0645a4a5e2a2b6/src/components/utils/DomHandler.js#L194) always returns an array.