### PR TITLE
Fix #2961: Calendar yearpicker incorrect

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -945,6 +945,8 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
             viewStateChanged.current = true;
             setViewDateState(value);
         }
+        setCurrentMonth(value.getMonth());
+        setCurrentYear(value.getFullYear());
     }
 
     const onDateCellKeydown = (event, date, groupIndex) => {


### PR DESCRIPTION
###Defect Fixes
Fix #2961: Calendar yearpicker incorrect

Must always update the CurrentYear and Current Month whenerver the View Date is updated.