### PR TITLE
Fix #1567:Editor showHeader attribute to be able to hide the toolbar

### DIFF
--- a/src/components/editor/Editor.d.ts
+++ b/src/components/editor/Editor.d.ts
@@ -23,6 +23,7 @@ export interface EditorProps {
     modules?: any;
     formats?: string[];
     theme?: string;
+    showHeader?: boolean;
     headerTemplate?: React.ReactNode;
     onTextChange?(e: EditorTextChangeParams): void;
     onSelectionChange?(e: EditorSelectionChangeParams): void;

--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -14,6 +14,7 @@ export class Editor extends Component {
         modules: null,
         formats: null,
         theme: 'snow',
+        showHeader: true,
         headerTemplate: null,
         onTextChange: null,
         onSelectionChange: null,
@@ -30,6 +31,7 @@ export class Editor extends Component {
         modules: PropTypes.object,
         formats: PropTypes.array,
         theme: PropTypes.string,
+        showHeader: PropTypes.bool,
         headerTemplate: PropTypes.any,
         onTextChange: PropTypes.func,
         onSelectionChange: PropTypes.func,
@@ -45,7 +47,7 @@ export class Editor extends Component {
             if (module && module.default && DomHandler.isExist(this.editorElement)) {
                 this.quill = new module.default(this.editorElement, {
                     modules: {
-                        toolbar: this.toolbarElement,
+                        toolbar: this.props.showHeader ? this.toolbarElement : false,
                         ...this.props.modules
                     },
                     placeholder: this.props.placeholder,
@@ -105,7 +107,11 @@ export class Editor extends Component {
         let containerClass = classNames('p-component p-editor-container', this.props.className);
         let toolbarHeader = null;
 
-        if (this.props.headerTemplate) {
+        if (this.props.showHeader === false) {
+            toolbarHeader = '';
+            this.toolbarElement = undefined;
+        }
+        else if (this.props.headerTemplate) {
             toolbarHeader = (
                 <div ref={(el) => this.toolbarElement = el} className="p-editor-toolbar">
                     {this.props.headerTemplate}

--- a/src/showcase/editor/EditorDoc.js
+++ b/src/showcase/editor/EditorDoc.js
@@ -281,6 +281,12 @@ const header = (
                                         <td>Whitelist of formats to display, see <a href="http://quilljs.com/docs/formats/">here</a> for available options.</td>
                                     </tr>
                                     <tr>
+                                        <td>showHeader</td>
+                                        <td>boolean</td>
+                                        <td>true</td>
+                                        <td>Whether to display the toolbar or hide it.</td>
+                                    </tr>
+                                    <tr>
                                         <td>headerTemplate</td>
                                         <td>any</td>
                                         <td>null</td>


### PR DESCRIPTION
###Defect Fixes
Fix #1567:Editor showHeader attribute to be able to hide the toolbar

Currently there was no way to disable the toolbar if you did not want one.