### PR TITLE
Fix #2641: TreeSelect header should be panelHeaderTemplate

### DIFF
--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -622,7 +622,7 @@ export class TreeSelect extends Component {
             </div>
         );
 
-        if (this.props.header) {
+        if (this.props.panelHeaderTemplate) {
             const defaultOptions = {
                 className: 'p-treeselect-header',
                 filterElement,
@@ -634,7 +634,7 @@ export class TreeSelect extends Component {
                 props: this.props
             }
 
-            return ObjectUtils.getJSXElement(this.props.header, defaultOptions);
+            return ObjectUtils.getJSXElement(this.props.panelHeaderTemplate, defaultOptions);
         }
 
         return content;


### PR DESCRIPTION
###Defect Fixes
Fix #2641: TreeSelect header should be panelHeaderTemplate

Looks like this property was named `panelHeaderTemplate` but it was referencing an invalid property called `header`