### PR TITLE
Fix #3023: Sort nulls like Excel by default at bottom

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -861,8 +861,8 @@ export const DataTable = React.forwardRef((props, ref) => {
         return props.removableSort ? (props.defaultSortOrder === currentOrder ? currentOrder * -1 : 0) : currentOrder * -1;
     }
 
-    const compareValuesOnSort = (value1, value2) => {
-        return ObjectUtils.sort(value1, value2, 1, PrimeReact.locale);
+    const compareValuesOnSort = (value1, value2, order) => {
+        return ObjectUtils.sort(value1, value2, order, PrimeReact.locale);
     }
 
     const addSortMeta = (meta, multiSortMeta) => {
@@ -904,9 +904,8 @@ export const DataTable = React.forwardRef((props, ref) => {
             value.sort((data1, data2) => {
                 const value1 = ObjectUtils.resolveFieldData(data1, field);
                 const value2 = ObjectUtils.resolveFieldData(data2, field);
-                const result = compareValuesOnSort(value1, value2);
 
-                return (order * result);
+                return compareValuesOnSort(value1, value2, order);;
             });
         }
 
@@ -953,9 +952,7 @@ export const DataTable = React.forwardRef((props, ref) => {
             return (multiSortMeta.length - 1) > (index) ? (multisortField(data1, data2, multiSortMeta, index + 1)) : 0;
         }
 
-        const result = compareValuesOnSort(value1, value2);
-
-        return (multiSortMeta[index].order * result);
+        return compareValuesOnSort(value1, value2, multiSortMeta[index].order);
     }
 
     const onFilterChange = (filters) => {

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -190,12 +190,15 @@ export default class ObjectUtils {
     static sort(value1, value2, order = 1, locale) {
         let result = null;
 
-        if (value1 == null && value2 != null)
-            result = -1;
-        else if (value1 != null && value2 == null)
-            result = 1;
-        else if (value1 == null && value2 == null)
+        const emptyValue1 = this.isEmpty(value1); 
+        const emptyValue2 = this.isEmpty(value2);
+
+        if (emptyValue1 && emptyValue2)
             result = 0;
+        else if (emptyValue1)
+            result = order; // sort nulls at bottom like Excel
+        else if (emptyValue2)
+            result = -order; // sort nulls at bottom like Excel
         else if (typeof value1 === 'string' && typeof value2 === 'string')
             result = value1.localeCompare(value2, locale, { numeric: true });
         else


### PR DESCRIPTION
###Feature Requests
Fix #3023: Sort nulls like Excel by default at bottom

This always sorts NULLs at the bottom which is the way Excel does it by default.