### PR TITLE
Fix #2948: Calendar monthpicker incorrect month on 1st click

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1311,6 +1311,7 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
             setCurrentMonth(month);
             createMonthsMeta(month, currentYear);
             const currentDate = new Date(getCurrentDateTime().getTime());
+            currentDate.setDate(1); // #2948 always set to 1st of month
             currentDate.setMonth(month);
             currentDate.setYear(currentYear);
 


### PR DESCRIPTION
###Defect Fixes
Fix #2948: Calendar monthpicker incorrect month on 1st click