### PR TITLE
Fix #2957: Image preview do not hide buttons behind image

### DIFF
--- a/components/doc/image/index.js
+++ b/components/doc/image/index.js
@@ -291,6 +291,10 @@ import { Image } from 'primereact/image';
                                         <td><i>space</i></td>
                                         <td>Activates the button.</td>
                                     </tr>
+                                    <tr>
+                                        <td><i>esc</i></td>
+                                        <td>Closes the image preview.</td>
+                                    </tr>
                                 </tbody>
                             </table>
                         </div>

--- a/components/lib/image/Image.css
+++ b/components/lib/image/Image.css
@@ -46,6 +46,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 99999999;
 }
 
 .p-image-preview {


### PR DESCRIPTION
###Defect Fixes
Fix #2957: Image preview do not hide buttons behind image

Documented ESC key for accessibility updates