### PR TITLE
Fix #2963: Allow access to ref

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -13,7 +13,7 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
     const [searchingState, setSearchingState] = React.useState(false);
     const [focusedState, setFocusedState] = React.useState(false);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
     const multiContainerRef = React.useRef(null);
@@ -421,6 +421,10 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useMountEffect(() => {
         if (!idState) {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -12,7 +12,7 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
     const [viewDateState, setViewDateState] = React.useState(null);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
     const navigation = React.useRef(null);
@@ -2331,6 +2331,10 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useMountEffect(() => {
         let viewDate = getViewDate(props.viewDate);

--- a/components/lib/captcha/Captcha.js
+++ b/components/lib/captcha/Captcha.js
@@ -3,7 +3,7 @@ import { useMountEffect, useUnmountEffect } from '../hooks/Hooks';
 import { ObjectUtils } from '../utils/Utils';
 
 export const Captcha = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const instance = React.useRef(null);
     const recaptchaScript = React.useRef(null);
     const isCaptchaLoaded = React.useRef(false);
@@ -84,6 +84,10 @@ export const Captcha = React.memo(React.forwardRef((props, ref) => {
         reset,
         getResponse
     }));
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const otherProps = ObjectUtils.findDiffKeys(props, Captcha.defaultProps);
 

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -25,7 +25,7 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     const [numScrollState, setNumScrollState] = React.useState(props.numScroll);
     const [totalShiftedItemsState, setTotalShiftedItemsState] = React.useState((props.page * props.numScroll) * -1);
     const [pageState, setPageState] = React.useState(props.page);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const itemsContainerRef = React.useRef(null);
     const remainingItems = React.useRef(0);
     const allowAutoplay = React.useRef(!!props.autoplayInterval);
@@ -382,6 +382,10 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
             stopAutoplay();
         }
     });
+ 
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createItems = () => {
         if (props.value && props.value.length) {

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -10,7 +10,7 @@ import { CascadeSelectSub } from './CascadeSelectSub';
 export const CascadeSelect = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(null);
     const labelRef = React.useRef(null);
@@ -185,6 +185,10 @@ export const CascadeSelect = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useUpdateEffect(() => {
         updateSelectionPath();

--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -5,7 +5,7 @@ import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Checkbox = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const inputRef = React.useRef(props.inputRef);
 
     const onClick = (event) => {
@@ -48,6 +48,10 @@ export const Checkbox = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useUpdateEffect(() => {
         inputRef.current.checked = isChecked();

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -4,7 +4,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Chips = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const listRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
 
@@ -157,6 +157,10 @@ export const Chips = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createRemoveIcon = (value, index) => {
         if (!props.disabled && !props.readOnly && isRemovable(value, index)) {

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -8,7 +8,7 @@ import { ColorPickerPanel } from './ColorPickerPanel';
 
 export const ColorPicker = React.memo(React.forwardRef((props, ref) => {
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
     const colorSelectorRef = React.useRef(null);
@@ -440,6 +440,10 @@ export const ColorPicker = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useMountEffect(() => {
         updateHSBValue(props.value);

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -10,7 +10,7 @@ export const Dropdown = React.memo(React.forwardRef((props, ref) => {
     const [filterState, setFilterState] = React.useState('');
     const [focusedState, setFocusedState] = React.useState(false);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
     const focusInputRef = React.useRef(null);
@@ -545,6 +545,10 @@ export const Dropdown = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useMountEffect(() => {
         if (props.autoFocus && focusInputRef.current) {

--- a/components/lib/fullcalendar/FullCalendar.js
+++ b/components/lib/fullcalendar/FullCalendar.js
@@ -3,7 +3,7 @@ import { useMountEffect, usePrevious, useUnmountEffect, useUpdateEffect } from '
 import { ObjectUtils } from '../utils/Utils';
 
 export const FullCalendar = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const config = React.useRef({});
     const calendar = React.useRef(null);
     const prevEvents = usePrevious(props.events);
@@ -65,6 +65,10 @@ export const FullCalendar = React.memo(React.forwardRef((props, ref) => {
             calendar.current.destroy();
         }
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const otherProps = ObjectUtils.findDiffKeys(props, FullCalendar.defaultProps);
 

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -13,7 +13,7 @@ export const Galleria = React.memo(React.forwardRef((props, ref) => {
     const [numVisibleState, setNumVisibleState] = React.useState(props.numVisible);
     const [slideShowActiveState, setSlideShowActiveState] = React.useState(false);
     const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const previewContentRef = React.useRef(null);
     const maskRef = React.useRef(null);
     const activeItemIndex = props.onItemChange ? props.activeIndex : activeIndexState;
@@ -92,6 +92,10 @@ export const Galleria = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         setNumVisibleState(props.numVisible);
     }, [props.numVisible]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useUnmountEffect(() => {
         if (slideShowActiveState) {

--- a/components/lib/gmap/GMap.js
+++ b/components/lib/gmap/GMap.js
@@ -4,7 +4,7 @@ import { useMountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { ObjectUtils } from '../utils/Utils';
 
 export const GMap = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const map = React.useRef(null);
     const prevOverlays = React.useRef(null);
 
@@ -109,6 +109,10 @@ export const GMap = React.memo(React.forwardRef((props, ref) => {
             removeOverlays(prevOverlays.current);
         }
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     React.useImperativeHandle(ref, () => ({
         getMap

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -10,7 +10,7 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     const [previewVisibleState, setPreviewVisibleState] = React.useState(false);
     const [rotateState, setRotateState] = React.useState(0);
     const [scaleState, setScaleState] = React.useState(1);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const maskRef = React.useRef(null);
     const previewRef = React.useRef(null);
     const previewClick = React.useRef(false);
@@ -89,6 +89,10 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     useUnmountEffect(() => {
         maskRef.current && ZIndexUtils.clear(maskRef.current);
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createPreview = () => {
         if (props.preview) {

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -4,7 +4,7 @@ import { InputText } from '../inputtext/InputText';
 import { classNames, DomHandler, ObjectUtils } from '../utils/Utils';
 
 export const InputMask = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(props.inputRef);
     const firstNonMaskPos = React.useRef(null);
     const lastRequiredNonMaskPos = React.useRef(0);
     const tests = React.useRef([]);

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -7,7 +7,7 @@ import { classNames, DomHandler, ObjectUtils } from '../utils/Utils';
 
 export const InputNumber = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const inputRef = React.useRef(null);
     const timer = React.useRef(null);
     const lastValue = React.useRef(null);
@@ -940,6 +940,10 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useMountEffect(() => {
         constructParser();

--- a/components/lib/inputswitch/InputSwitch.js
+++ b/components/lib/inputswitch/InputSwitch.js
@@ -4,7 +4,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const InputSwitch = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const inputRef = React.useRef(props.inputRef);
     const checked = props.checked === props.trueValue;
 
@@ -50,6 +50,10 @@ export const InputSwitch = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, InputSwitch.defaultProps);

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -9,7 +9,7 @@ const minRadians = 4 * Math.PI / 3;
 const maxRadians = -Math.PI / 3;
 
 export const Knob = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const enabled = !props.disabled && !props.readOnly;
 
     const [bindWindowMouseMoveListener, unbindWindowMouseMoveListener] = useEventListener({
@@ -129,6 +129,10 @@ export const Knob = React.memo(React.forwardRef((props, ref) => {
         unbindWindowTouchMoveListener();
         unbindWindowTouchEndListener();
     }
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const otherProps = ObjectUtils.findDiffKeys(props, Knob.defaultProps);
     const className = classNames('p-knob p-component', {

--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -9,7 +9,7 @@ import { ListBoxItem } from './ListBoxItem';
 
 export const ListBox = React.memo(React.forwardRef((props, ref) => {
     const [filterValueState, setFilterValueState] = React.useState('');
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const virtualScrollerRef = React.useRef(null);
     const optionTouched = React.useRef(false);
     const filteredValue = (props.onFilterValueChange ? props.filterValue : filterValueState) || '';
@@ -253,6 +253,10 @@ export const ListBox = React.memo(React.forwardRef((props, ref) => {
     useMountEffect(() => {
         scrollToSelectedIndex();
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createHeader = () => {
         return props.filter ? <ListBoxHeader filter={filteredValue} onFilter={onFilter} disabled={props.disabled} filterPlaceholder={props.filterPlaceholder} filterInputProps={props.filterInputProps} /> : null;

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -10,7 +10,7 @@ export const MultiSelect = React.memo(React.forwardRef((props, ref) => {
     const [filterState, setFilterState] = React.useState('');
     const [focusedState, setFocusedState] = React.useState(false);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const inputRef = React.useRef(props.inputRef);
     const labelRef = React.useRef(null);
     const overlayRef = React.useRef(null);
@@ -503,6 +503,10 @@ export const MultiSelect = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     useUpdateEffect(() => {
         if (overlayVisibleState && hasFilter) {

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -6,7 +6,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const MultiStateCheckbox = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const equalityKey = props.optionValue ? null : props.dataKey;
 
     const onClick = (event) => {
@@ -81,6 +81,10 @@ export const MultiStateCheckbox = React.memo(React.forwardRef((props, ref) => {
             toggle();
         }
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createIcon = () => {
         const icon = (selectedOption && selectedOption.icon) || '';

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -6,7 +6,7 @@ import { OrderListSubList } from './OrderListSubList';
 
 export const OrderList = React.memo(React.forwardRef((props, ref) => {
     const [selectionState, setSelectionState] = React.useState([]);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const reorderDirection = React.useRef(null);
 
     const onItemClick = (event) => {
@@ -109,6 +109,10 @@ export const OrderList = React.memo(React.forwardRef((props, ref) => {
             reorderDirection.current = null;
         }
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const otherProps = ObjectUtils.findDiffKeys(props, OrderList.defaultProps);
     const className = classNames('p-orderlist p-component', props.className);

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -18,7 +18,7 @@ export const Password = React.memo(React.forwardRef((props, ref) => {
     const [infoTextState, setInfoTextState] = React.useState(promptLabel);
     const [focusedState, setFocusedState] = React.useState(false);
     const [unmaskedState, setUnmaskedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const overlayRef = React.useRef(null);
     const inputRef = React.useRef(props.inputRef);
     const mediumCheckRegExp = React.useRef(new RegExp(props.mediumRegex));
@@ -211,6 +211,10 @@ export const Password = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     React.useEffect(() => {
         mediumCheckRegExp.current = new RegExp(props.mediumRegex);

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -4,7 +4,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const RadioButton = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const inputRef = React.useRef(props.inputRef);
 
     const select = (e) => {
@@ -50,6 +50,10 @@ export const RadioButton = React.memo(React.forwardRef((props, ref) => {
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     React.useImperativeHandle(ref, () => ({
         select

--- a/components/lib/rating/Rating.js
+++ b/components/lib/rating/Rating.js
@@ -3,7 +3,7 @@ import { Tooltip } from '../tooltip/Tooltip';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Rating = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const enabled = !props.disabled && !props.readOnly;
     const tabIndex = enabled ? 0 : null;
 
@@ -75,6 +75,10 @@ export const Rating = React.memo(React.forwardRef((props, ref) => {
 
         return null;
     }
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, Rating.defaultProps);

--- a/components/lib/selectbutton/SelectButton.js
+++ b/components/lib/selectbutton/SelectButton.js
@@ -4,7 +4,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 import { SelectButtonItem } from './SelectButtonItem';
 
 export const SelectButton = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
 
     const onOptionClick = (event) => {
         if (props.disabled || isOptionDisabled(event.option)) {
@@ -89,6 +89,10 @@ export const SelectButton = React.memo(React.forwardRef((props, ref) => {
 
         return null;
     }
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, SelectButton.defaultProps);

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -3,7 +3,7 @@ import { useEventListener } from '../hooks/Hooks';
 import { classNames, DomHandler, ObjectUtils } from '../utils/Utils';
 
 export const Slider = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const handleIndex = React.useRef(0);
     const sliderHandleClick = React.useRef(false);
     const dragging = React.useRef(false);
@@ -19,6 +19,10 @@ export const Slider = React.memo(React.forwardRef((props, ref) => {
     const [bindDocumentMouseUpListener, unbindDocumentMouseUpListener] = useEventListener({ type: 'mouseup', listener: (event) => onDragEnd(event) });
     const [bindDocumentTouchMoveListener, unbindDocumentTouchMoveListener] = useEventListener({ type: 'touchmove', listener: (event) => onDrag(event) });
     const [bindDocumentTouchEndListener, unbindDocumentTouchEndListener] = useEventListener({ type: 'touchend', listener: (event) => onDragEnd(event) });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const spin = (event, dir) => {
         const val = props.range ? value[handleIndex.current] : value;

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -11,7 +11,7 @@ import { SplitButtonPanel } from './SplitButtonPanel';
 export const SplitButton = React.memo(React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const defaultButtonRef = React.useRef(null);
     const overlayRef = React.useRef(null);
 
@@ -83,6 +83,10 @@ export const SplitButton = React.memo(React.forwardRef((props, ref) => {
         show,
         hide
     }));
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createItems = () => {
         if (props.model) {

--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -5,7 +5,7 @@ import { useMountEffect, useEventListener } from '../hooks/Hooks';
 export const SplitterPanel = () => { }
 
 export const Splitter = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const gutterRef = React.useRef();
     const gutterRefs = React.useRef({});
     const size = React.useRef(null);
@@ -199,6 +199,10 @@ export const Splitter = React.memo(React.forwardRef((props, ref) => {
             }
         }
     });
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const createPanel = (panel, index) => {
         const otherProps = ObjectUtils.findDiffKeys(panel.props, SplitterPanel.defaultProps);

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -4,11 +4,15 @@ import { Tooltip } from '../tooltip/Tooltip';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const ToggleButton = React.memo(React.forwardRef((props, ref) => {
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
     const hasLabel = props.onLabel && props.onLabel.length > 0 && props.offLabel && props.offLabel.length > 0;
     const hasIcon = props.onIcon && props.onIcon.length > 0 && props.offIcon && props.offIcon.length > 0;
     const label = hasLabel ? (props.checked ? props.onLabel : props.offLabel) : '&nbsp;';
-    const icon = props.checked ? props.onIcon : props.offIcon
+    const icon = props.checked ? props.onIcon : props.offIcon;
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const toggle = (e) => {
         if (!props.disabled && props.onChange) {

--- a/components/lib/tristatecheckbox/TriStateCheckbox.js
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.js
@@ -5,7 +5,11 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const TriStateCheckbox = React.memo(React.forwardRef((props, ref) => {
     const [focusedState, setFocusedState] = React.useState(false);
-    const elementRef = React.useRef(null);
+    const elementRef = React.useRef(ref);
+
+    React.useEffect(() => {
+        ObjectUtils.combinedRefs(elementRef, ref);
+    }, [elementRef, ref]);
 
     const onClick = (event) => {
         if (!props.disabled && !props.readOnly) {


### PR DESCRIPTION
###Defect Fixes
Fix #2963: Allow access to ref

Many components were not forwarding the `ref` to the actual root `elementRef` of the component.