### PR TITLE
Fix #2866: wrong tooltip when trying to get to page 0

### DIFF
--- a/pages/datatable/paginator.js
+++ b/pages/datatable/paginator.js
@@ -40,7 +40,7 @@ const DataTablePaginatorDemo = () => {
     const onPageInputKeyDown = (event, options) => {
         if (event.key === 'Enter') {
             const page = parseInt(currentPage);
-            if (page < 0 || page > options.totalPages) {
+            if (page < 1 || page > options.totalPages) {
                 setPageInputTooltip(`Value must be between 1 and ${options.totalPages}.`);
             }
             else {
@@ -254,7 +254,7 @@ export class DataTablePaginatorDemo extends Component {
     onPageInputKeyDown(event, options) {
         if (event.key === 'Enter') {
             const page = parseInt(this.state.currentPage);
-            if (page < 0 || page > options.totalPages) {
+            if (page < 1 || page > options.totalPages) {
                 this.setState({ pageInputTooltip: \`Value must be between 1 and \${options.totalPages}.\`})
             }
             else {
@@ -432,7 +432,7 @@ const DataTablePaginatorDemo = () => {
     const onPageInputKeyDown = (event, options) => {
         if (event.key === 'Enter') {
             const page = parseInt(currentPage);
-            if (page < 0 || page > options.totalPages) {
+            if (page < 1 || page > options.totalPages) {
                 setPageInputTooltip(\`Value must be between 1 and \${options.totalPages}.\`);
             }
             else {
@@ -609,7 +609,7 @@ const DataTablePaginatorDemo = () => {
     const onPageInputKeyDown = (event, options) => {
         if (event.key === 'Enter') {
             const page = parseInt(currentPage);
-            if (page < 0 || page > options.totalPages) {
+            if (page < 1 || page > options.totalPages) {
                 setPageInputTooltip(\`Value must be between 1 and \${options.totalPages}.\`);
             }
             else {
@@ -796,7 +796,7 @@ const DataTablePaginatorDemo = () => {
     const onPageInputKeyDown = (event, options) => {
         if (event.key === 'Enter') {
             const page = parseInt(currentPage);
-            if (page < 0 || page > options.totalPages) {
+            if (page < 1 || page > options.totalPages) {
                 setPageInputTooltip(\`Value must be between 1 and \${options.totalPages}.\`);
             }
             else {


### PR DESCRIPTION
You can't go to page 0, so the correct way is to show the tooltip if the page value is actually smaller than 1, and not 0 as it was before.

Issue here: https://github.com/primefaces/primereact/issues/2866