### PR TITLE
Fix #2921: FloatLabel with webkit autofill fix

### DIFF
--- a/components/lib/inputtext/InputText.css
+++ b/components/lib/inputtext/InputText.css
@@ -54,17 +54,13 @@
 }
 
 .p-float-label input:focus ~ label,
+.p-float-label input:-webkit-autofill ~ label,
 .p-float-label input.p-filled ~ label,
 .p-float-label textarea:focus ~ label,
 .p-float-label textarea.p-filled ~ label,
 .p-float-label .p-inputwrapper-focus ~ label,
 .p-float-label .p-inputwrapper-filled ~ label {
     top: -.75rem;
-    font-size: 12px;
-}
-
-.p-float-label input:-webkit-autofill ~ label {
-    top: -20px;
     font-size: 12px;
 }
 


### PR DESCRIPTION
###Defect Fixes
Fix #2921: FloatLabel with webkit autofill fix

Standardized to the same `top` value as the others.