### PR TITLE
Fix #2548: TreeNode typescript add expanded attribute

### DIFF
--- a/components/lib/treenode/TreeNode.d.ts
+++ b/components/lib/treenode/TreeNode.d.ts
@@ -12,4 +12,5 @@ export default interface TreeNode {
     draggable?: boolean;
     selectable?: boolean;
     leaf?: boolean;
+    expanded?: boolean;
 }


### PR DESCRIPTION
###Defect Fixes
Fix #2548: TreeNode typescript add expanded attribute

I am writing my own custom tree node filtering algorithm and I based it on the current file name based filtering algorithm in the tree component.

I noticed this code:

```typescript
            if (matched) {
                node.expanded = true;
                return true;
            }
```

But in TypeScript my code says that `expanded` is not a valid property of TreeNode.  