### PR TITLE
Fix #2893: Remove imperativeHandle as it blocks access to ref

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -453,10 +453,6 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(overlayRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        search
-    }));
-
     const createSimpleAutoComplete = () => {
         const value = formatValue(props.value);
         const ariaControls = overlayVisibleState ? idState + '_list' : null;

--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -62,11 +62,6 @@ export const BlockUI = React.forwardRef((props, ref) => {
         ZIndexUtils.clear(maskRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        block,
-        unblock
-    }));
-
     const createMask = () => {
         if (visibleState) {
             const appendTo = props.fullScreen ? document.body : 'self';

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2479,14 +2479,6 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(overlayRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        hide,
-        getCurrentDateTime,
-        getViewDate,
-        updateViewDate
-    }));
-
     const createBackwardNavigator = (isVisible) => {
         const navigatorProps = isVisible ? { 'onClick': onPrevButtonClick, 'onKeyDown': e => onContainerButtonKeydown(e) } : { 'style': { visibility: 'hidden' } };
         return (

--- a/components/lib/captcha/Captcha.js
+++ b/components/lib/captcha/Captcha.js
@@ -80,11 +80,6 @@ export const Captcha = React.memo(React.forwardRef((props, ref) => {
         }
     });
 
-    React.useImperativeHandle(ref, () => ({
-        reset,
-        getResponse
-    }));
-
     const otherProps = ObjectUtils.findDiffKeys(props, Captcha.defaultProps);
 
     return <div ref={elementRef} id={props.id} {...otherProps}></div>

--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -93,10 +93,6 @@ export const ConfirmDialog = React.memo(React.forwardRef((props, ref) => {
         OverlayService.off('confirm-dialog', confirm);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        confirm
-    }));
-
     const createFooter = () => {
         const acceptClassName = classNames('p-confirm-dialog-accept', getPropValue('acceptClassName'));
         const rejectClassName = classNames('p-confirm-dialog-reject', {

--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -178,10 +178,6 @@ export const ConfirmPopup = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(overlayRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        confirm
-    }));
-
     const createContent = () => {
         const currentProps = getCurrentProps();
         const message = ObjectUtils.getJSXElement(getPropValue('message'), currentProps);

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -163,11 +163,6 @@ export const ContextMenu = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(menuRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        hide
-    }));
-
     const createContextMenu = () => {
         const otherProps = ObjectUtils.findDiffKeys(props, ContextMenu.defaultProps);
         const className = classNames('p-contextmenu p-component', props.className);

--- a/components/lib/datascroller/DataScroller.js
+++ b/components/lib/datascroller/DataScroller.js
@@ -140,11 +140,6 @@ export const DataScroller = React.memo(React.forwardRef((props, ref) => {
         }
     });
 
-    React.useImperativeHandle(ref, () => ({
-        load,
-        reset
-    }));
-
     const createHeader = () => {
         if (props.header) {
             return <div className="p-datascroller-header">{props.header}</div>

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1316,17 +1316,6 @@ export const DataTable = React.forwardRef((props, ref) => {
         destroyResponsiveStyle();
     });
 
-    React.useImperativeHandle(ref, () => ({
-        reset,
-        resetScroll,
-        exportCSV,
-        filter,
-        resetColumnOrder,
-        closeEditingCell,
-        restoreTableState,
-        clearState
-    }));
-
     const createLoader = () => {
         if (props.loading) {
             const iconClassName = classNames('p-datatable-loading-icon pi-spin', props.loadingIcon);

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -398,10 +398,6 @@ export const Dialog = React.forwardRef((props, ref) => {
         ZIndexUtils.clear(maskRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        resetPosition
-    }));
-
     const createCloseIcon = () => {
         if (props.closable) {
             return (

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -312,12 +312,6 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
         !disabled && hasFiles ? upload() : fileInputRef.current.click();
     }
 
-    React.useImperativeHandle(ref, () => ({
-        upload,
-        clear,
-        formatSize
-    }));
-
     const createChooseButton = () => {
         const { className, style, icon: _icon, iconOnly } = props.chooseOptions;
         const chooseClassName = classNames('p-button p-fileupload-choose p-component', {

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -101,14 +101,6 @@ export const Galleria = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(maskRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        hide,
-        isAutoPlayActive,
-        startSlideShow,
-        stopSlideShow
-    }));
-
     const createHeader = () => {
         if (props.header) {
             return (

--- a/components/lib/gmap/GMap.js
+++ b/components/lib/gmap/GMap.js
@@ -110,10 +110,6 @@ export const GMap = React.memo(React.forwardRef((props, ref) => {
         }
     });
 
-    React.useImperativeHandle(ref, () => ({
-        getMap
-    }));
-
     const otherProps = ObjectUtils.findDiffKeys(props, GMap.defaultProps);
 
     return <div ref={elementRef} style={props.style} className={props.className} {...otherProps}></div>

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -933,10 +933,6 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
         return numberFormat.current;
     }
 
-    React.useImperativeHandle(ref, () => ({
-        getFormatter
-    }));
-
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -121,12 +121,6 @@ export const Menu = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(menuRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        toggle,
-        show,
-        hide
-    }));
-
     const createSubmenu = (submenu, index) => {
         const key = submenu.label + '_' + index;
         const className = classNames('p-submenu-header', {

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -47,11 +47,6 @@ export const Menubar = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(rootMenuRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        toggle,
-        useCustomContent
-    }));
-
     const createStartContent = () => {
         if (props.start) {
             const start = ObjectUtils.getJSXElement(props.start, props);

--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -42,12 +42,6 @@ export const Messages = React.memo(React.forwardRef((props, ref) => {
         props.onRemove && props.onRemove(message);
     }
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        replace,
-        clear
-    }));
-
     const otherProps = ObjectUtils.findDiffKeys(props, Messages.defaultProps);
 
     return (

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -173,12 +173,6 @@ export const OverlayPanel = React.forwardRef((props, ref) => {
         ZIndexUtils.clear(overlayRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        toggle,
-        show,
-        hide
-    }));
-
     const createCloseIcon = () => {
         if (props.showCloseIcon) {
             return (

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -51,10 +51,6 @@ export const RadioButton = React.memo(React.forwardRef((props, ref) => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);
 
-    React.useImperativeHandle(ref, () => ({
-        select
-    }));
-
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, RadioButton.defaultProps);
     const className = classNames('p-radiobutton p-component', {

--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -148,10 +148,6 @@ export const ScrollPanel = React.forwardRef((props, ref) => {
         }
     });
 
-    React.useImperativeHandle(ref, () => ({
-        refresh
-    }));
-
     const otherProps = ObjectUtils.findDiffKeys(props, ScrollPanel.defaultProps);
     const className = classNames('p-scrollpanel p-component', props.className);
 

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -85,12 +85,6 @@ export const SlideMenu = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(menuRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        toggle,
-        show,
-        hide
-    }));
-
     const createBackward = () => {
         const className = classNames('p-slidemenu-backward', {
             'p-hidden': levelState === 0

--- a/components/lib/speeddial/SpeedDial.js
+++ b/components/lib/speeddial/SpeedDial.js
@@ -145,11 +145,6 @@ export const SpeedDial = React.memo(React.forwardRef((props, ref) => {
         }
     }, [visibleState]);
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        hide
-    }));
-
     const createItem = (item, index) => {
         const style = getItemStyle(index);
         const { disabled, icon: _icon, label, template, url, target } = item;

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -79,11 +79,6 @@ export const SplitButton = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(overlayRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        hide
-    }));
-
     const createItems = () => {
         if (props.model) {
             return props.model.map((menuitem, index) => {

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -145,10 +145,6 @@ export const TabView = React.forwardRef((props, ref) => {
         updateScrollBar(props.activeIndex);
     }, [props.activeIndex]);
 
-    React.useImperativeHandle(ref, () => ({
-        reset
-    }));
-
     const createTabHeader = (tab, index) => {
         const selected = isSelected(index);
         const { headerStyle, headerClassName, style: _style, className: _className, disabled, leftIcon, rightIcon, header, headerTemplate, closable } = tab.props;

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -70,12 +70,6 @@ export const TieredMenu = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(menuRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        toggle,
-        show,
-        hide
-    }));
-
     const createElement = () => {
         const otherProps = ObjectUtils.findDiffKeys(props, TieredMenu.defaultProps);
         const className = classNames('p-tieredmenu p-component', {

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -65,12 +65,6 @@ export const Toast = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(containerRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        show,
-        replace,
-        clear
-    }));
-
     const createElement = () => {
         const otherProps = ObjectUtils.findDiffKeys(props, Toast.defaultProps);
         const className = classNames('p-toast p-component p-toast-' + props.position, props.className);

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -429,12 +429,6 @@ export const Tooltip = React.memo(React.forwardRef((props, ref) => {
         ZIndexUtils.clear(elementRef.current);
     });
 
-    React.useImperativeHandle(ref, () => ({
-        updateTargetEvents,
-        loadTargetEvents,
-        unloadTargetEvents
-    }));
-
     const createElement = () => {
         const otherProps = ObjectUtils.findDiffKeys(props, Tooltip.defaultProps);
         const tooltipClassName = classNames('p-tooltip p-component', {

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -285,10 +285,6 @@ export const Tree = React.memo(React.forwardRef((props, ref) => {
         return matched;
     }
 
-    React.useImperativeHandle(ref, () => ({
-        filter
-    }));
-
     const createRootChild = (node, index, last) => {
         return (
             <UITreeNode key={node.key || node.label} node={node} index={index} last={last} path={String(index)} disabled={props.disabled} selectionMode={props.selectionMode}

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -790,10 +790,6 @@ export const TreeTable = React.forwardRef((props, ref) => {
         return data;
     }
 
-    React.useImperativeHandle(ref, () => ({
-        filter
-    }));
-
     const createTableHeader = (columns, columnGroup) => {
         const sortField = getSortField();
         const sortOrder = getSortOrder();


### PR DESCRIPTION
###Defect Fixes
Fix #2893: Remove imperativeHandle as it blocks access to ref

I have confirmed this break code that worked between 7.0 and 8.0 as for example in a DataTable I can no longer access `dtRef.current.exportFileName` or any other Datatable property.