### PR TITLE
Fix #2821: sortSingle calling the ref instead of the function within

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -885,7 +885,7 @@ export const DataTable = React.forwardRef((props, ref) => {
         let value = [...data];
 
         if (columnSortable.current && columnSortFunction.current) {
-            value = columnSortFunction({ field, order });
+            value = columnSortFunction.current({ field, order });
         }
         else {
             value.sort((data1, data2) => {


### PR DESCRIPTION
###Defect Fixes
Fix https://github.com/primefaces/primereact/issues/2821: Custom sort functions throw errors in single sort mode

It's a pretty simple fix so I thought I'd submit the PR as well.