### PR TITLE
Add SplitButton show and hide method type declarations

### DIFF
--- a/components/lib/splitbutton/SplitButton.d.ts
+++ b/components/lib/splitbutton/SplitButton.d.ts
@@ -30,4 +30,7 @@ export interface SplitButtonProps {
     onHide?(): void;
 }
 
-export declare class SplitButton extends React.Component<SplitButtonProps, any> { }
+export declare class SplitButton extends React.Component<SplitButtonProps, any> {
+    public show(event: React.SyntheticEvent): void;
+    public hide(event: React.SyntheticEvent): void;
+}

--- a/components/lib/splitbutton/SplitButton.d.ts
+++ b/components/lib/splitbutton/SplitButton.d.ts
@@ -31,6 +31,6 @@ export interface SplitButtonProps {
 }
 
 export declare class SplitButton extends React.Component<SplitButtonProps, any> {
-    public show(event: React.SyntheticEvent): void;
-    public hide(event: React.SyntheticEvent): void;
+    public show(): void;
+    public hide(): void;
 }


### PR DESCRIPTION
###Defect Fixes

Fixes https://github.com/primefaces/primereact/issues/2625

###Feature Requests

The `SplitButton` should have the (already implemented) `show` and `hide` methods listed in the type declaration. This PR fixes that.