### PR TITLE
Fix #2777: Check if `globalFilter` is not null before triggering filter

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1295,7 +1295,9 @@ export const DataTable = React.forwardRef((props, ref) => {
     }, [props.responsiveLayout]);
 
     useUpdateEffect(() => {
-        filter(props.globalFilter, 'global', 'contains');
+        if (props.globalFilter) {
+            filter(props.globalFilter, 'global', 'contains');
+        }
     }, [props.globalFilter]);
 
     useUnmountEffect(() => {


### PR DESCRIPTION
###Defect Fixes
Fix #2777: Check if `globalFilter` is not null before triggering filter

Check if `globalFilter` is not null before triggering filter in React 18 StrictMode when double-invoking effects (mount -> unmount -> mount)