### PR TITLE
Fix #2429: ConfirmDialog Typescript remove double semicolon

### DIFF
--- a/src/components/confirmdialog/ConfirmDialog.d.ts
+++ b/src/components/confirmdialog/ConfirmDialog.d.ts
@@ -28,8 +28,8 @@ export interface ConfirmDialogProps extends Omit<DialogProps, 'onHide'> {
     rejectLabel?: string;
     acceptLabel?: string;
     icon?: IconType<ConfirmDialogProps>;
-    rejectIcon?: IconType<ConfirmDialogProps>;;
-    acceptIcon?: IconType<ConfirmDialogProps>;;
+    rejectIcon?: IconType<ConfirmDialogProps>;
+    acceptIcon?: IconType<ConfirmDialogProps>;
     rejectClassName?: string;
     acceptClassName?: string;
     appendTo?: ConfirmDialogAppendToType;


### PR DESCRIPTION
###Defect Fixes
Fix #2429: ConfirmDialog Typescript remove double semicolon
