### PR TITLE
Fix typo

### DIFF
--- a/components/doc/datatable/index.js
+++ b/components/doc/datatable/index.js
@@ -1147,7 +1147,7 @@ export const DataTableDemo = () => {
                                     <td>filterMatchMode</td>
                                     <td>string</td>
                                     <td>null</td>
-                                    <td>Defines filterMatchMode; "startsWith", "contains", "endsWidth", "equals", "notEquals", "in", "lt", "lte", "gt", "gte" and "custom".</td>
+                                    <td>Defines filterMatchMode; "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "lt", "lte", "gt", "gte" and "custom".</td>
                                 </tr>
                                 <tr>
                                     <td>filterType</td>


### PR DESCRIPTION
Unrelated to the change at hand, I believe it would be positive for the quality of the documentation to get it reviewed by a native speaker, ideally a qualified professional. I often find the wording and style confusing, including odd use of commas, inconsistent highlighting of code references, etc. Also, lengthier descriptions for component parameters and such would not hurt; they are sometimes not enough. Just my two cents.