### PR TITLE
Fix #2974: Badge/Avatar typescript inheritance

### DIFF
--- a/components/lib/avatar/Avatar.d.ts
+++ b/components/lib/avatar/Avatar.d.ts
@@ -7,14 +7,12 @@ type AvatarShapeType = 'square' | 'circle';
 
 type AvatarTemplateType = React.ReactNode | ((props: AvatarProps) => React.ReactNode);
 
-export interface AvatarProps {
+export interface AvatarProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     label?: string;
     icon?: IconType<AvatarProps>;
     image?: string;
     size?: AvatarSizeType;
     shape?: AvatarShapeType;
-    style?: object;
-    className?: string;
     template?: AvatarTemplateType;
     imageAlt?: string;
     onImageError?(event: React.SyntheticEvent): void;

--- a/components/lib/badge/Badge.d.ts
+++ b/components/lib/badge/Badge.d.ts
@@ -4,12 +4,10 @@ type BadgeSeverityType = 'success' | 'info' | 'warn' | 'error' | (string & {});
 
 type BadgeSizeType = 'normal' | 'large' | 'xlarge';
 
-export interface BadgeProps {
+export interface BadgeProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, 'ref'> {
     value?: any;
     severity?: BadgeSeverityType;
     size?: BadgeSizeType;
-    style?: object;
-    className?: string;
     children?: React.ReactNode;
 }
 


### PR DESCRIPTION
###Defect Fixes
Fix #2974: Badge/Avatar typescript inheritance

Extends `div` and `span` to inherit all of Reacts props.