### PR TITLE
Fix #2792: FileUpload single mode only allow 1 file

### DIFF
--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -74,7 +74,11 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
             return;
         }
 
-        let currentFiles = filesState ? [...filesState] : [];
+        let currentFiles = [];
+        if (props.multiple) {
+            currentFiles = filesState ? [...filesState] : [];
+        }
+
         let selectedFiles = event.dataTransfer ? event.dataTransfer.files : event.target.files;
         for (let i = 0; i < selectedFiles.length; i++) {
             let file = selectedFiles[i];


### PR DESCRIPTION
###Defect Fixes
Fix #2792: FileUpload single mode only allow 1 file

When using single mode in advanced mode it currently allowed you to keep selecting Choose and adding files to the list instead of overwriting the 1 file that was already there