### PR TITLE
Fix #2469: Remove inline styles and prevent DOM Exception

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -1016,17 +1016,11 @@ export class DataTable extends Component {
     }
 
     destroyResponsiveStyle() {
-        if (this.responsiveStyleElement) {
-            document.head.removeChild(this.responsiveStyleElement);
-            this.responsiveStyleElement = null;
-        }
+        this.responsiveStyleElement = DomHandler.removeInlineStyle(this.responsiveStyleElement);
     }
 
     destroyStyleElement() {
-        if (this.styleElement) {
-            document.head.removeChild(this.styleElement);
-            this.styleElement = null;
-        }
+        this.styleElement = DomHandler.removeInlineStyle(this.styleElement);
     }
 
     onPageChange(e) {

--- a/src/components/dialog/Dialog.js
+++ b/src/components/dialog/Dialog.js
@@ -553,10 +553,7 @@ export class Dialog extends Component {
     componentWillUnmount() {
         this.disableDocumentSettings();
 
-        if (this.styleElement) {
-            document.head.removeChild(this.styleElement);
-            this.styleElement = null;
-        }
+        this.styleElement = DomHandler.removeInlineStyle(this.styleElement);
 
         ZIndexUtils.clear(this.mask);
     }

--- a/src/components/overlaypanel/OverlayPanel.js
+++ b/src/components/overlaypanel/OverlayPanel.js
@@ -261,10 +261,7 @@ export class OverlayPanel extends Component {
             this.scrollHandler = null;
         }
 
-        if (this.styleElement) {
-            document.head.removeChild(this.styleElement);
-            this.styleElement = null;
-        }
+        this.styleElement = DomHandler.removeInlineStyle(this.styleElement);
 
         if (this.overlayEventListener) {
             OverlayService.off('overlay-click', this.overlayEventListener);

--- a/src/components/utils/DomHandler.js
+++ b/src/components/utils/DomHandler.js
@@ -881,4 +881,22 @@ export default class DomHandler {
         document.head.appendChild(styleElement);
         return styleElement;
     }
+
+    /**
+     * Remove a style element from the head and attempt to prevent DOM Exception on fast refresh.
+     *
+     * @see https://github.com/primefaces/primereact/issues/2469
+     * @param {HtmlStyleElement} styleElement the element to remove from head
+     */
+    static removeInlineStyle(styleElement) {
+        if (styleElement && styleElement.parentNode) {
+            try {
+                document.head.removeChild(styleElement);
+            } catch (error) {
+                // style element may have already been removed in a fast refresh
+            }
+            styleElement = null;
+        }
+        return styleElement;
+    }
 }


### PR DESCRIPTION
###Defect Fixes
Fix #2469: Remove inline styles and prevent DOM Exception

Similar to creating inline styles created a utility to remove inline styles and checks the `parentNode` so we don't get DOMException on fast refreshes.