### PR TITLE
fix: avoid DOMException

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -1017,7 +1017,7 @@ export class DataTable extends Component {
 
     destroyResponsiveStyle() {
         if (this.responsiveStyleElement) {
-            if (this.responsiveStyleElement.parent) document.head.removeChild(this.responsiveStyleElement);
+            if (this.responsiveStyleElement.parentNode) document.head.removeChild(this.responsiveStyleElement);
             this.responsiveStyleElement = null;
         }
     }

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -1017,7 +1017,7 @@ export class DataTable extends Component {
 
     destroyResponsiveStyle() {
         if (this.responsiveStyleElement) {
-            document.head.removeChild(this.responsiveStyleElement);
+            if (this.responsiveStyleElement.parent) document.head.removeChild(this.responsiveStyleElement);
             this.responsiveStyleElement = null;
         }
     }


### PR DESCRIPTION
The below exception is thrown during react fast refresh:
DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
