### PR TITLE
Add missing PrimeReact import.  Fixes #2663

### DIFF
--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import PrimeReact from '../api/Api';
 import { Paginator } from '../paginator/Paginator';
 import { ObjectUtils, classNames } from '../utils/Utils';
 import { Ripple } from '../ripple/Ripple';


### PR DESCRIPTION
Super simple PR to fix https://github.com/primefaces/primereact/issues/2663

https://github.com/primefaces/primereact/commit/ce9a52a2d486b7839d84264f15ad4f26e0d19ee4 added references to `PrimeReact.locale` during sorting to a handful of components.  DataView was the only one that hadn't already imported `PrimeReact` into scope.

Tested by running the DataView example.  Entertainingly, the public demo at https://www.primefaces.org/primereact/dataview/ on v7.2.1 currently breaks with `ReferenceError: PrimeReact is not defined` if you try to change the sort order.  After this fix, sorting works as expected.