### PR TITLE
Fix #1661: Calendar do not navigate past min and max

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -947,6 +947,51 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    const setNavigationState = (newViewDate) => {
+        if (props.view !== 'date' || !overlayRef.current) {
+            return;
+        }
+
+        const navPrev = DomHandler.findSingle(overlayRef.current, '.p-datepicker-prev');
+        const navNext = DomHandler.findSingle(overlayRef.current, '.p-datepicker-next');
+
+        if (props.disabled) {
+            DomHandler.addClass(navPrev, 'p-disabled');
+            DomHandler.addClass(navNext, 'p-disabled');
+            return;
+        }
+
+        // previous (check first day of month at 00:00:00)
+        if (props.minDate) {
+            let firstDayOfMonth = new Date(newViewDate.getTime());
+            firstDayOfMonth.setDate(1);
+            firstDayOfMonth.setHours(0);
+            firstDayOfMonth.setMinutes(0);
+            firstDayOfMonth.setSeconds(0);
+            if (props.minDate > firstDayOfMonth) {
+                DomHandler.addClass(navPrev, 'p-disabled');
+            } else {
+                DomHandler.removeClass(navPrev, 'p-disabled');
+            }
+        }
+
+        // next (check last day of month at 11:59:59)
+        if (props.maxDate) {
+            let lastDayOfMonth = new Date(newViewDate.getTime());
+            lastDayOfMonth.setMonth(lastDayOfMonth.getMonth()+1);
+            lastDayOfMonth.setDate(1);
+            lastDayOfMonth.setHours(0);
+            lastDayOfMonth.setMinutes(0);
+            lastDayOfMonth.setSeconds(0)
+            lastDayOfMonth.setSeconds(-1);
+            if (props.maxDate < lastDayOfMonth) {
+                DomHandler.addClass(navNext, 'p-disabled');
+            } else {
+                DomHandler.removeClass(navNext, 'p-disabled');
+            }
+        }
+    }
+
     const onDateCellKeydown = (event, date, groupIndex) => {
         const cellContent = event.currentTarget;
         const cell = cellContent.parentElement;
@@ -2399,7 +2444,10 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
     }, [props.dateFormat, props.hourFormat, props.timeOnly, props.showSeconds, props.showMillisec]);
 
     useUpdateEffect(() => {
-        overlayRef.current && updateFocus();
+        if (overlayRef.current) {
+            setNavigationState(viewDateState);
+            updateFocus();
+        }
     });
 
     useUnmountEffect(() => {


### PR DESCRIPTION
###Defect Fixes
Fix #1661: Calendar do not navigate past min and max

@mertsincan this actually is much easier now that you switched to hooks because I can put this code in one place when the overlay panel renders and update the navigators appropriately without and additional property.  