### PR TITLE
Fix #2814: Carousel less items than allocated slots

### DIFF
--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -42,9 +42,10 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     const isVertical = props.orientation === 'vertical';
     const circular = props.circular || !!props.autoplayInterval;
     const isCircular = circular && props.value.length >= numVisibleState;
-    const isAutoplay = props.autoplayInterval && allowAutoplay.current;
     const currentPage = props.onPageChange ? props.page : pageState;
-    const totalIndicators = props.value ? Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1 : 0;
+    let totalIndicators = props.value.length ? Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1 : 0;
+    totalIndicators = totalIndicators <= 0 ? 0 : totalIndicators;
+    const isAutoplay = totalIndicators && props.autoplayInterval && allowAutoplay.current;
 
     const [bindWindowResizeListener,] = useResizeListener({
         listener: () => {

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -41,9 +41,9 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     const prevPage = usePrevious(props.page);
     const isVertical = props.orientation === 'vertical';
     const circular = props.circular || !!props.autoplayInterval;
-    const isCircular = circular && props.value.length >= numVisibleState;
+    const isCircular = circular && props.value && props.value.length >= numVisibleState;
     const currentPage = props.onPageChange ? props.page : pageState;
-    const totalIndicators = Math.max((Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1), 0);
+    const totalIndicators = props.value ? Math.max(Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1, 0) : 0;
     const isAutoplay = totalIndicators && props.autoplayInterval && allowAutoplay.current;
 
     const [bindWindowResizeListener,] = useResizeListener({

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -43,7 +43,7 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     const circular = props.circular || !!props.autoplayInterval;
     const isCircular = circular && props.value.length >= numVisibleState;
     const currentPage = props.onPageChange ? props.page : pageState;
-    const totalIndicators = Math.max((props.value.length ? Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1 : 0), 0);
+    const totalIndicators = Math.max((Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1), 0);
     const isAutoplay = totalIndicators && props.autoplayInterval && allowAutoplay.current;
 
     const [bindWindowResizeListener,] = useResizeListener({

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -43,8 +43,7 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     const circular = props.circular || !!props.autoplayInterval;
     const isCircular = circular && props.value.length >= numVisibleState;
     const currentPage = props.onPageChange ? props.page : pageState;
-    let totalIndicators = props.value.length ? Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1 : 0;
-    totalIndicators = totalIndicators <= 0 ? 0 : totalIndicators;
+    const totalIndicators = Math.max((props.value.length ? Math.ceil((props.value.length - numVisibleState) / numScrollState) + 1 : 0), 0);
     const isAutoplay = totalIndicators && props.autoplayInterval && allowAutoplay.current;
 
     const [bindWindowResizeListener,] = useResizeListener({


### PR DESCRIPTION
###Defect Fixes
Fix #2814: Carousel less items than allocated slots