### PR TITLE
Fix #3014: TreeTable sortMeta corrected

### DIFF
--- a/components/lib/treetable/TreeTable.d.ts
+++ b/components/lib/treetable/TreeTable.d.ts
@@ -41,8 +41,8 @@ type TreeTableExpandedKeysType = {
 }
 
 interface TreeTableSortMeta {
-    sortField: string;
-    sortOrder: TreeTableSortOrderType;
+    field: string;
+    order: TreeTableSortOrderType;
 }
 
 interface TreeTableFilterMetaData {


### PR DESCRIPTION
###Defect Fixes
Fix #3014: TreeTable sortMeta corrected

`sortOrder` and `sortField` are actually just `order` and `field`