### PR TITLE
Fix #2445: Typescript Autocomplete add search method

### DIFF
--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -12,6 +12,8 @@ type AutoCompleteSelectedItemTemplateType = React.ReactNode | ((value: any) => R
 
 type AutoCompleteAppendToType = 'self' | HTMLElement | undefined | null;
 
+type AutoCompleteSourceType = 'dropdown' | 'input';
+
 interface AutoCompleteChangeTargetOptions {
     name: string;
     id: string;
@@ -104,4 +106,6 @@ export interface AutoCompleteProps {
     onHide?(): void;
 }
 
-export declare class AutoComplete extends React.Component<AutoCompleteProps, any> { }
+export declare class AutoComplete extends React.Component<AutoCompleteProps, any> { 
+    public search(event:React.SyntheticEvent, query:string, source: AutoCompleteSourceType): void;
+}


### PR DESCRIPTION
###Defect Fixes
Fix #2445: Autocomplete add search method to Typescript def.

AS from the ticket the user had a use case where they wanted to dynamically call Search from code.