### PR TITLE
[Doc]: InputTextarea component to receive row as number

### DIFF
--- a/src/showcase/formlayout/FormLayoutDoc.js
+++ b/src/showcase/formlayout/FormLayoutDoc.js
@@ -405,7 +405,7 @@ const FormLayoutDemo = () => {
                 </div>
                 <div className="p-field p-col-12">
                     <label htmlFor="address">Address</label>
-                    <InputTextarea id="address" type="text" rows="4" />
+                    <InputTextarea id="address" rows={4} />
                 </div>
                 <div className="p-field p-col-12 p-md-6">
                     <label htmlFor="city">City</label>
@@ -609,7 +609,7 @@ const FormLayoutDemo = () => {
                         </div>
                         <div className="p-field p-col-12">
                             <label htmlFor="address">Address</label>
-                            <InputTextarea id="address" type="text" rows="4" />
+                            <InputTextarea id="address" rows={4} />
                         </div>
                         <div className="p-field p-col-12 p-md-6">
                             <label htmlFor="city">City</label>
@@ -822,7 +822,7 @@ const FormLayoutDemo = () => {
                 </div>
                 <div className="p-field p-col-12">
                     <label htmlFor="address">Address</label>
-                    <InputTextarea id="address" type="text" rows="4" />
+                    <InputTextarea id="address" rows={4} />
                 </div>
                 <div className="p-field p-col-12 p-md-6">
                     <label htmlFor="city">City</label>
@@ -1057,7 +1057,7 @@ import 'primeflex/primeflex.css';
     </div>
     <div className="p-field p-col-12">
         <label htmlFor="address">Address</label>
-        <InputTextarea id="address" type="text" rows="4" />
+        <InputTextarea id="address" rows={4} />
     </div>
     <div className="p-field p-col-12 p-md-6">
         <label htmlFor="city">City</label>


### PR DESCRIPTION
Updated the documentation to show the props for InputTextarea to receive row as a number instead of string (errors out in typescript). Also removed type prop as its not a prop for InputTextarea

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.