### PR TITLE
Fix #2521: MenuItem TypeScript updates

### DIFF
--- a/components/lib/menuitem/MenuItem.d.ts
+++ b/components/lib/menuitem/MenuItem.d.ts
@@ -12,7 +12,6 @@ interface MenuItemOptions {
     iconClassName: string;
     element: React.ReactNode;
     props: any;
-    [key: string]: any;
 }
 
 type MenuItemTemplateType = React.ReactNode | ((item: MenuItem, options: MenuItemOptions) => React.ReactNode);
@@ -30,5 +29,4 @@ export interface MenuItem {
     className?: string;
     command?(e: MenuItemCommandParams): void;
     template?: MenuItemTemplateType;
-    [key: string]: any;
 }


### PR DESCRIPTION
###Feature Requests
Fix #2521: MenuItem TypeScript updates

I agree with @VsevolodGolovanov that these `any` `key` mappings are not needed in the TS def