### PR TITLE
Fix #2412: BlockUI NPE with 0s animation as mask might not be created

### DIFF
--- a/src/components/blockui/BlockUI.js
+++ b/src/components/blockui/BlockUI.js
@@ -49,6 +49,14 @@ export class BlockUI extends Component {
     }
 
     unblock() {
+        if (!this.mask) {
+           this.setState({ visible: false }, () => {
+                this.props.fullScreen && DomHandler.removeClass(document.body, 'p-overflow-hidden');
+                this.props.onUnblocked && this.props.onUnblocked();
+            });
+           return;
+        }
+
         DomHandler.addClass(this.mask, 'p-component-overlay-leave');
         this.mask.addEventListener('animationend', () => {
             ZIndexUtils.clear(this.mask);


### PR DESCRIPTION
###Defect Fixes
Fix #2412: BlockUI NPE with 0s animation as mask might not be created

Because the `this.mask` is dynamically created its possible that it does not exist yet when `unblock()`is called. So we must defend against it being NULL and still mark the blockUI as finished.