### PR TITLE
Fix #2953 ConfirmDialogProps extension of  DialogProps

### DIFF
--- a/components/lib/confirmdialog/ConfirmDialog.d.ts
+++ b/components/lib/confirmdialog/ConfirmDialog.d.ts
@@ -2,24 +2,12 @@ import * as React from 'react';
 import { DialogProps } from '../dialog';
 import { IconType } from '../utils';
 
-type ConfirmDialogTemplateType = React.ReactNode | ((options: ConfirmDialogOptions) => React.ReactNode);
+type ConfirmDialogTemplateType = React.ReactNode | ((options: ConfirmDialogProps) => React.ReactNode);
 
 type ConfirmDialogAppendToType = 'self' | HTMLElement | undefined | null;
 
 interface ConfirmDialogBreakpoints {
     [key: string]: string;
-}
-
-interface ConfirmDialogOptions {
-    accept(): void;
-    reject(): void;
-    acceptClassName: string;
-    rejectClassName: string;
-    acceptLabel: string;
-    rejectLabel: string;
-    element: React.ReactNode;
-    props: ConfirmDialogProps;
-    [key: string]: any;
 }
 
 export interface ConfirmDialogProps extends Omit<DialogProps, 'onHide'> {


### PR DESCRIPTION
`ConfirmDialogProps` currently extends `DialogProps` incorrectly (see [#2953](https://github.com/primefaces/primereact/issues/2953)):
![image](https://user-images.githubusercontent.com/19190267/171798683-e63f2d1e-2191-4b53-94c3-5b7698849488.png)

`ConfirmDialogTemplateType` has an incorrect type of `((options: ConfirmDialogOptions) => React.ReactNode)`, where it should actually be `((options: ConfirmDialogProps) => React.ReactNode)` to correctly extend the `footer` property of `DialogProps`.

I also don't see any references to `ConfirmDialogOptions` other that the incorrect reference above, so also removed as cleanup.
