### PR TITLE
Fix #2887: Storage hook respect changes in other tabs

### DIFF
--- a/components/lib/hooks/Hooks.d.ts
+++ b/components/lib/hooks/Hooks.d.ts
@@ -32,4 +32,6 @@ export declare function useOverlayScrollListener(options: EventOptions): any[];
 export declare function useResizeListener(options: ResizeEventOptions): any[];
 export declare function useInterval(fn: any, delay?: number, when?: boolean): any[];
 export declare function useTimeout(fn: any, delay?: number, when?: boolean): any[];
-export declare function useStorage<S>(initialValue: S, key: string, storage?: StorageType): [S, React.Dispatch<React.SetStateAction<S>>];
+export declare function useStorage<S, K extends string = string>(initialValue: S, key: K, storage?: StorageType): [S, React.Dispatch<React.SetStateAction<S>>];
+export declare function useLocalStorage<S>(initialValue: S, key: string): [S, React.Dispatch<React.SetStateAction<S>>];
+export declare function useSessionStorage<S>(initialValue: S, key: string): [S, React.Dispatch<React.SetStateAction<S>>];

--- a/components/lib/hooks/Hooks.js
+++ b/components/lib/hooks/Hooks.js
@@ -7,7 +7,7 @@ import { useOverlayListener } from './useOverlayListener';
 import { useOverlayScrollListener } from './useOverlayScrollListener';
 import { useResizeListener } from './useResizeListener';
 import { useInterval } from './useInterval';
-import { useStorage } from './useStorage';
+import { useStorage, useLocalStorage, useSessionStorage } from './useStorage';
 import { useTimeout } from './useTimeout';
 
-export { usePrevious, useMountEffect, useUpdateEffect, useUnmountEffect, useEventListener, useOverlayListener, useOverlayScrollListener, useResizeListener, useInterval, useStorage, useTimeout };
+export { usePrevious, useMountEffect, useUpdateEffect, useUnmountEffect, useEventListener, useOverlayListener, useOverlayScrollListener, useResizeListener, useInterval, useStorage, useLocalStorage, useSessionStorage, useTimeout };


### PR DESCRIPTION
###Feature Requests
Fix #2887: Storage hook respect changes in other tabs

- now listens to `window.storage` events so changes in other tabs are subscribed to
- added `useLocalStorage` and `useSessionStorage` convenience hooks.