### PR TITLE
Fix #3033: Autocomplete form submit on ENTER if no item highlighted

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -277,9 +277,9 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
                     if (highlightItem) {
                         selectHighlightItem(event, highlightItem);
                         hide();
+                        event.preventDefault();
                     }
 
-                    event.preventDefault();
                     break;
 
                 //escape


### PR DESCRIPTION
###Defect Fixes
Fix #3033: Autocomplete form submit on ENTER if no item highlighted

This makes it work just like it does when the dropdown panel is not displayed it submits the form.  The only way ENTER won't submit the form is if a dropdown item is highlighted then it will simply select the item