### PR TITLE
Fix utils.d.ts import in TreeNode.d.ts for case-sensitive file systems

### DIFF
--- a/src/components/accordion/Accordion.d.ts
+++ b/src/components/accordion/Accordion.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from '../utils/Utils';
+import { IconType } from '../utils/utils';
 
 type AccordionTabHeaderTemplateType = React.ReactNode | ((props: AccordionTabProps) => React.ReactNode);
 

--- a/src/components/autocomplete/AutoComplete.d.ts
+++ b/src/components/autocomplete/AutoComplete.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { VirtualScrollerProps } from '../virtualscroller';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from '../utils/Utils';
+import { IconType } from '../utils/utils';
 
 type AutoCompleteOptionGroupTemplateType = React.ReactNode | ((suggestion: any, index: number) => React.ReactNode);
 

--- a/src/components/avatar/Avatar.d.ts
+++ b/src/components/avatar/Avatar.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type AvatarSizeType = 'normal' | 'large' | 'xlarge';
 

--- a/src/components/button/Button.d.ts
+++ b/src/components/button/Button.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type ButtonPositionType = 'top' | 'bottom' | 'left' | 'right';
 

--- a/src/components/calendar/Calendar.d.ts
+++ b/src/components/calendar/Calendar.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from "../utils/Utils";
+import { IconType } from "../utils/utils";
 
 type CalendarAppendToType = 'self' | HTMLElement | undefined | null;
 

--- a/src/components/checkbox/Checkbox.d.ts
+++ b/src/components/checkbox/Checkbox.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 interface CheckboxChangeTargetOptions {
     type: 'checkbox';

--- a/src/components/chip/Chip.d.ts
+++ b/src/components/chip/Chip.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IconType, TemplateType} from "../utils/Utils";
+import {IconType, TemplateType} from "../utils/utils";
 
 export interface ChipProps {
     label?: string;

--- a/src/components/confirmdialog/ConfirmDialog.d.ts
+++ b/src/components/confirmdialog/ConfirmDialog.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DialogProps } from '../dialog';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type ConfirmDialogTemplateType = React.ReactNode | ((options: ConfirmDialogOptions) => React.ReactNode);
 

--- a/src/components/confirmpopup/ConfirmPopup.d.ts
+++ b/src/components/confirmpopup/ConfirmPopup.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from "../utils/Utils";
+import { IconType } from "../utils/utils";
 
 type ConfirmPopupTemplateType = React.ReactNode | ((options: ConfirmPopupOptions) => React.ReactNode);
 

--- a/src/components/fileupload/FileUpload.d.ts
+++ b/src/components/fileupload/FileUpload.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type FileUploadModeType = 'basic' | 'advanced';
 

--- a/src/components/multiselect/MultiSelect.d.ts
+++ b/src/components/multiselect/MultiSelect.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from '../utils/Utils';
+import { IconType } from '../utils/utils';
 import { VirtualScrollerProps } from '../virtualscroller';
 
 type MultiSelectOptionGroupTemplateType = React.ReactNode | ((option: any, index: number) => React.ReactNode);

--- a/src/components/multistatecheckbox/MultiStateCheckbox.d.ts
+++ b/src/components/multistatecheckbox/MultiStateCheckbox.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type MultiStateCheckboxOptionsType = MultiStateCheckboxOption[] | any[];
 

--- a/src/components/scrolltop/ScrollTop.d.ts
+++ b/src/components/scrolltop/ScrollTop.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType } from '../utils/Utils';
+import { IconType } from '../utils/utils';
 
 type ScrollTopTargetType = 'window' | 'parent';
 

--- a/src/components/selectitem/SelectItem.d.ts
+++ b/src/components/selectitem/SelectItem.d.ts
@@ -1,4 +1,4 @@
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 export interface SelectItem {
     label?: string;

--- a/src/components/speeddial/SpeedDial.d.ts
+++ b/src/components/speeddial/SpeedDial.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MenuItem } from '../menuitem';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type SpeedDialDirectionType = 'up' | 'down' | 'left' | 'right' | 'up-left' | 'up-right' | 'down-left' | 'down-right';
 

--- a/src/components/splitbutton/SplitButton.d.ts
+++ b/src/components/splitbutton/SplitButton.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { MenuItem } from '../menuitem';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { CSSTransitionProps } from '../csstransition';
-import { IconType, TemplateType } from "../utils/Utils";
+import { IconType, TemplateType } from "../utils/utils";
 
 type SplitButtonAppendToType = 'self' | HTMLElement | undefined | null;
 

--- a/src/components/tag/Tag.d.ts
+++ b/src/components/tag/Tag.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type TagSeverityType = 'success' | 'info' | 'warn' | 'error' | (string & {});
 

--- a/src/components/togglebutton/ToggleButton.d.ts
+++ b/src/components/togglebutton/ToggleButton.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 type ToggleButtonIconPositionType = 'left' | 'right';
 

--- a/src/components/treenode/TreeNode.d.ts
+++ b/src/components/treenode/TreeNode.d.ts
@@ -1,4 +1,4 @@
-import {IconType} from "../utils/Utils";
+import {IconType} from "../utils/utils";
 
 export default interface TreeNode {
     key?: string | number;


### PR DESCRIPTION
- Closes https://github.com/primefaces/primereact/issues/2462

In my project I get errors for primereact v7: https://github.com/pixiebrix/pixiebrix-extension/pull/1913


```
node_modules/primereact/treenode/treenode.d.ts:1:24 - error TS2307: Cannot find module '../utils/Utils' or its corresponding type declarations.

1 import {IconType} from "../utils/Utils";
                         ~~~~~~~~~~~~~~~~


Found 1 error.
```

This is likely due to a mix of `skipLibTest: false` (which enables TS on `node_modules` and other `d.ts` files) and a case-sensitive file-system (which apparently GitHub Actions use)

This change fixes the issue I'm having