### PR TITLE
Fix #2876: InputSwitch typescript def remove ref

### DIFF
--- a/components/lib/inputswitch/InputSwitch.d.ts
+++ b/components/lib/inputswitch/InputSwitch.d.ts
@@ -15,7 +15,7 @@ interface InputSwitchChangeParams {
     target: InputSwitchChangeTargetOptions;
 }
 
-export interface InputSwitchProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'> {
+export interface InputSwitchProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
     id?: string;
     inputRef?: React.Ref<HTMLInputElement>;
     style?: object;


### PR DESCRIPTION
###Defect Fixes
Fix #2876: InputSwitch typescript def remove ref