### PR TITLE
Fix #2880: Calendar footer and button bar always on bottom

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3048,10 +3048,10 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
                 transitionOptions={props.transitionOptions}>
                 {datePicker}
                 {timePicker}
-                {buttonBar}
-                {footer}
                 {monthPicker}
                 {yearPicker}
+                {buttonBar}
+                {footer}
             </CalendarPanel>
         </span>
     )


### PR DESCRIPTION
###Defect Fixes
Fix #2880: Calendar footer and button bar always on bottom