### PR TITLE
Fix #2726: renamed parameter before merging #2611

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -200,7 +200,7 @@ export const BodyRow = React.memo((props) => {
                 let dataKeyValue = String(ObjectUtils.resolveFieldData(data, dataKey));
                 editingRows = props.editingRows ? { ...props.editingRows } : {};
 
-                if (!editing) {
+                if (!isEditing) {
                     delete editingRows[dataKeyValue];
                     // if the key value was changed, stop editing for the new key value too
                     let newDataKeyValue = String(ObjectUtils.resolveFieldData(newData, dataKey));


### PR DESCRIPTION
Fixes #2726

The issue was caused by applying two separate changes:
64c075e9d6b4348b2e8e408dc689da277bb9b7a8 and #2611

The first one renamed the parameter `editing` to `isEditing`,
the second included code that was using the parameter named `editing`.