### PR TITLE
Fix #2686: InputMask fix Android input

### DIFF
--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -154,6 +154,7 @@ export const InputMask = React.memo(React.forwardRef((props, ref) => {
                 value: getValue()
             });
         }
+        updateModel(e);
     }
 
     const onBlur = (e) => {


### PR DESCRIPTION
###Defect Fixes
Fix #2686: InputMask fix Android input

Analyzed this and `updateModel` was being called for normal input but not for special Android input.