### PR TITLE
Fix #2176: AutoComplete only fire onChange if value changed

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -107,6 +107,10 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
     }
 
     const updateModel = (event, value) => {
+        // #2176 only call change if value actually changed
+        if (selectedItem && selectedItem.current === value) {
+            return;
+        }
         if (props.onChange) {
             props.onChange({
                 originalEvent: event,


### PR DESCRIPTION
###Defect Fixes
Fix #2176: AutoComplete only fire onChange if value changed

Based on the Reproducer provided do not fire `onChange` event if the value has not changed.