### PR TITLE
Fix #2981: dialog p-overflow-hidden wasn't removed from body on dialog

### DIFF
--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -291,7 +291,7 @@ export const Dialog = React.forwardRef((props, ref) => {
 
         if (props.modal) {
             let hasBlockScroll = document.primeDialogParams && document.primeDialogParams.some(param => param.hasBlockScroll);
-            if (!hasBlockScroll) {
+            if (hasBlockScroll) {
                 DomHandler.removeClass(document.body, 'p-overflow-hidden');
             }
         }


### PR DESCRIPTION
updated if check to remove `p-overflow-hidden` to revert document's original scrolling.
Issue: # 2981