### PR TITLE
Fix #2045: Colorpicker TypeScript definition for value

### DIFF
--- a/src/components/colorpicker/ColorPicker.d.ts
+++ b/src/components/colorpicker/ColorPicker.d.ts
@@ -9,11 +9,11 @@ type ColorPickerFormatType = 'hex' | 'rgb' | 'hsb';
 interface ColorPickerChangeTargetOptions {
     name: string;
     id: string;
-    value: string;
+    value: any;
 }
 
 interface ColorPickerChangeParams {
-    value: string;
+    value: any;
     stopPropagation(): void;
     preventDefault(): void;
     target: ColorPickerChangeTargetOptions;


### PR DESCRIPTION
###Defect Fixes
Fix #2045: Colorpicker TypeScript definition for value