### PR TITLE
Fix #2926: Toast wrap long text

### DIFF
--- a/components/lib/toast/Toast.css
+++ b/components/lib/toast/Toast.css
@@ -12,6 +12,10 @@
     flex: 1 1 auto;
 }
 
+.p-toast-detail {
+    overflow-wrap: anywhere;
+}
+
 .p-toast-top-right {
 	top: 20px;
 	right: 20px;


### PR DESCRIPTION
###Defect Fixes
Fix #2926: Toast wrap long text

![image](https://user-images.githubusercontent.com/4399574/170258547-5ae584e4-5faf-4e32-88db-983902567ccc.png)
