### PR TITLE
fix #2868 Ensure CSS is marked as a sideeffect to avoid being omission via tree-shaking

### DIFF
--- a/package-build.json
+++ b/package-build.json
@@ -45,7 +45,9 @@
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"
     },
-    "sideEffects": false,
+    "sideEffects": [
+        "**/*.css"
+    ],
     "unpkg": "primereact.all.min.js",
     "jsdelivr": "primereact.all.min.js"
 }


### PR DESCRIPTION
Refer to #2868 to description of issue

Ref: https://jaketrent.com/post/webpack-skip-css-import