### PR TITLE
Fix #2221: ToolTipOptions missing disabled property

### DIFF
--- a/src/components/tooltip/Tooltip.d.ts
+++ b/src/components/tooltip/Tooltip.d.ts
@@ -7,7 +7,6 @@ export interface TooltipProps extends TooltipOptions {
     id?: string;
     target?: TooltipTargetType;
     content?: string;
-    disabled?: boolean;
 }
 
 export declare class Tooltip extends React.Component<TooltipProps, any> {

--- a/src/components/tooltip/TooltipOptions.d.ts
+++ b/src/components/tooltip/TooltipOptions.d.ts
@@ -30,6 +30,7 @@ export default interface TooltipOptions {
     updateDelay?: number;
     hideDelay?: number;
     autoHide?: boolean;
+    disabled?: boolean;
     onBeforeShow?(e: TooltipEventParams): void;
     onBeforeHide?(e: TooltipEventParams): void;
     onShow?(e: TooltipEventParams): void;


### PR DESCRIPTION
###Defect Fixes
Fix #2221: ToolTipOptions missing disabled property

This property was incorrectly on `TooltipProps` which extended `ToolTipOptions`.  But the base property should have been declared on `ToolTipOptions `