### PR TITLE
Fixed #2764 - Intro section of Accessibility page is not accessible

### DIFF
--- a/pages/accessibility/index.js
+++ b/pages/accessibility/index.js
@@ -22,7 +22,7 @@ const AccessibilityPage = () => {
             </div>
 
             <div className="content-section documentation">
-                <p className="line-height-3 bg-indigo-500 text-white p-3 text-lg" style={{borderRadius:'10px'}}>Accessibility is a majorn concern of the Prime UI libraries and PrimeReact is no exception. <a href="https://www.primetek.com.tr" className="text-white">PrimeTek</a> teams have initiated a significant process to review and enhance the accessibility features of the components. This guide
+                <p className="line-height-3 bg-indigo-600 text-white p-3 text-lg" style={{borderRadius:'10px'}}>Accessibility is a majorn concern of the Prime UI libraries and PrimeReact is no exception. <a href="https://www.primetek.com.tr" className="text-white">PrimeTek</a> teams have initiated a significant process to review and enhance the accessibility features of the components. This guide
                     documents the foundation of the general guidelines that PrimeReact will follow and each component documentation will have a separate <b>Accessibility</b> section that states the keyboard support, screen reader compatibility, the implementation details along
                         with tips to achieve WCAG compliancy. This work has been initiated in Q2 2022 and planned to be completed by early Q3. PrimeReact will be the reference implementation which then will be ported to PrimeFaces, PrimeNG and PrimeVue. 
                 </p>


### PR DESCRIPTION
<img width="727" alt="image" src="https://user-images.githubusercontent.com/244957/163844441-6f808574-485c-448b-890d-63a26f3b8514.png">
