### PR TITLE
Fix #2232: Chips onAdd allow callback to return false

### DIFF
--- a/components/doc/chips/index.js
+++ b/components/doc/chips/index.js
@@ -356,7 +356,7 @@ customChip(item) {
                                     <td>onAdd</td>
                                     <td>originalEvent: Browser event <br />
                             value: Added item value</td>
-                                    <td>Callback to invoke when a chip is added.</td>
+                                    <td>Callback to invoke when a chip is added. Return 'false' to prevent the item from being added.</td>
                                 </tr>
                                 <tr>
                                     <td>onRemove</td>

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -47,13 +47,16 @@ export const Chips = React.memo(React.forwardRef((props, ref) => {
             let values = props.value ? [...props.value] : [];
 
             if (props.allowDuplicate || values.indexOf(item) === -1) {
-                values.push(item);
-
+                let allowAddition = true;
                 if (props.onAdd) {
-                    props.onAdd({
+                    allowAddition = props.onAdd({
                         originalEvent: event,
                         value: item
                     });
+                }
+
+                if (allowAddition !== false) {
+                    values.push(item);
                 }
             }
 


### PR DESCRIPTION
###Feature Requests
Fix #2232: Chips onAdd allow callback to return false

Check the `return` value from the user `onAdd` function and if `false` do not add the item to the Chips