### PR TITLE
Fix #3016: InputMask StrictMode fix

### DIFF
--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -517,7 +517,9 @@ export const InputMask = React.memo(React.forwardRef((props, ref) => {
     useUpdateEffect(() => {
         init();
         caret(updateValue(true));
-        updateModel();
+        if (props.unmask) {
+            updateModel();
+        }
     }, [props.mask]);
 
     useUpdateEffect(() => {


### PR DESCRIPTION
###Defect Fixes
Fix #3016: InputMask StrictMode fix

After debugging in strict mode this is the only spot where `updateModel` is called without and event so it was resetting the value back to `''` in StrictMode because it was using the `e.target` value.