### PR TITLE
Fix #1364: InputText update doc to link to inherited properties

### DIFF
--- a/components/doc/inputnumber/index.js
+++ b/components/doc/inputnumber/index.js
@@ -875,10 +875,10 @@ Vertical
                                     <td>Maximum boundary value.</td>
                                 </tr>
                                 <tr>
-                                <td>disabled</td>
-                                <td>boolean</td>
-                                <td>false</td>
-                                <td>When present, it specifies that the element should be disabled.</td>
+                                    <td>disabled</td>
+                                    <td>boolean</td>
+                                    <td>false</td>
+                                    <td>When present, it specifies that the element should be disabled.</td>
                                 </tr>
                                 <tr>
                                     <td>required</td>

--- a/components/doc/inputtext/index.js
+++ b/components/doc/inputtext/index.js
@@ -328,7 +328,7 @@ import { InputText } from 'primereact/inputtext';
                     <p>InputText has built-in key filtering support to block certain keys, refer to <Link href="/keyfilter">keyfilter</Link> page for more information.</p>
 
                     <h5>Properties</h5>
-                    <p>InputText passes any valid attribute to the underlying input element. Extended properties are as follows;</p>
+                    <p>InputText passes any valid attribute to the underlying <a href="https://use-form.netlify.app/interfaces/_node_modules__types_react_index_d_.react.inputhtmlattributes.html" rel="noopener noreferrer" target="_blank">React HTMLInputElement</a> element. Extended properties are as follows;</p>
                     <div className="doc-tablewrapper">
                         <table className="doc-table">
                             <thead>

--- a/components/doc/inputtext/index.js
+++ b/components/doc/inputtext/index.js
@@ -328,7 +328,7 @@ import { InputText } from 'primereact/inputtext';
                     <p>InputText has built-in key filtering support to block certain keys, refer to <Link href="/keyfilter">keyfilter</Link> page for more information.</p>
 
                     <h5>Properties</h5>
-                    <p>InputText passes any valid attribute to the underlying <a href="https://use-form.netlify.app/interfaces/_node_modules__types_react_index_d_.react.inputhtmlattributes.html" rel="noopener noreferrer" target="_blank">React HTMLInputElement</a> element. Extended properties are as follows;</p>
+                    <p>InputText passes any valid attribute to the underlying <a href="https://devdocs.io/html/element/input" rel="noopener noreferrer" target="_blank">React HTMLInputElement</a> element. Extended properties are as follows;</p>
                     <div className="doc-tablewrapper">
                         <table className="doc-table">
                             <thead>


### PR DESCRIPTION
###Feature Requests
Fix #1364: InputText update doc to link to inherited properties

There a over 100 properties inherited from core React InputHtmlElement this simply provides a documentation link to those properties.