### PR TITLE
Fix #3031: Image add onError callback

### DIFF
--- a/components/lib/image/Image.d.ts
+++ b/components/lib/image/Image.d.ts
@@ -1,10 +1,8 @@
 import * as React from 'react';
 
-export interface ImageProps {
+export interface ImageProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, 'ref'> {
     preview?: boolean;
-    className?: string;
     downloadable?: boolean;
-    style?: string;
     imageStyle?: string;
     imageClassName?: string;
     template?: any;

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -152,10 +152,10 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     const element = createElement();
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : <i className="p-image-preview-icon pi pi-eye"></i>;
     const preview = createPreview();
-    const image = <img src={src} className={props.imageClassName} width={width} height={height} style={props.imageStyle} alt={alt} />;
+    const image = <img src={src} className={props.imageClassName} width={width} height={height} style={props.imageStyle} alt={alt} onError={props.onError} />;
 
     return (
-        <span ref={elementRef} className={containerClassName} style={props.style} {...otherProps}>
+        <span ref={elementRef} className={containerClassName} {...otherProps}>
             {image}
             {preview}
             {maskVisibleState && <Portal element={element} appendTo={document.body} />}
@@ -169,12 +169,12 @@ Image.defaultProps = {
     preview: false,
     className: null,
     downloadable: false,
-    style: null,
     imageStyle: null,
     imageClassName: null,
     template: null,
     src: null,
     alt: null,
     width: null,
-    height: null
+    height: null,
+    onError: null
 }


### PR DESCRIPTION
###Defect Fixes
Fix #3031: Image add onError callback

Extending `span` element adds the necessary onError and other methods.  The OnError is added to the Image and not the SPAN.