### PR TITLE
Fix #2422: Dropdown do not close on scroll in mobile

### DIFF
--- a/src/components/dropdown/Dropdown.js
+++ b/src/components/dropdown/Dropdown.js
@@ -694,7 +694,7 @@ export class Dropdown extends Component {
     bindScrollListener() {
         if (!this.scrollHandler) {
             this.scrollHandler = new ConnectedOverlayScrollHandler(this.container, () => {
-                if (this.state.overlayVisible) {
+                if (this.state.overlayVisible && !DomHandler.isTouchDevice()) {
                     this.hideOverlay();
                 }
             });


### PR DESCRIPTION
###Defect Fixes
Fix #2422: Dropdown do not close on scroll in mobile

Exactly like this PrimeFaces issue: https://github.com/primefaces/primefaces/issues/7075

What happens in the displaying of the keyboard on some mobile devices causes a "scroll" event to be fired and it closes the dropdown