### PR TITLE
Fix Tooltip positioning issue with SVG targets

### DIFF
--- a/src/components/utils/DomHandler.js
+++ b/src/components/utils/DomHandler.js
@@ -34,7 +34,7 @@ export default class DomHandler {
 
     static getOuterWidth(el, margin) {
         if (el) {
-            let width = el.offsetWidth;
+            let width = el.offsetWidth ?? el.getBoundingClientRect().width;
 
             if (margin) {
                 let style = getComputedStyle(el);
@@ -48,7 +48,7 @@ export default class DomHandler {
 
     static getOuterHeight(el, margin) {
         if (el) {
-            let height = el.offsetHeight;
+            let height = el.offsetHeight ?? el.getBoundingClientRect().height;
 
             if (margin) {
                 let style = getComputedStyle(el);


### PR DESCRIPTION
### Defect Fixes
Addresses https://github.com/primefaces/primereact/issues/2406.

The issue was that if the target of a global tooltip was an SVG, the tooltip would not be positioned next to the target when triggered (it will often appear offscreen). The source of the problem was that `DomHandler.getOuterWidth` and `DomHandler.getOuterHeight` rely on `Element.offsetWidth` to get the target element's width. This works for HTMLElement instances but not SVGElement instances.

My PR uses `Element.getBoundingClientRect` to get the target element's width when `Element.offsetWidth` is undefined.
