### PR TITLE
Fix #2018: Calendar only fire onChange if dirty

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1334,9 +1334,10 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
     const updateModel = (event, value) => {
         if (props.onChange) {
             const newValue = (value && value instanceof Date) ? new Date(value.getTime()) : value;
+            const dirty = previousValue !== props.value;
             viewStateChanged.current = true;
 
-            props.onChange({
+            dirty && props.onChange({
                 originalEvent: event,
                 value: newValue,
                 stopPropagation: () => { },


### PR DESCRIPTION
###Defect Fixes
Fix #2018: Calendar only fire onChange if dirty

OnChange was firing twice every time now it properly only fires once and only when the value has actually changed.