### PR TITLE
Fix #2226: Breadcrumb allow Home MenuItem template

### DIFF
--- a/api-generator/components/breadcrumb.js
+++ b/api-generator/components/breadcrumb.js
@@ -18,6 +18,12 @@ const BreadCrumbProps = [
         description: 'MenuItem configuration for the home icon.'
     },
     {
+        name: 'homeTemplate',
+        type: 'function',
+        default: 'null',
+        description: 'Template function to render the Home icon.'
+    },
+    {
         name: 'style',
         type: 'string',
         default: 'null',

--- a/api-generator/components/breadcrumb.js
+++ b/api-generator/components/breadcrumb.js
@@ -7,7 +7,7 @@ const BreadCrumbProps = [
     },
     {
         name: 'model',
-        type: 'array',
+        type: 'MenuItem[]',
         default: 'null',
         description: 'An array of menuitems.'
     },
@@ -16,12 +16,6 @@ const BreadCrumbProps = [
         type: 'MenuItem',
         default: 'null',
         description: 'MenuItem configuration for the home icon.'
-    },
-    {
-        name: 'homeTemplate',
-        type: 'function',
-        default: 'null',
-        description: 'Template function to render the Home icon.'
     },
     {
         name: 'style',

--- a/components/doc/breadcrumb/index.js
+++ b/components/doc/breadcrumb/index.js
@@ -191,7 +191,7 @@ const home = { icon: 'pi pi-home', url: 'https://www.primefaces.org/primereact' 
                                 </tr>
                                 <tr>
                                     <td>model</td>
-                                    <td>array</td>
+                                    <td>MenuItem[]</td>
                                     <td>null</td>
                                     <td>An array of menuitems.</td>
                                 </tr>
@@ -200,6 +200,12 @@ const home = { icon: 'pi pi-home', url: 'https://www.primefaces.org/primereact' 
                                     <td>MenuItem</td>
                                     <td>null</td>
                                     <td>MenuItem configuration for the home icon.</td>
+                                </tr>
+                                <tr>
+                                    <td>homeTemplate</td>
+                                    <td>any</td>
+                                    <td>null</td>
+                                    <td>Template to use instead of home menu item to control the rendering and attributes of the home node.</td>
                                 </tr>
                                 <tr>
                                     <td>style</td>

--- a/components/doc/breadcrumb/index.js
+++ b/components/doc/breadcrumb/index.js
@@ -202,12 +202,6 @@ const home = { icon: 'pi pi-home', url: 'https://www.primefaces.org/primereact' 
                                     <td>MenuItem configuration for the home icon.</td>
                                 </tr>
                                 <tr>
-                                    <td>homeTemplate</td>
-                                    <td>any</td>
-                                    <td>null</td>
-                                    <td>Template to use instead of home menu item to control the rendering and attributes of the home node.</td>
-                                </tr>
-                                <tr>
                                     <td>style</td>
                                     <td>string</td>
                                     <td>null</td>

--- a/components/lib/breadcrumb/BreadCrumb.d.ts
+++ b/components/lib/breadcrumb/BreadCrumb.d.ts
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { MenuItem } from '../menuitem';
 
-type BreadCrumbHomeTemplateType = React.ReactNode | ((props: BreadCrumbProps) => React.ReactNode);
-
 export interface BreadCrumbProps {
     id?: string;
     model?: MenuItem[];
     home?: MenuItem;
-    homeTemplate?: BreadCrumbHomeTemplateType;
     style?: object;
     className?: string;
     children?: React.ReactNode;

--- a/components/lib/breadcrumb/BreadCrumb.d.ts
+++ b/components/lib/breadcrumb/BreadCrumb.d.ts
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { MenuItem } from '../menuitem';
 
+type BreadCrumbHomeTemplateType = React.ReactNode | ((props: BreadCrumbProps) => React.ReactNode);
+
 export interface BreadCrumbProps {
     id?: string;
     model?: MenuItem[];
     home?: MenuItem;
+    homeTemplate?: BreadCrumbHomeTemplateType;
     style?: object;
     className?: string;
     children?: React.ReactNode;

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -22,24 +22,38 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
     }
 
     const createHome = () => {
-        let element = null;
         const home = props.home;
-
-        if (home) {
-            const { icon: _icon, target, url, disabled, style, className: _className } = home;
-            const className = classNames('p-breadcrumb-home', { 'p-disabled': disabled }, _className);
-            const icon = IconUtils.getJSXIcon(_icon, { className: 'p-menuitem-icon' }, { props });
-
-            element =  (
-                <li className={className} style={style}>
-                    <a href={url || '#'} className="p-menuitem-link" aria-disabled={disabled} target={target} onClick={(event) => itemClick(event, home)}>
-                        {icon}
-                    </a>
-                </li>
-            )
+        if (!home) {
+            return null;
         }
 
-        return props.homeTemplate ? ObjectUtils.getJSXElement(props.homeTemplate, props) : element;
+        const { icon: _icon, target, url, disabled, style, className: _className, template } = home;
+        const className = classNames('p-breadcrumb-home', { 'p-disabled': disabled }, _className);
+        const icon = IconUtils.getJSXIcon(_icon, { className: 'p-menuitem-icon' }, { props });
+
+        let content = (
+            <a href={url || '#'} className="p-menuitem-link" aria-disabled={disabled} target={target} onClick={(event) => itemClick(event, home)}>
+                {icon}
+            </a>
+        )
+
+        if (template) {
+            const defaultContentOptions = {
+                onClick: (event) => itemClick(event, home),
+                className: 'p-menuitem-link',
+                labelClassName: 'p-menuitem-text',
+                element: content,
+                props
+            };
+
+            content = ObjectUtils.getJSXElement(template, home, defaultContentOptions);
+        }
+
+        return (
+            <li className={className} style={style}>
+                {content}
+            </li>
+        )
     }
 
     const createSeparator = () => {
@@ -118,7 +132,6 @@ BreadCrumb.defaultProps = {
     id: null,
     model: null,
     home: null,
-    homeTemplate: null,
     style: null,
     className: null
 }

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -22,6 +22,7 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
     }
 
     const createHome = () => {
+        let element = null;
         const home = props.home;
 
         if (home) {
@@ -29,7 +30,7 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
             const className = classNames('p-breadcrumb-home', { 'p-disabled': disabled }, _className);
             const icon = IconUtils.getJSXIcon(_icon, { className: 'p-menuitem-icon' }, { props });
 
-            return (
+            element =  (
                 <li className={className} style={style}>
                     <a href={url || '#'} className="p-menuitem-link" aria-disabled={disabled} target={target} onClick={(event) => itemClick(event, home)}>
                         {icon}
@@ -38,7 +39,7 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
             )
         }
 
-        return null;
+        return props.homeTemplate ? ObjectUtils.getJSXElement(props.homeTemplate, props) : element;
     }
 
     const createSeparator = () => {
@@ -117,6 +118,7 @@ BreadCrumb.defaultProps = {
     id: null,
     model: null,
     home: null,
+    homeTemplate: null,
     style: null,
     className: null
 }


### PR DESCRIPTION
###Feature Requests
Fix #2226: Breadcrumb add homeTemplate

Allows complete control of how the Home value is rendered using `homeTemplate={yourTemplate}`