### PR TITLE
Fix #2594: DataTable: Responsive broken in 7.2.0

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1531,11 +1531,11 @@ export class DataTable extends Component {
     componentDidMount() {
         this.setState({ attributeSelector: UniqueComponentId() }, () => {
             this.el.setAttribute(this.state.attributeSelector, '');
-        });
 
-        if (this.props.responsiveLayout === 'stack' && !this.props.scrollable) {
-            this.createResponsiveStyle();
-        }
+            if (this.props.responsiveLayout === 'stack' && !this.props.scrollable) {
+                this.createResponsiveStyle();
+            }
+        });
 
         if (this.isStateful()) {
             this.setState(this.restoreState(this.state));


### PR DESCRIPTION
### Defect Fixes

Fixes #2594: DataTable: Responsive broken in 7.2.0

By calling `createResponsiveStyle()` within `setState` callback to ensure `this.state.attributeSelector` is set before using.