### PR TITLE
Fix #2792: FileUpload advanced mode custom uploader

### DIFF
--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -140,6 +140,9 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
 
     const upload = (files) => {
         files = files || filesState;
+        if (files && files.nativeEvent) {
+            files = filesState;
+        }
 
         if (props.customUpload) {
             if (props.fileLimit) {


### PR DESCRIPTION
###Defect Fixes
Fix #2792: FileUpload advanced mode custom uploader

In Advanced mode `files` was the SyntheticEvent and not the list of files so we must detect that and use `fileState` for files.