### PR TITLE
Fix #2782/#2363: FileUpload drag and drop

### DIFF
--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -284,7 +284,7 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
             event.preventDefault();
 
             const files = event.dataTransfer ? event.dataTransfer.files : event.target.files;
-            const allowDrop = props.multiple || (files && files.length === 0);
+            const allowDrop = props.multiple || (ObjectUtils.isEmpty(filesState) && files && files.length === 1);
 
             allowDrop && onFileSelect(event);
         }


### PR DESCRIPTION
###Defect Fixes
Fix #2782/#2363: FileUpload drag and drop

This fixes both issues correctly.  It checks if NOT multiple then it will only allow dropping if there is not already a file in the upload AND you are dragging only 1 file.

Tested with `multiple=true` and `multiple=false`