### PR TITLE
Fix #2997: Badge 0 as a value not properly rendered

### DIFF
--- a/components/lib/badge/Badge.js
+++ b/components/lib/badge/Badge.js
@@ -4,8 +4,8 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 export const Badge = React.memo(React.forwardRef((props, ref) => {
     const otherProps = ObjectUtils.findDiffKeys(props, Badge.defaultProps);
     const className = classNames('p-badge p-component', {
-        'p-badge-no-gutter': props.value && String(props.value).length === 1,
-        'p-badge-dot': !props.value,
+        'p-badge-no-gutter': ObjectUtils.isNotEmpty(props.value) && String(props.value).length === 1,
+        'p-badge-dot': ObjectUtils.isEmpty(props.value),
         'p-badge-lg': props.size === 'large',
         'p-badge-xl': props.size === 'xlarge',
         [`p-badge-${props.severity}`]: props.severity !== null


### PR DESCRIPTION
###Defect Fixes
Fix #2997: Badge 0 as a value not properly rendered

these two should render identically.

```xml
      <Badge severity="info" value={0}></Badge>
      <Badge severity="info" value={"0"}></Badge>
```