### PR TITLE
Update SelectItem import statement

### DIFF
--- a/components/lib/dropdown/Dropdown.d.ts
+++ b/components/lib/dropdown/Dropdown.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { CSSTransitionProps } from '../csstransition';
 import { VirtualScrollerProps } from '../virtualscroller';
-import { SelectItemOptionsType } from '../selectitem/SelectItem';
+import { SelectItemOptionsType } from '../selectitem/selectitem';
 
 type DropdownOptionGroupTemplateType = React.ReactNode | ((option: any, index: number) => React.ReactNode);
 


### PR DESCRIPTION
The actual file name when pulling from npm is "selectitem" and not "SelectItem", so when running builds on case sensitive OS, the build fails:

![image](https://user-images.githubusercontent.com/19190267/170907909-d946a076-1051-40de-ba40-a59886466e94.png)