### PR TITLE
Fix #2739: Accordion respect activeIndex

### DIFF
--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -7,7 +7,7 @@ export const AccordionTab = () => { }
 
 export const Accordion = React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
-    const [activeIndexState, setActiveIndexState] = React.useState(null);
+    const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
     const activeIndex = props.onTabChange ? props.activeIndex : activeIndexState;
 
     const shouldUseTab = (tab) => tab && tab.props.__TYPE === 'AccordionTab';


### PR DESCRIPTION
###Defect Fixes
Fix #2739: Accordion respect activeIndex.  The property was not being defaults in the `useState` variable.

You can see its broken on the Showcase right now in 8.0.0-rc1: https://primefaces.org/primereact/accordion/