### PR TITLE
Fix #2963: Expose ref and element

### DIFF
--- a/components/lib/accordion/Accordion.d.ts
+++ b/components/lib/accordion/Accordion.d.ts
@@ -26,11 +26,8 @@ interface AccordionEventParams {
     index: number;
 }
 
-export interface AccordionProps {
-    id?: string;
+export interface AccordionProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     activeIndex?: AccordionActiveIndexType;
-    className?: string;
-    style?: object;
     multiple?: boolean;
     expandIcon?: IconType<AccordionProps>;
     collapseIcon?: IconType<AccordionProps>;
@@ -42,4 +39,6 @@ export interface AccordionProps {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-export declare class Accordion extends React.Component<AccordionProps, any> { }
+export declare class Accordion extends React.Component<AccordionProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -8,6 +8,7 @@ export const AccordionTab = () => { }
 export const Accordion = React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
     const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
+    const elementRef = React.useRef(null);
     const activeIndex = props.onTabChange ? props.activeIndex : activeIndexState;
 
     const shouldUseTab = (tab) => tab && tab.props.__TYPE === 'AccordionTab';
@@ -45,6 +46,11 @@ export const Accordion = React.forwardRef((props, ref) => {
     const isSelected = (index) => {
         return props.multiple ? (activeIndex && activeIndex.some(i => i === index)) : activeIndex === index;
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     useMountEffect(() => {
         if (!idState) {
@@ -123,7 +129,7 @@ export const Accordion = React.forwardRef((props, ref) => {
     const tabs = createTabs();
 
     return (
-        <div id={idState} className={className} style={props.style} {...otherProps}>
+        <div id={idState} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {tabs}
         </div>
     )

--- a/components/lib/autocomplete/AutoComplete.d.ts
+++ b/components/lib/autocomplete/AutoComplete.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import { VirtualScrollerProps } from '../virtualscroller';
+import { VirtualScrollerProps, VirtualScroller } from '../virtualscroller';
 import { CSSTransitionProps } from '../csstransition';
 import { IconType } from '../utils';
 
@@ -109,4 +109,8 @@ export interface AutoCompleteProps extends Omit<React.DetailedHTMLProps<React.In
 
 export declare class AutoComplete extends React.Component<AutoCompleteProps, any> {
     public search(event:React.SyntheticEvent, query:string, source: AutoCompleteSourceType): void;
+    public getElement(): HTMLSpanElement;
+    public getInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
+    public getVirtualScroller(): VirtualScroller;
 }

--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -455,6 +455,10 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         search,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        getVirtualScroller: () => virtualScrollerRef.current,
         ...props
     }));
 

--- a/components/lib/avatar/Avatar.d.ts
+++ b/components/lib/avatar/Avatar.d.ts
@@ -20,4 +20,6 @@ export interface AvatarProps extends Omit<React.DetailedHTMLProps<React.HTMLAttr
     children?: React.ReactNode;
 }
 
-export declare class Avatar extends React.Component<AvatarProps, any> { }
+export declare class Avatar extends React.Component<AvatarProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/avatar/Avatar.js
+++ b/components/lib/avatar/Avatar.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Avatar = React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const createContent = () => {
         if (props.image) {
@@ -17,6 +18,11 @@ export const Avatar = React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Avatar.defaultProps);
     const containerClassName = classNames('p-avatar p-component', {
         'p-avatar-image': props.image != null,
@@ -29,7 +35,7 @@ export const Avatar = React.forwardRef((props, ref) => {
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();
 
     return (
-        <div className={containerClassName} style={props.style} {...otherProps}>
+        <div ref={elementRef} className={containerClassName} style={props.style} {...otherProps}>
             {content}
             {props.children}
         </div>

--- a/components/lib/avatargroup/AvatarGroup.d.ts
+++ b/components/lib/avatargroup/AvatarGroup.d.ts
@@ -1,9 +1,9 @@
 import * as React from 'react';
 
-export interface AvatarGroupProps {
-    style?: object;
-    className?: string;
+export interface AvatarGroupProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     children?: React.ReactNode;
 }
 
-export declare class AvatarGroup extends React.Component<AvatarGroupProps, any> { }
+export declare class AvatarGroup extends React.Component<AvatarGroupProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/avatargroup/AvatarGroup.js
+++ b/components/lib/avatargroup/AvatarGroup.js
@@ -2,11 +2,17 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const AvatarGroup = React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, AvatarGroup.defaultProps);
     const className = classNames('p-avatar-group p-component', props.className);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <div className={className} style={props.style} {...otherProps}>
+        <div ref={elementRef} className={className} style={props.style} {...otherProps}>
             {props.children}
         </div>
     )

--- a/components/lib/badge/Badge.d.ts
+++ b/components/lib/badge/Badge.d.ts
@@ -11,4 +11,6 @@ export interface BadgeProps extends Omit<React.DetailedHTMLProps<React.HTMLAttri
     children?: React.ReactNode;
 }
 
-export declare class Badge extends React.Component<BadgeProps, any> { }
+export declare class Badge extends React.Component<BadgeProps, any> {
+    public getElement(): HTMLSpanElement;
+ }

--- a/components/lib/badge/Badge.js
+++ b/components/lib/badge/Badge.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Badge = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, Badge.defaultProps);
     const className = classNames('p-badge p-component', {
         'p-badge-no-gutter': ObjectUtils.isNotEmpty(props.value) && String(props.value).length === 1,
@@ -11,8 +12,13 @@ export const Badge = React.memo(React.forwardRef((props, ref) => {
         [`p-badge-${props.severity}`]: props.severity !== null
     }, props.className);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <span className={className} style={props.style} {...otherProps}>
+        <span ref={elementRef} className={className} style={props.style} {...otherProps}>
             {props.value}
         </span>
     )

--- a/components/lib/blockui/BlockUI.d.ts
+++ b/components/lib/blockui/BlockUI.d.ts
@@ -2,14 +2,11 @@ import * as React from 'react';
 
 type BlockUITemplateType = React.ReactNode | ((props: BlockUIProps) => React.ReactNode);
 
-export interface BlockUIProps {
-    id?: string;
+export interface BlockUIProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     blocked?: boolean;
     fullScreen?: boolean;
     baseZIndex?: number;
     autoZIndex?: boolean;
-    style?: object;
-    className?: string;
     template?: BlockUITemplateType;
     onBlocked?(): void;
     onUnblocked?(): void;
@@ -19,4 +16,5 @@ export interface BlockUIProps {
 export declare class BlockUI extends React.Component<BlockUIProps, any> {
     public block(): void;
     public unblock(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -6,6 +6,7 @@ import { classNames, DomHandler, ObjectUtils, ZIndexUtils } from '../utils/Utils
 
 export const BlockUI = React.forwardRef((props, ref) => {
     const [visibleState, setVisibleState] = React.useState(props.blocked);
+    const elementRef = React.useRef(null);
     const maskRef = React.useRef(null);
 
     const block = () => {
@@ -65,6 +66,7 @@ export const BlockUI = React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         block,
         unblock,
+        getElement: () => elementRef.current,
         ...props
     }));
 
@@ -91,7 +93,7 @@ export const BlockUI = React.forwardRef((props, ref) => {
     const mask = createMask();
 
     return (
-        <div id={props.id} className="p-blockui-container" {...otherProps}>
+        <div id={props.id} ref={elementRef} className="p-blockui-container" {...otherProps}>
             {props.children}
             {mask}
         </div>

--- a/components/lib/breadcrumb/BreadCrumb.d.ts
+++ b/components/lib/breadcrumb/BreadCrumb.d.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { MenuItem } from '../menuitem';
 
-export interface BreadCrumbProps {
-    id?: string;
+export interface BreadCrumbProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>, 'ref'> {
     model?: MenuItem[];
     home?: MenuItem;
-    style?: object;
-    className?: string;
     children?: React.ReactNode;
 }
 
-export declare class BreadCrumb extends React.Component<BreadCrumbProps, any> { }
+export declare class BreadCrumb extends React.Component<BreadCrumbProps, any> { 
+    public getElement(): HTMLElement;
+}

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const itemClick = (event, item) => {
         if (item.disabled) {
@@ -110,6 +111,11 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, BreadCrumb.defaultProps);
     const className = classNames('p-breadcrumb p-component', props.className);
     const home = createHome();
@@ -117,7 +123,7 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
     const separator = createSeparator();
 
     return (
-        <nav id={props.id} className={className} style={props.style} aria-label="Breadcrumb" {...otherProps}>
+        <nav id={props.id} ref={elementRef} className={className} style={props.style} aria-label="Breadcrumb" {...otherProps}>
             <ul>
                 {home}
                 {separator}

--- a/components/lib/button/Button.d.ts
+++ b/components/lib/button/Button.d.ts
@@ -18,4 +18,6 @@ export interface ButtonProps extends Omit<React.DetailedHTMLProps<React.ButtonHT
     children?: React.ReactNode;
 }
 
-export declare class Button extends React.Component<ButtonProps, any> { }
+export declare class Button extends React.Component<ButtonProps, any> { 
+    public getElement(): HTMLButtonElement;
+}

--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -38,6 +38,11 @@ export const Button = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const disabled = props.disabled || props.loading;
     const otherProps = ObjectUtils.findDiffKeys(props, Button.defaultProps);

--- a/components/lib/calendar/Calendar.d.ts
+++ b/components/lib/calendar/Calendar.d.ts
@@ -165,5 +165,8 @@ export declare class Calendar extends React.Component<CalendarProps, any> {
     public hide(): void;
     public getCurrentDateTime(): Date | Date[];
     public getViewDate(): Date | Date[];
+    public getElement(): HTMLSpanElement;
+    public getInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
     public updateViewDate(event: CalendarEventType, value: Date | Date[]): void;
 }

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2485,6 +2485,9 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
         getCurrentDateTime,
         getViewDate,
         updateViewDate,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
         ...props
     }));
 

--- a/components/lib/captcha/Captcha.d.ts
+++ b/components/lib/captcha/Captcha.d.ts
@@ -1,12 +1,10 @@
 import * as React from 'react';
 
-export interface CaptchaProps {
-    id?: string;
+export interface CaptchaProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     siteKey?: string;
     theme?: string;
     type?: string;
     size?: string;
-    tabIndex?: number;
     language?: string;
     onResponse?(response: any): void;
     onExpire?(): void;
@@ -16,4 +14,5 @@ export interface CaptchaProps {
 export declare class Captcha extends React.Component<CaptchaProps, any> {
     public reset(): void;
     public getResponse(): any;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/captcha/Captcha.js
+++ b/components/lib/captcha/Captcha.js
@@ -83,6 +83,7 @@ export const Captcha = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         reset,
         getResponse,
+        getElement: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/carousel/Carousel.d.ts
+++ b/components/lib/carousel/Carousel.d.ts
@@ -12,14 +12,11 @@ interface CarouselPageChangeParams {
     page: number;
 }
 
-export interface CarouselProps {
-    id?: string;
+export interface CarouselProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: any[];
     page?: number;
     header?: React.ReactNode;
     footer?: React.ReactNode;
-    style?: object;
-    className?: string;
     itemTemplate?(item: any): React.ReactNode;
     circular?: boolean;
     autoplayInterval?: number;
@@ -35,4 +32,6 @@ export interface CarouselProps {
     children?: React.ReactNode;
 }
 
-export declare class Carousel extends React.Component<CarouselProps, any> { }
+export declare class Carousel extends React.Component<CarouselProps, any> {
+    public getElement(): HTMLDivElement;
+ }

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -286,6 +286,11 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         if (elementRef.current) {
             attributeSelector.current = UniqueComponentId();

--- a/components/lib/cascadeselect/CascadeSelect.d.ts
+++ b/components/lib/cascadeselect/CascadeSelect.d.ts
@@ -44,4 +44,9 @@ export interface CascadeSelectProps extends Omit<React.DetailedHTMLProps<React.I
     children?: React.ReactNode;
 }
 
-export declare class CascadeSelect extends React.Component<CascadeSelectProps, any> { }
+export declare class CascadeSelect extends React.Component<CascadeSelectProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
+    public getLabel(): HTMLSpanElement;
+}

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -182,6 +182,14 @@ export const CascadeSelect = React.memo(React.forwardRef((props, ref) => {
         DomHandler.alignOverlay(overlayRef.current, labelRef.current.parentElement, props.appendTo || PrimeReact.appendTo);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        getLabel: () => labelRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/chart/Chart.d.ts
+++ b/components/lib/chart/Chart.d.ts
@@ -19,4 +19,5 @@ export declare class Chart extends React.Component<ChartProps, any> {
     public getBase64Image(): any;
     public generateLegend(): string;
     public refresh(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -3,6 +3,7 @@ import { useUnmountEffect } from '../hooks/Hooks';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Chart = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const chartRef = React.useRef(null);
     const canvasRef = React.useRef(null);
 
@@ -34,6 +35,7 @@ export const Chart = React.memo(React.forwardRef((props, ref) => {
         getCanvas: () => canvasRef.current,
         getChart: () => chartRef.current,
         getBase64Image: () => chartRef.current.toBase64Image(),
+        getElement: () => elementRef.current,
         generateLegend: () => chartRef.current && chartRef.current.generateLegend(),
         refresh: () => chartRef.current && chartRef.current.update(),
         ...props
@@ -55,7 +57,7 @@ export const Chart = React.memo(React.forwardRef((props, ref) => {
     const style = Object.assign({ width: props.width, height: props.height }, props.style);
 
     return (
-        <div id={props.id} style={style} className={className} {...otherProps}>
+        <div id={props.id} ref={elementRef} style={style} className={className} {...otherProps}>
             <canvas ref={canvasRef} width={props.width} height={props.height}></canvas>
         </div>
     );

--- a/components/lib/checkbox/Checkbox.d.ts
+++ b/components/lib/checkbox/Checkbox.d.ts
@@ -43,4 +43,7 @@ export interface CheckboxProps extends Omit<React.DetailedHTMLProps<React.InputH
     children?: React.ReactNode;
 }
 
-export declare class Checkbox extends React.Component<CheckboxProps, any> { }
+export declare class Checkbox extends React.Component<CheckboxProps, any> {
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+ }

--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -45,6 +45,12 @@ export const Checkbox = React.memo(React.forwardRef((props, ref) => {
         return props.checked === props.trueValue;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/chip/Chip.d.ts
+++ b/components/lib/chip/Chip.d.ts
@@ -14,4 +14,6 @@ export interface ChipProps extends Omit<React.DetailedHTMLProps<React.HTMLAttrib
     children?: React.ReactNode;
 }
 
-export declare class Chip extends React.Component<ChipProps, any> { }
+export declare class Chip extends React.Component<ChipProps, any> {
+    public getElement(): HTMLDivElement;
+ }

--- a/components/lib/chip/Chip.js
+++ b/components/lib/chip/Chip.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Chip = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const [visibleState, setVisibleState] = React.useState(true);
 
     const onKeyDown = (event) => {
@@ -48,11 +49,16 @@ export const Chip = React.memo(React.forwardRef((props, ref) => {
         const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();
 
         return (
-            <div className={className} style={props.style} {...otherProps}>
+            <div ref={elementRef} className={className} style={props.style} {...otherProps}>
                 {content}
             </div>
         )
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     return visibleState && createElement();
 }));

--- a/components/lib/chips/Chips.d.ts
+++ b/components/lib/chips/Chips.d.ts
@@ -31,8 +31,7 @@ interface ChipsChangeParams {
     target: ChipsChangeTargetOptions;
 }
 
-export interface ChipsProps {
-    id?: string;
+export interface ChipsProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'onFocus' | 'onBlur' | 'onKeyDown' |'ref'> {
     inputRef?: React.Ref<HTMLInputElement>;
     inputId?: string;
     name?: string;
@@ -42,8 +41,6 @@ export interface ChipsProps {
     disabled?: boolean;
     readOnly?: boolean;
     removable?: ChipsRemovableType;
-    style?: object;
-    className?: string;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     ariaLabelledBy?: string;
@@ -60,4 +57,7 @@ export interface ChipsProps {
     children?: React.ReactNode;
 }
 
-export declare class Chips extends React.Component<ChipsProps, any> { }
+export declare class Chips extends React.Component<ChipsProps, any> {
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+ }

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -169,6 +169,12 @@ export const Chips = React.memo(React.forwardRef((props, ref) => {
         return ObjectUtils.getPropValue(props.removable, { value, index, props });
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/colorpicker/ColorPicker.d.ts
+++ b/components/lib/colorpicker/ColorPicker.d.ts
@@ -50,4 +50,10 @@ export interface ColorPickerProps extends Omit<React.DetailedHTMLProps<React.Inp
     children?: React.ReactNode;
 }
 
-export declare class ColorPicker extends React.Component<ColorPickerProps, any> { }
+export declare class ColorPicker extends React.Component<ColorPickerProps, any> {
+    public show(): void;
+    public hide(): void;
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
+ }

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -437,6 +437,15 @@ export const ColorPicker = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        show,
+        hide,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/contextmenu/ContextMenu.d.ts
+++ b/components/lib/contextmenu/ContextMenu.d.ts
@@ -4,11 +4,8 @@ import { CSSTransitionProps } from '../csstransition';
 
 type ContextMenuAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface ContextMenuProps {
-    id?: string;
+export interface ContextMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
-    style?: object;
-    className?: string;
     global?: boolean;
     autoZIndex?: boolean;
     baseZIndex?: number;
@@ -22,4 +19,5 @@ export interface ContextMenuProps {
 export declare class ContextMenu extends React.Component<ContextMenuProps, any> {
     public show(event: React.SyntheticEvent): void;
     public hide(event: React.SyntheticEvent): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -166,6 +166,7 @@ export const ContextMenu = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         show,
         hide,
+        getElement: () => menuRef.current,
         ...props
     }));
 

--- a/components/lib/datascroller/DataScroller.d.ts
+++ b/components/lib/datascroller/DataScroller.d.ts
@@ -7,16 +7,13 @@ interface DataScrollerLazyLoadParams {
     rows: number;
 }
 
-export interface DataScrollerProps {
-    id?: string;
+export interface DataScrollerProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: any[];
     rows?: number;
     inline?: boolean;
     scrollHeight?: string;
     loader?: boolean;
     buffer?: number;
-    style?: object;
-    className?: string;
     header?: React.ReactNode;
     footer?: React.ReactNode;
     lazy?: boolean;
@@ -28,4 +25,5 @@ export interface DataScrollerProps {
 
 export declare class DataScroller extends React.Component<DataScrollerProps, any> {
     public load(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/datascroller/DataScroller.js
+++ b/components/lib/datascroller/DataScroller.js
@@ -5,6 +5,7 @@ import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const DataScroller = React.memo(React.forwardRef((props, ref) => {
     const [dataToRenderState, setDataToRenderState] = React.useState([]);
+    const elementRef = React.useRef(null);
     const contentRef = React.useRef(null);
     const value = React.useRef(props.value);
     const dataToRender = React.useRef([]);
@@ -143,6 +144,8 @@ export const DataScroller = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         load,
         reset,
+        getElement: () => elementRef.current,
+        getContent: () => contentRef.current,
         ...props
     }));
 
@@ -200,7 +203,7 @@ export const DataScroller = React.memo(React.forwardRef((props, ref) => {
     const content = createContent();
 
     return (
-        <div id={props.id} className={className} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} {...otherProps}>
             {header}
             {content}
             {footer}

--- a/components/lib/datatable/DataTable.d.ts
+++ b/components/lib/datatable/DataTable.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Column } from '../column';
 import { PaginatorTemplate } from '../paginator';
-import { VirtualScrollerProps } from '../virtualscroller/virtualscroller';
+import { VirtualScrollerProps, VirtualScroller } from '../virtualscroller/virtualscroller';
 
 type DataTableHeaderTemplateType = React.ReactNode | ((options: DataTableHeaderTemplateOptions) => React.ReactNode);
 
@@ -371,4 +371,7 @@ export declare class DataTable extends React.Component<DataTableProps, any> {
     public closeEditingCell(): void;
     public restoreTableState(state: any): void;
     public clearState(): void;
+    public getElement(): HTMLDivElement;
+    public getTable(): HTMLTableElement;
+    public getVirtualScroller(): VirtualScroller;
 }

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1325,6 +1325,9 @@ export const DataTable = React.forwardRef((props, ref) => {
         closeEditingCell,
         restoreTableState,
         clearState,
+        getElement: () => elementRef.current,
+        getTable: () => tableRef.current,
+        getVirtualScroller: () => virtualScrollerRef.current,
         ...props
     }));
 

--- a/components/lib/dataview/DataView.d.ts
+++ b/components/lib/dataview/DataView.d.ts
@@ -32,8 +32,7 @@ export interface DataViewLayoutOptionsProps {
 
 export declare class DataViewLayoutOptions extends React.Component<DataViewLayoutOptionsProps, any> { }
 
-export interface DataViewProps {
-    id?: string;
+export interface DataViewProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     header?: React.ReactNode;
     footer?: React.ReactNode;
     value?: any[];
@@ -56,8 +55,6 @@ export interface DataViewProps {
     emptyMessage?: string;
     sortField?: string;
     sortOrder?: DataViewSortOrderType;
-    style?: object;
-    className?: string;
     lazy?: boolean;
     loading?: boolean;
     loadingIcon?: string;
@@ -68,4 +65,6 @@ export interface DataViewProps {
 }
 
 // tslint:disable-next-line:max-classes-per-file
-export declare class DataView extends React.Component<DataViewProps, any> { }
+export declare class DataView extends React.Component<DataViewProps, any> {
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -40,6 +40,7 @@ export const DataViewItem = React.memo((props) => {
 export const DataView = React.memo(React.forwardRef((props, ref) => {
     const [firstState, setFirstState] = React.useState(props.first);
     const [rowsState, setRowsState] = React.useState(props.rows);
+    const elementRef = React.useRef(null);
     const first = props.onPage ? props.first : firstState;
     const rows = props.onPage ? props.rows : rowsState;
 
@@ -195,6 +196,11 @@ export const DataView = React.memo(React.forwardRef((props, ref) => {
         return data;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const data = processData();
 
     const otherProps = ObjectUtils.findDiffKeys(props, DataView.defaultProps);
@@ -210,7 +216,7 @@ export const DataView = React.memo(React.forwardRef((props, ref) => {
     const content = createContent(data);
 
     return (
-        <div id={props.id} style={props.style} className={className} {...otherProps}>
+        <div id={props.id} ref={elementRef} style={props.style} className={className} {...otherProps}>
             {loader}
             {header}
             {topPaginator}

--- a/components/lib/deferredcontent/DeferredContent.d.ts
+++ b/components/lib/deferredcontent/DeferredContent.d.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
 
-export interface DeferredContentProps {
+export interface DeferredContentProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     onLoad?(event: React.SyntheticEvent): void;
     children?: React.ReactNode;
 }
 
-export declare class DeferredContent extends React.Component<DeferredContentProps, any> { }
+export declare class DeferredContent extends React.Component<DeferredContentProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/deferredcontent/DeferredContent.js
+++ b/components/lib/deferredcontent/DeferredContent.js
@@ -32,6 +32,11 @@ export const DeferredContent = React.forwardRef((props, ref) => {
         props.onLoad && props.onLoad(event);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         if (!loadedState) {
             shouldLoad() ? load() : bindScrollListener();

--- a/components/lib/dialog/Dialog.d.ts
+++ b/components/lib/dialog/Dialog.d.ts
@@ -67,4 +67,10 @@ export interface DialogProps {
 
 export declare class Dialog extends React.Component<DialogProps, any> {
     public resetPosition(): void;
+    public getElement(): HTMLDivElement;
+    public getMask(): HTMLDivElement;
+    public getContent(): HTMLDivElement;
+    public getHeader(): HTMLDivElement;
+    public getFooter(): HTMLDivElement;
+    public getCloseButton(): HTMLButtonElement;
 }

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -400,6 +400,12 @@ export const Dialog = React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         resetPosition,
+        getElement: () => dialogRef.current,
+        getMask: () => maskRef.current,
+        getContent: () => contentRef.current,
+        getHeader: () => headerRef.current,
+        getFooter: () => footerRef.current,
+        getCloseButton: () => closeRef.current,
         ...props
     }));
 

--- a/components/lib/divider/Divider.d.ts
+++ b/components/lib/divider/Divider.d.ts
@@ -6,13 +6,13 @@ type DividerLayoutType = 'vertical' | 'horizontal';
 
 type DividerBorderType = 'solid' | 'dashed' | 'dotted';
 
-export interface DividerProps {
+export interface DividerProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     align?: DividerAlignType;
     layout?: DividerLayoutType;
     type?: DividerBorderType;
-    style?: object;
-    className?: string;
     children?: React.ReactNode;
 }
 
-export declare class Divider extends React.Component<DividerProps, any> { }
+export declare class Divider extends React.Component<DividerProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/divider/Divider.js
+++ b/components/lib/divider/Divider.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Divider = React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const horizontal = props.layout === 'horizontal';
     const vertical = props.layout === 'vertical';
     const otherProps = ObjectUtils.findDiffKeys(props, Divider.defaultProps);
@@ -13,8 +14,13 @@ export const Divider = React.forwardRef((props, ref) => {
         'p-divider-bottom': vertical && props.align === 'bottom',
     }, props.className);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <div className={className} style={props.style} role="separator" {...otherProps}>
+        <div ref={elementRef} className={className} style={props.style} role="separator" {...otherProps}>
             <div className="p-divider-content">
                 {props.children}
             </div>

--- a/components/lib/dock/Dock.d.ts
+++ b/components/lib/dock/Dock.d.ts
@@ -13,10 +13,7 @@ interface DockHeaderTemplateOptions {
 
 interface DockFooterTemplateOptions extends DockHeaderTemplateOptions {}
 
-export interface DockProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface DockProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     position?: DockPositionType;
     magnification?: boolean;
@@ -25,4 +22,6 @@ export interface DockProps {
     children?: React.ReactNode;
 }
 
-export declare class Dock extends React.Component<DockProps, any> { }
+export declare class Dock extends React.Component<DockProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/dock/Dock.js
+++ b/components/lib/dock/Dock.js
@@ -4,6 +4,7 @@ import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Dock = React.memo(React.forwardRef((props, ref) => {
     const [currentIndexState, setCurrentIndexState] = React.useState(-3);
+    const elementRef = React.useRef(null);
 
     const onListMouseLeave = () => {
         setCurrentIndexState(-3);
@@ -101,6 +102,11 @@ export const Dock = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Dock.defaultProps);
     const className = classNames(`p-dock p-component p-dock-${props.position}`, {
         'p-dock-magnification': props.magnification
@@ -110,7 +116,7 @@ export const Dock = React.memo(React.forwardRef((props, ref) => {
     const footer = createFooter();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             <div className="p-dock-container">
                 {header}
                 {list}

--- a/components/lib/dropdown/Dropdown.d.ts
+++ b/components/lib/dropdown/Dropdown.d.ts
@@ -96,4 +96,9 @@ export interface DropdownProps extends Omit<React.DetailedHTMLProps<React.InputH
     children?: React.ReactNode;
 }
 
-export declare class Dropdown extends React.Component<DropdownProps, any> { }
+export declare class Dropdown extends React.Component<DropdownProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+    public getFocusInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
+}

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -548,6 +548,16 @@ export const Dropdown = React.memo(React.forwardRef((props, ref) => {
         return index !== -1 ? (props.optionGroupLabel ? getOptionGroupChildren(props.options[index.group])[index.option] : props.options[index]) : null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        show,
+        hide,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        getFocusInput: () => focusInputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/editor/Editor.d.ts
+++ b/components/lib/editor/Editor.d.ts
@@ -33,4 +33,7 @@ export interface EditorProps extends React.DetailedHTMLProps<React.InputHTMLAttr
 
 export declare class Editor extends React.Component<EditorProps, any> {
     public getQuill(): any;
+    public getElement(): HTMLDivElement;
+    public getContent(): HTMLDivElement;
+    public getToolbar(): HTMLDivElement;
 }

--- a/components/lib/editor/Editor.js
+++ b/components/lib/editor/Editor.js
@@ -3,14 +3,11 @@ import { useMountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { classNames, DomHandler, ObjectUtils } from '../utils/Utils';
 
 export const Editor = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const contentRef = React.useRef(null);
     const toolbarRef = React.useRef(null);
     const quill = React.useRef(null);
     const isQuillLoaded = React.useRef(false);
-
-    const getQuill = () => {
-        return quill.current;
-    }
 
     useMountEffect(() => {
         if (!isQuillLoaded.current) {
@@ -86,7 +83,10 @@ export const Editor = React.memo(React.forwardRef((props, ref) => {
     }, [props.value]);
 
     React.useImperativeHandle(ref, () => ({
-        getQuill,
+        getQuill: () => quill.current,
+        getElement: () => elementRef.current,
+        getContent: () => contentRef.current,
+        getToolbar: () => toolbarRef.current,
         ...props
     }));
 
@@ -154,7 +154,7 @@ export const Editor = React.memo(React.forwardRef((props, ref) => {
     const content = <div ref={contentRef} className="p-editor-content" style={props.style}></div>
 
     return (
-        <div id={props.id} className={className} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} {...otherProps}>
             {header}
             {content}
         </div>

--- a/components/lib/fieldset/Fieldset.d.ts
+++ b/components/lib/fieldset/Fieldset.d.ts
@@ -6,11 +6,8 @@ interface FieldsetToggleParams {
     value: boolean;
 }
 
-export interface FieldsetProps {
-    id?: string;
+export interface FieldsetProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLFieldSetElement>, HTMLFieldSetElement>, 'ref'> {
     legend?: React.ReactNode;
-    className?: string;
-    style?: object;
     toggleable?: boolean;
     collapsed?: boolean;
     transitionOptions?: CSSTransitionProps;
@@ -21,4 +18,7 @@ export interface FieldsetProps {
     children?: React.ReactNode;
 }
 
-export declare class Fieldset extends React.Component<FieldsetProps, any> { }
+export declare class Fieldset extends React.Component<FieldsetProps, any> { 
+    public getElement(): HTMLFieldSetElement;
+    public getContent(): HTMLDivElement;
+}

--- a/components/lib/fieldset/Fieldset.js
+++ b/components/lib/fieldset/Fieldset.js
@@ -8,6 +8,7 @@ export const Fieldset = React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
     const [collapsedState, setCollapsedState] = React.useState(props.collapsed);
     const collapsed = props.toggleable ? (props.onToggle ? props.collapsed : collapsedState) : false;
+    const elementRef = React.useRef(null);
     const contentRef = React.useRef(null);
     const headerId = idState + '_header';
     const contentId = idState + '_content';
@@ -102,6 +103,12 @@ export const Fieldset = React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getContent: () => contentRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Fieldset.defaultProps);
     const className = classNames('p-fieldset p-component', {
         'p-fieldset-toggleable': props.toggleable
@@ -110,7 +117,7 @@ export const Fieldset = React.forwardRef((props, ref) => {
     const content = createContent();
 
     return (
-        <fieldset id={idState} className={className} style={props.style} {...otherProps} onClick={props.onClick}>
+        <fieldset id={idState} ref={elementRef} className={className} style={props.style} {...otherProps} onClick={props.onClick}>
             {legend}
             {content}
         </fieldset>

--- a/components/lib/fileupload/FileUpload.d.ts
+++ b/components/lib/fileupload/FileUpload.d.ts
@@ -130,4 +130,6 @@ export declare class FileUpload extends React.Component<FileUploadProps, any> {
     public upload(): void;
     public clear(): void;
     public formatSize(bytes: number): number;
+    public getElement(): HTMLElement;
+    public getInput(): HTMLInputElement;
 }

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -316,6 +316,8 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
         upload,
         clear,
         formatSize,
+        getInput: () => fileInputRef.current,
+        getContent: () => contentRef.current,
         ...props
     }));
 

--- a/components/lib/fullcalendar/FullCalendar.d.ts
+++ b/components/lib/fullcalendar/FullCalendar.d.ts
@@ -9,4 +9,6 @@ export interface FullCalendarProps {
     children?: React.ReactNode;
 }
 
-export declare class FullCalendar extends React.Component<FullCalendarProps, any> { }
+export declare class FullCalendar extends React.Component<FullCalendarProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/fullcalendar/FullCalendar.js
+++ b/components/lib/fullcalendar/FullCalendar.js
@@ -23,6 +23,11 @@ export const FullCalendar = React.memo(React.forwardRef((props, ref) => {
         });
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         // eslint-disable-next-line no-console
         console.warn("FullCalendar component is deprecated. Use FullCalendar component of '@fullcalendar/react' package.");

--- a/components/lib/galleria/Galleria.d.ts
+++ b/components/lib/galleria/Galleria.d.ts
@@ -12,16 +12,13 @@ interface GalleriaItemChangeParams {
     index: number;
 }
 
-export interface GalleriaProps {
-    id?: string;
+export interface GalleriaProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: any[];
     activeIndex?: number;
     fullScreen?: boolean;
     item?(item: any): React.ReactNode;
     thumbnail?(item: any): React.ReactNode;
     indicator?(index: number): React.ReactNode;
-    className?: string;
-    style?: object;
     header?: React.ReactNode;
     footer?: React.ReactNode;
     numVisible?: number;
@@ -53,4 +50,5 @@ export declare class Galleria extends React.Component<GalleriaProps, any> {
     public isAutoPlayActive(): boolean;
     public startSlideShow(): void;
     public stopSlideShow(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -107,6 +107,8 @@ export const Galleria = React.memo(React.forwardRef((props, ref) => {
         isAutoPlayActive,
         startSlideShow,
         stopSlideShow,
+        getElement: () => elementRef.current,
+        getPreviewContent: () => previewContentRef.current,
         ...props
     }));
 

--- a/components/lib/gmap/GMap.d.ts
+++ b/components/lib/gmap/GMap.d.ts
@@ -6,11 +6,9 @@ interface GMapEventParams {
     map: any;
 }
 
-export interface GMapProps {
+export interface GMapProps  extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     options?: object;
     overlays?: any[];
-    style?: object;
-    className?: string;
     onMapReady?(map: any): void;
     onMapClick?(event: React.SyntheticEvent): void;
     onMapDragEnd?(): void;
@@ -22,4 +20,7 @@ export interface GMapProps {
     children?: React.ReactNode;
 }
 
-export declare class GMap extends React.Component<GMapProps, any> { }
+export declare class GMap extends React.Component<GMapProps, any> { 
+    public getMap(): any;
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/gmap/GMap.js
+++ b/components/lib/gmap/GMap.js
@@ -112,6 +112,7 @@ export const GMap = React.memo(React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         getMap,
+        getElement: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/image/Image.d.ts
+++ b/components/lib/image/Image.d.ts
@@ -15,4 +15,7 @@ export interface ImageProps extends Omit<React.DetailedHTMLProps<React.HTMLAttri
     children?: React.ReactNode;
 }
 
-export declare class Image extends React.Component<ImageProps, any> { }
+export declare class Image extends React.Component<ImageProps, any> { 
+    public getElement(): HTMLSpanElement;
+    public getImage(): HTMLImageElement;
+}

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -11,6 +11,7 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     const [rotateState, setRotateState] = React.useState(0);
     const [scaleState, setScaleState] = React.useState(1);
     const elementRef = React.useRef(null);
+    const imageRef = React.useRef(null);
     const maskRef = React.useRef(null);
     const previewRef = React.useRef(null);
     const previewClick = React.useRef(false);
@@ -144,6 +145,12 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
         )
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getImage: () => imageRef.current,
+        ...props
+    }));
+
     const { src, alt, width, height } = props;
     const otherProps = ObjectUtils.findDiffKeys(props, Image.defaultProps);
     const containerClassName = classNames('p-image p-component', props.className, {
@@ -152,7 +159,7 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     const element = createElement();
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : <i className="p-image-preview-icon pi pi-eye"></i>;
     const preview = createPreview();
-    const image = <img src={src} className={props.imageClassName} width={width} height={height} style={props.imageStyle} alt={alt} onError={props.onError} />;
+    const image = <img ref={imageRef} src={src} className={props.imageClassName} width={width} height={height} style={props.imageStyle} alt={alt} onError={props.onError} />;
 
     return (
         <span ref={elementRef} className={containerClassName} {...otherProps}>

--- a/components/lib/inplace/Inplace.d.ts
+++ b/components/lib/inplace/Inplace.d.ts
@@ -5,13 +5,10 @@ interface InplaceToggleParams {
     value: boolean;
 }
 
-export interface InplaceProps {
-    style?: object;
-    className?: string;
+export interface InplaceProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     active?: boolean;
     closable?: boolean;
     disabled?: boolean;
-    tabIndex?: number;
     ariaLabel?: string;
     onOpen?(event: React.MouseEvent<HTMLElement>): void;
     onClose?(event: React.MouseEvent<HTMLElement>): void;
@@ -19,7 +16,9 @@ export interface InplaceProps {
     children?: React.ReactNode;
 }
 
-export declare class Inplace extends React.Component<InplaceProps, any> { }
+export declare class Inplace extends React.Component<InplaceProps, any> { 
+    public getElement(): HTMLDivElement;
+}
 
 // tslint:disable-next-line:max-classes-per-file
 export declare class InplaceDisplay extends React.Component {

--- a/components/lib/inplace/Inplace.js
+++ b/components/lib/inplace/Inplace.js
@@ -7,6 +7,7 @@ export const InplaceContent = (props) => props.children;
 
 export const Inplace = React.forwardRef((props, ref) => {
     const [activeState, setActiveState] = React.useState(props.active);
+    const elementRef = React.useRef(null);
     const active = props.onToggle ? props.active : activeState;
 
     const shouldUseInplaceContent = (child) => child && child.props.__TYPE === 'InplaceContent';
@@ -97,6 +98,11 @@ export const Inplace = React.forwardRef((props, ref) => {
         );
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Inplace.defaultProps);
     const children = createChildren();
     const className = classNames('p-inplace p-component', {
@@ -104,7 +110,7 @@ export const Inplace = React.forwardRef((props, ref) => {
     }, props.className);
 
     return (
-        <div className={className} {...otherProps}>
+        <div ref={elementRef} className={className} {...otherProps}>
             {children}
         </div>
     )

--- a/components/lib/inputmask/InputMask.d.ts
+++ b/components/lib/inputmask/InputMask.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { InputText, InputTextProps } from '../inputtext';
 import TooltipOptions from '../tooltip/tooltipoptions';
 
 interface InputMaskCompleteParams {
@@ -20,23 +21,13 @@ interface InputMaskChangeParams {
     target: InputMaskChangeTargetOptions;
 }
 
-export interface InputMaskProps {
-    id?: string;
-    value?: string;
-    type?: string;
+export interface InputMaskProps extends InputTextProps {
     mask?: string;
     slotChar?: string;
     autoClear?: boolean;
     unmask?: boolean;
-    style?: object;
-    className?: string;
-    placeholder?: string;
-    size?: number;
-    maxLength?: number;
-    tabIndex?: number;
     disabled?: boolean;
     readOnly?: boolean;
-    name?: string;
     required?: boolean;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
@@ -47,4 +38,6 @@ export interface InputMaskProps {
     children?: React.ReactNode;
 }
 
-export declare class InputMask extends React.Component<InputMaskProps, any> { }
+export declare class InputMask extends React.Component<InputMaskProps, any> { 
+    public getElement(): InputText;
+}

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -505,6 +505,11 @@ export const InputMask = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(elementRef, ref);
     }, [elementRef, ref]);

--- a/components/lib/inputnumber/InputNumber.d.ts
+++ b/components/lib/inputnumber/InputNumber.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { InputText } from '../inputtext/inputtext';
 import TooltipOptions from '../tooltip/tooltipoptions';
 
 interface InputNumberValueChangeTargetOptions {
@@ -20,7 +21,7 @@ interface InputNumberChangeParams {
     value: number | null;
 }
 
-export interface InputNumberProps {
+export interface InputNumberProps  extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, 'ref'> {
     value?: number | null;
     inputRef?: React.Ref<HTMLInputElement>;
     format?: boolean;
@@ -40,7 +41,6 @@ export interface InputNumberProps {
     useGrouping?: boolean;
     minFractionDigits?: number;
     maxFractionDigits?: number;
-    id?: string;
     name?: string;
     type?: string;
     allowEmpty?: boolean;
@@ -55,8 +55,6 @@ export interface InputNumberProps {
     placeholder?: string;
     readOnly?: boolean;
     size?: number;
-    style?: object;
-    className?: string;
     inputId?: string;
     autoFocus?: boolean;
     inputStyle?: object;
@@ -74,4 +72,6 @@ export interface InputNumberProps {
 
 export declare class InputNumber extends React.Component<InputNumberProps, any> {
     public getFormatter(): any;
+    public getElement(): HTMLSpanElement;
+    public getInput(): InputText;
 }

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -935,6 +935,8 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         getFormatter,
+        getElement: () => elementRef.current,
+        getInput: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/inputswitch/InputSwitch.d.ts
+++ b/components/lib/inputswitch/InputSwitch.d.ts
@@ -35,4 +35,7 @@ export interface InputSwitchProps extends Omit<React.DetailedHTMLProps<React.Inp
     children?: React.ReactNode;
 }
 
-export declare class InputSwitch extends React.Component<InputSwitchProps, any> { }
+export declare class InputSwitch extends React.Component<InputSwitchProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+}

--- a/components/lib/inputswitch/InputSwitch.js
+++ b/components/lib/inputswitch/InputSwitch.js
@@ -47,6 +47,12 @@ export const InputSwitch = React.memo(React.forwardRef((props, ref) => {
         props.onBlur && props.onBlur(event);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getInput: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/inputtext/InputText.d.ts
+++ b/components/lib/inputtext/InputText.d.ts
@@ -11,4 +11,7 @@ export interface InputTextProps extends Omit<React.DetailedHTMLProps<React.Input
     children?: React.ReactNode;
 }
 
-export declare class InputText extends React.Component<InputTextProps, any> { }
+export declare class InputText extends React.Component<InputTextProps, any> { 
+    public getElement(): HTMLInputElement;
+    public getInput(): HTMLInputElement;
+}

--- a/components/lib/inputtext/InputText.js
+++ b/components/lib/inputtext/InputText.js
@@ -40,6 +40,12 @@ export const InputText = React.memo(React.forwardRef((props, ref) => {
         ObjectUtils.isNotEmpty(props.value) || ObjectUtils.isNotEmpty(props.defaultValue) || (elementRef.current && ObjectUtils.isNotEmpty(elementRef.current.value))
     ), [props.value, props.defaultValue]);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getInput: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(elementRef, ref);
     }, [elementRef, ref]);

--- a/components/lib/inputtextarea/InputTextarea.d.ts
+++ b/components/lib/inputtextarea/InputTextarea.d.ts
@@ -8,4 +8,7 @@ export interface InputTextareaProps extends Omit<React.DetailedHTMLProps<React.T
     children?: React.ReactNode;
 }
 
-export declare class InputTextarea extends React.Component<InputTextareaProps, any> { }
+export declare class InputTextarea extends React.Component<InputTextareaProps, any> { 
+    public getElement(): HTMLTextAreaElement;
+    public getInput(): HTMLTextAreaElement;
+}

--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -71,6 +71,12 @@ export const InputTextarea = React.memo(React.forwardRef((props, ref) => {
         ObjectUtils.isNotEmpty(props.value) || ObjectUtils.isNotEmpty(props.defaultValue) || (elementRef.current && ObjectUtils.isNotEmpty(elementRef.current.value))
     ), [props.value, props.defaultValue]);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getInput: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(elementRef, ref);
     }, [elementRef, ref]);

--- a/components/lib/knob/Knob.d.ts
+++ b/components/lib/knob/Knob.d.ts
@@ -26,4 +26,6 @@ export interface KnobProps extends Omit<React.DetailedHTMLProps<React.InputHTMLA
     children?: React.ReactNode;
 }
 
-export declare class Knob extends React.Component<KnobProps, any> { }
+export declare class Knob extends React.Component<KnobProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -130,6 +130,11 @@ export const Knob = React.memo(React.forwardRef((props, ref) => {
         unbindWindowTouchEndListener();
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Knob.defaultProps);
     const className = classNames('p-knob p-component', {
         'p-disabled': props.disabled,

--- a/components/lib/listbox/ListBox.d.ts
+++ b/components/lib/listbox/ListBox.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { SelectItemOptionsType } from '../selectitem/selectitem';
 import TooltipOptions from '../tooltip/tooltipoptions';
-import { VirtualScrollerProps } from '../virtualscroller';
+import { VirtualScrollerProps, VirtualScroller } from '../virtualscroller';
 
 
 type ListBoxOptionGroupTemplateType = React.ReactNode | ((option: any, index: number) => React.ReactNode);
@@ -30,7 +30,6 @@ interface ListBoxFilterValueChangeParams {
 }
 
 export interface ListBoxProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
-    id?: string;
     value?: any;
     options?: SelectItemOptionsType;
     optionLabel?: string;
@@ -40,10 +39,8 @@ export interface ListBoxProps extends Omit<React.DetailedHTMLProps<React.InputHT
     optionGroupChildren?: string;
     optionGroupTemplate?: ListBoxOptionGroupTemplateType;
     itemTemplate?: ListBoxItemTemplateType;
-    style?: object;
     listStyle?: object;
     listClassName?: string;
-    className?: string;
     virtualScrollerOptions?: VirtualScrollerProps;
     disabled?: boolean;
     dataKey?: string;
@@ -56,7 +53,6 @@ export interface ListBoxProps extends Omit<React.DetailedHTMLProps<React.InputHT
     filterPlaceholder?: string;
     filterLocale?: string;
     filterInputProps?: any;
-    tabIndex?: number;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     ariaLabelledBy?: string;
@@ -65,4 +61,7 @@ export interface ListBoxProps extends Omit<React.DetailedHTMLProps<React.InputHT
     children?: React.ReactNode;
 }
 
-export declare class ListBox extends React.Component<ListBoxProps, any> { }
+export declare class ListBox extends React.Component<ListBoxProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getVirtualScroller(): VirtualScroller;
+}

--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -250,6 +250,12 @@ export const ListBox = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getVirtualScroller: () => virtualScrollerRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         scrollToSelectedIndex();
     });

--- a/components/lib/megamenu/MegaMenu.d.ts
+++ b/components/lib/megamenu/MegaMenu.d.ts
@@ -8,15 +8,14 @@ type MegaMenuStartTemplate = React.ReactNode | ((props: MegaMenuProps) => React.
 type MegaMenuEndTemplate = React.ReactNode | ((props: MegaMenuProps) => React.ReactNode);
 
 
-export interface MegaMenuProps {
-    id?: string;
+export interface MegaMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
-    style?: object;
-    className?: string;
     orientation?: MegaMenuOrientationType;
     start?: MegaMenuStartTemplate;
     end?: MegaMenuEndTemplate;
     children?: React.ReactNode;
 }
 
-export declare class MegaMenu extends React.Component<MegaMenuProps, any> { }
+export declare class MegaMenu extends React.Component<MegaMenuProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -167,6 +167,11 @@ export const MegaMenu = React.memo(React.forwardRef((props, ref) => {
         return columnClass;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         bindDocumentClickListener();
     });

--- a/components/lib/mention/Mention.d.ts
+++ b/components/lib/mention/Mention.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { CSSTransitionProps } from '../csstransition';
+import { InputTextarea } from '../inputtextarea';
 
 type MentionTriggerType = string | string[];
 
@@ -27,12 +28,9 @@ interface MentionSelectParams {
     suggestion: any;
 }
 
-export interface MentionProps {
-    id?: string;
+export interface MentionProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'onInput' | 'onFocus' | 'onBlur' | 'ref'> {
     inputId?: string;
     inputRef?: React.Ref<HTMLInputElement>;
-    style?: object;
-    className?: string;
     trigger?: MentionTriggerType;
     suggestions?: any[];
     field?: MentionFieldType;
@@ -58,4 +56,8 @@ export interface MentionProps {
     children?: React.ReactNode;
 }
 
-export declare class Mention extends React.Component<MentionProps, any> { }
+export declare class Mention extends React.Component<MentionProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getInput(): InputTextarea;
+    public getOverlay(): HTMLElement;
+}

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -312,6 +312,15 @@ export const Mention = React.memo(React.forwardRef((props, ref) => {
         ObjectUtils.isNotEmpty(props.value) || ObjectUtils.isNotEmpty(props.defaultValue) || (inputRef.current && ObjectUtils.isNotEmpty(inputRef.current.value))
     ), [props.value, props.defaultValue, inputRef]);
 
+    React.useImperativeHandle(ref, () => ({
+        show,
+        hide,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/menu/Menu.d.ts
+++ b/components/lib/menu/Menu.d.ts
@@ -4,12 +4,9 @@ import { CSSTransitionProps } from '../csstransition';
 
 type MenuAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface MenuProps {
-    id?: string;
+export interface MenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     popup?: boolean;
-    style?: object;
-    className?: string;
     autoZIndex?: boolean;
     baseZIndex?: number;
     appendTo?: MenuAppendToType;
@@ -23,4 +20,6 @@ export declare class Menu extends React.Component<MenuProps, any> {
     public toggle(event: React.SyntheticEvent): void;
     public show(event: React.SyntheticEvent): void;
     public hide(event: React.SyntheticEvent): void;
+    public getElement(): HTMLDivElement;
+    public getTarget(): EventTarget | null;
 }

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -125,6 +125,8 @@ export const Menu = React.memo(React.forwardRef((props, ref) => {
         toggle,
         show,
         hide,
+        getElement: () => menuRef.current,
+        getTarget: () => targetRef.current,
         ...props
     }));
 

--- a/components/lib/menubar/Menubar.d.ts
+++ b/components/lib/menubar/Menubar.d.ts
@@ -5,14 +5,15 @@ type MenubarStartTemplate = React.ReactNode | ((props: MenubarProps) => React.Re
 
 type MenubarEndTemplate = React.ReactNode | ((props: MenubarProps) => React.ReactNode);
 
-export interface MenubarProps {
-    id?: string;
+export interface MenubarProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
-    style?: object;
-    className?: string;
     start?: MenubarStartTemplate;
     end?: MenubarEndTemplate;
     children?: React.ReactNode;
 }
 
-export declare class Menubar extends React.Component<MenubarProps, any> { }
+export declare class Menubar extends React.Component<MenubarProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getRootMenu(): HTMLElement;
+    public getMenuButton(): HTMLElement;
+}

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -6,6 +6,7 @@ import { MenubarSub } from './MenubarSub';
 
 export const Menubar = React.memo(React.forwardRef((props, ref) => {
     const [mobileActiveState, setMobileActiveState] = React.useState(false);
+    const elementRef = React.useRef(null);
     const rootMenuRef = React.useRef(null);
     const menuButtonRef = React.useRef(null);
 
@@ -50,6 +51,9 @@ export const Menubar = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         toggle,
         useCustomContent,
+        getElement: () => elementRef.current,
+        getRootMenu: () => rootMenuRef.current,
+        getMenuButton: () => menuButtonRef.current,
         ...props
     }));
 

--- a/components/lib/message/Message.d.ts
+++ b/components/lib/message/Message.d.ts
@@ -6,14 +6,13 @@ type MessageContentType = React.ReactNode | ((props: MessageProps) => React.Reac
 
 type MessageTextType = React.ReactNode | ((props: MessageProps) => React.ReactNode);
 
-export interface MessageProps {
-    id?: string;
-    className?: string;
-    style?: object;
+export interface MessageProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     text?: MessageTextType;
     severity?: MessageSeverityType;
     content?: MessageContentType;
     children?: React.ReactNode;
 }
 
-export declare class Message extends React.Component<MessageProps, any> { }
+export declare class Message extends React.Component<MessageProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/message/Message.js
+++ b/components/lib/message/Message.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Message = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const createContent = () => {
         if (props.content) {
@@ -24,6 +25,11 @@ export const Message = React.memo(React.forwardRef((props, ref) => {
         )
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Message.defaultProps);
     const className = classNames('p-inline-message p-component', {
         'p-inline-message-info': props.severity === 'info',
@@ -35,7 +41,7 @@ export const Message = React.memo(React.forwardRef((props, ref) => {
     const content = createContent();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps} role="alert" aria-live="polite">
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps} role="alert" aria-live="polite">
             {content}
         </div>
     )

--- a/components/lib/messages/Messages.d.ts
+++ b/components/lib/messages/Messages.d.ts
@@ -15,10 +15,7 @@ export interface MessagesMessage {
     life?: number;
 }
 
-export interface MessagesProps {
-    id?: string;
-    className?: string;
-    style?: object;
+export interface MessagesProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     transitionOptions?: CSSTransitionProps;
     onRemove?(message: MessagesMessage): void;
     onClick?(message: MessagesMessage): void;
@@ -29,4 +26,5 @@ export declare class Messages extends React.Component<MessagesProps, any> {
     public show(message: MessagesMessageType): void;
     public clear(): void;
     public replace(message: MessagesMessageType): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -8,6 +8,7 @@ let messageIdx = 0;
 
 export const Messages = React.memo(React.forwardRef((props, ref) => {
     const [messagesState, setMessagesState] = React.useState([]);
+    const elementRef = React.useRef(null);
 
     const show = (value) => {
         if (value) {
@@ -46,13 +47,14 @@ export const Messages = React.memo(React.forwardRef((props, ref) => {
         show,
         replace,
         clear,
+        getElement: () => elementRef.current,
         ...props
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Messages.defaultProps);
 
     return (
-        <div id={props.id} className={props.className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={props.className} style={props.style} {...otherProps}>
             <TransitionGroup>
                 {
                     messagesState.map((message) => {

--- a/components/lib/multiselect/MultiSelect.d.ts
+++ b/components/lib/multiselect/MultiSelect.d.ts
@@ -125,4 +125,10 @@ export interface MultiSelectProps extends Omit<React.DetailedHTMLProps<React.Inp
     children?: React.ReactNode;
 }
 
-export declare class MultiSelect extends React.Component<MultiSelectProps, any> { }
+export declare class MultiSelect extends React.Component<MultiSelectProps, any> { 
+    public show(): void;
+    public hide(): void;
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
+    public getOverlay(): HTMLElement;
+}

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -499,6 +499,15 @@ export const MultiSelect = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        show,
+        hide,
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.d.ts
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.d.ts
@@ -34,19 +34,15 @@ interface MultiStateCheckboxChangeParams {
     target: MultiStateCheckboxChangeTargetOptions;
 }
 
-export interface MultiStateCheckboxProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'> {
-    id?: string;
+export interface MultiStateCheckboxProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
     value?: any;
     options?: MultiStateCheckboxOptionsType;
     optionValue?: string;
     optionLabel?: string;
     iconTemplate?: MultiStateCheckboxIconTemplateType;
     dataKey?: string;
-    style?: object;
-    className?: string;
     disabled?: boolean;
     readOnly?: boolean;
-    tabIndex?: number;
     empty?: boolean;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
@@ -54,4 +50,6 @@ export interface MultiStateCheckboxProps extends Omit<React.DetailedHTMLProps<Re
     children?: React.ReactNode;
 }
 
-export declare class MultiStateCheckbox extends React.Component<MultiStateCheckboxProps, any> { }
+export declare class MultiStateCheckbox extends React.Component<MultiStateCheckboxProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -76,6 +76,11 @@ export const MultiStateCheckbox = React.memo(React.forwardRef((props, ref) => {
         return { option, index };
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         if (!props.empty && props.value === null) {
             toggle();

--- a/components/lib/orderlist/OrderList.d.ts
+++ b/components/lib/orderlist/OrderList.d.ts
@@ -5,19 +5,17 @@ interface OrderListChangeParams {
     value: any;
 }
 
-export interface OrderListProps {
-    id?: string;
+export interface OrderListProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
     value?: any[];
     header?: React.ReactNode;
-    style?: object;
-    className?: string;
     listStyle?: object;
     dragdrop?: boolean;
-    tabIndex?: number;
     dataKey?: string;
     onChange?(e: OrderListChangeParams): void;
     itemTemplate?(item: any): React.ReactNode;
     children?: React.ReactNode;
 }
 
-export declare class OrderList extends React.Component<OrderListProps, any> { }
+export declare class OrderList extends React.Component<OrderListProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -103,6 +103,11 @@ export const OrderList = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useUpdateEffect(() => {
         if (reorderDirection.current) {
             updateListScroll();

--- a/components/lib/organizationchart/OrganizationChart.d.ts
+++ b/components/lib/organizationchart/OrganizationChart.d.ts
@@ -21,11 +21,8 @@ interface OrganizationChartNodeData {
     label?: string;
 }
 
-export interface OrganizationChartProps {
-    id?: string;
+export interface OrganizationChartProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: OrganizationChartNodeData[];
-    style?: object;
-    className?: string;
     selectionMode?: OrganizationChartSelectionModeType;
     selection?: OrganizationChartSelectionNodeDataType;
     nodeTemplate?(node: OrganizationChartNodeData): React.ReactNode;
@@ -35,4 +32,6 @@ export interface OrganizationChartProps {
     children?: React.ReactNode;
 }
 
-export declare class OrganizationChart extends React.Component<OrganizationChartProps, any> { }
+export declare class OrganizationChart extends React.Component<OrganizationChartProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/organizationchart/OrganizationChart.js
+++ b/components/lib/organizationchart/OrganizationChart.js
@@ -3,6 +3,7 @@ import { classNames, DomHandler, ObjectUtils } from '../utils/Utils';
 import { OrganizationChartNode } from './OrganizationChartNode';
 
 export const OrganizationChart = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const root = props.value && props.value.length ? props.value[0] : null;
 
     const onNodeClick = (event, node) => {
@@ -61,11 +62,16 @@ export const OrganizationChart = React.memo(React.forwardRef((props, ref) => {
         return findIndexInSelection(node) !== -1;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, OrganizationChart.defaultProps);
     const className = classNames('p-organizationchart p-component', props.className);
 
     return (
-        <div id={props.id} style={props.style} className={className} {...otherProps}>
+        <div id={props.id} ref={elementRef} style={props.style} className={className} {...otherProps}>
             <OrganizationChartNode node={root} nodeTemplate={props.nodeTemplate} selectionMode={props.selectionMode} onNodeClick={onNodeClick} isSelected={isSelected} />
         </div>
     )

--- a/components/lib/overlaypanel/OverlayPanel.d.ts
+++ b/components/lib/overlaypanel/OverlayPanel.d.ts
@@ -11,12 +11,9 @@ interface OverlayPanelBreakpoints {
     [key: string]: string;
 }
 
-export interface OverlayPanelProps {
-    id?: string;
+export interface OverlayPanelProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     dismissable?: boolean;
     showCloseIcon?: boolean;
-    style?: object;
-    className?: string;
     appendTo?: OverlayPanelAppendToType;
     ariaCloseLabel?: string;
     breakpoints?: OverlayPanelBreakpoints;
@@ -30,4 +27,5 @@ export declare class OverlayPanel extends React.Component<OverlayPanelProps, any
     public toggle(event: OverlayPanelEventType, target?: OverlayPanelTargetType): void;
     public show(event: OverlayPanelEventType, target: OverlayPanelTargetType): void;
     public hide(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -177,6 +177,7 @@ export const OverlayPanel = React.forwardRef((props, ref) => {
         toggle,
         show,
         hide,
+        getElement: () => overlayRef.current,
         ...props
     }));
 

--- a/components/lib/paginator/Paginator.d.ts
+++ b/components/lib/paginator/Paginator.d.ts
@@ -138,15 +138,13 @@ interface PaginatorTemplateOptions {
 
 export type PaginatorTemplate = string | PaginatorTemplateOptions;
 
-export interface PaginatorProps {
+export interface PaginatorProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     totalRecords?: number;
     rows?: number;
     first?: number;
     pageLinkSize?: number;
     rowsPerPageOptions?: number[];
     alwaysShow?: boolean;
-    style?: object;
-    className?: string;
     template?: PaginatorTemplate;
     leftContent?: React.ReactNode;
     rightContent?: React.ReactNode;
@@ -156,4 +154,6 @@ export interface PaginatorProps {
     children?: React.ReactNode;
 }
 
-export declare class Paginator extends React.Component<PaginatorProps, any> { }
+export declare class Paginator extends React.Component<PaginatorProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/paginator/Paginator.js
+++ b/components/lib/paginator/Paginator.js
@@ -11,6 +11,7 @@ import { PrevPageLink } from './PrevPageLink';
 import { RowsPerPageDropdown } from './RowsPerPageDropdown';
 
 export const Paginator = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const rppChanged = React.useRef(false);
     const page = Math.floor(props.first / props.rows);
     const pageCount = Math.ceil(props.totalRecords / props.rows);
@@ -94,6 +95,11 @@ export const Paginator = React.memo(React.forwardRef((props, ref) => {
 
         changePage(0, rows);
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     useUpdateEffect(() => {
         if (!rppChanged.current) {
@@ -191,7 +197,7 @@ export const Paginator = React.memo(React.forwardRef((props, ref) => {
         const rightElement = rightContent && <div className="p-paginator-right-content">{rightContent}</div>;
 
         return (
-            <div className={className} style={props.style} {...otherProps}>
+            <div ref={elementRef} className={className} style={props.style} {...otherProps}>
                 {leftElement}
                 {elements}
                 {rightElement}

--- a/components/lib/panel/Panel.d.ts
+++ b/components/lib/panel/Panel.d.ts
@@ -26,13 +26,10 @@ interface PanelToggleParams {
     value: boolean;
 }
 
-export interface PanelProps {
-    id?: string;
+export interface PanelProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     header?: React.ReactNode;
     headerTemplate?: PanelHeaderTemplateType;
     toggleable?: boolean;
-    style?: object;
-    className?: string;
     collapsed?: boolean;
     expandIcon?: IconType<PanelProps>;
     collapseIcon?: IconType<PanelProps>;
@@ -44,4 +41,7 @@ export interface PanelProps {
     children?: React.ReactNode;
 }
 
-export declare class Panel extends React.Component<PanelProps, any> { }
+export declare class Panel extends React.Component<PanelProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getContent(): HTMLDivElement;
+}

--- a/components/lib/panel/Panel.js
+++ b/components/lib/panel/Panel.js
@@ -44,6 +44,12 @@ export const Panel = React.forwardRef((props, ref) => {
         props.onCollapse && props.onCollapse(event);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getContent: () => contentRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(elementRef, ref);
     }, [elementRef, ref]);

--- a/components/lib/panelmenu/PanelMenu.d.ts
+++ b/components/lib/panelmenu/PanelMenu.d.ts
@@ -2,14 +2,13 @@ import * as React from 'react';
 import { MenuItem } from '../menuitem';
 import { CSSTransitionProps } from '../csstransition';
 
-export interface PanelMenuProps {
-    id?: string;
+export interface PanelMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
-    style?: object;
-    className?: string;
     multiple?: boolean;
     transitionOptions?: CSSTransitionProps;
     children?: React.ReactNode;
 }
 
-export declare class PanelMenu extends React.Component<PanelMenuProps, any> { }
+export declare class PanelMenu extends React.Component<PanelMenuProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -8,6 +8,7 @@ export const PanelMenu = React.memo(React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
     const [activeItemState, setActiveItemState] = React.useState(null);
     const [animationDisabled, setAnimationDisabled] = React.useState(false);
+    const elementRef = React.useRef(null);
     const headerId = idState + '_header';
     const contentId = idState + '_content';
 
@@ -71,6 +72,11 @@ export const PanelMenu = React.memo(React.forwardRef((props, ref) => {
     const isItemActive = (item) => {
         return activeItemState && (props.multiple ? activeItemState.indexOf(item) > -1 : activeItemState === item);
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     useMountEffect(() => {
         if (!idState) {
@@ -151,7 +157,7 @@ export const PanelMenu = React.memo(React.forwardRef((props, ref) => {
     const panels = createPanels();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {panels}
         </div>
     )

--- a/components/lib/password/Password.d.ts
+++ b/components/lib/password/Password.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import TooltipOptions from '../tooltip/tooltipoptions';
 import { CSSTransitionProps } from '../csstransition';
+import { InputText } from '../inputtext';
 
 type PasswordHeaderType = React.ReactNode | ((props: PasswordProps) => React.ReactNode);
 
@@ -20,7 +21,6 @@ type PasswordIconType = React.ReactNode | ((e: PasswordIconParams) => React.Reac
 type PasswordAppendToType = 'self' | HTMLElement | undefined | null;
 
 export interface PasswordProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>, 'onInput'|'ref'> {
-    id?: string;
     inputId?: string;
     inputRef?: React.Ref<HTMLInputElement>;
     promptLabel?: string;
@@ -38,8 +38,6 @@ export interface PasswordProps extends Omit<React.DetailedHTMLProps<React.InputH
     icon?: PasswordIconType;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
-    style?: object;
-    className?: string;
     inputStyle?: object;
     inputClassName?: string;
     panelStyle?: object;
@@ -51,4 +49,8 @@ export interface PasswordProps extends Omit<React.DetailedHTMLProps<React.InputH
     children?: React.ReactNode;
 }
 
-export declare class Password extends React.Component<PasswordProps, any> { }
+export declare class Password extends React.Component<PasswordProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getInput(): InputText;
+    public getOverlay(): HTMLElement;
+}

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -208,6 +208,13 @@ export const Password = React.memo(React.forwardRef((props, ref) => {
         return 0;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getOverlay: () => overlayRef.current,
+        getInput: () => inputRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         ObjectUtils.combinedRefs(inputRef, props.inputRef);
     }, [inputRef, props.inputRef]);

--- a/components/lib/picklist/PickList.d.ts
+++ b/components/lib/picklist/PickList.d.ts
@@ -72,4 +72,6 @@ export interface PickListProps {
     children?: React.ReactNode;
 }
 
-export declare class PickList extends React.Component<PickListProps, any> { }
+export declare class PickList extends React.Component<PickListProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/picklist/PickList.js
+++ b/components/lib/picklist/PickList.js
@@ -11,6 +11,7 @@ export const PickList = React.memo(React.forwardRef((props, ref) => {
     const [targetSelectionState, setTargetSelectionState] = React.useState([]);
     const [sourceFilterValueState, setSourceFilterValueState] = React.useState('');
     const [targetFilterValueState, setTargetFilterValueState] = React.useState('');
+    const elementRef = React.useRef(null);
     const sourceListElementRef = React.useRef(null);
     const targetListElementRef = React.useRef(null);
     const reorderedListElementRef = React.useRef(null);
@@ -181,6 +182,11 @@ export const PickList = React.memo(React.forwardRef((props, ref) => {
         return FilterService.filter(list, searchFields, filterValue, props.filterMatchMode, props.filterLocale);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useUpdateEffect(() => {
         if (reorderedListElementRef.current) {
             handleScrollPosition(reorderedListElementRef.current, reorderDirection.current);
@@ -197,7 +203,7 @@ export const PickList = React.memo(React.forwardRef((props, ref) => {
     const targetList = getVisibleList(props.target, 'target');
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {props.showSourceControls && <PickListControls list={props.source} selection={sourceSelection} onReorder={onSourceReorder} className="p-picklist-source-controls" dataKey={props.dataKey} />}
 
             <PickListSubList ref={sourceListElementRef} type="source" list={sourceList} selection={sourceSelection} onSelectionChange={(e) => onSelectionChange(e, 'sourceSelection', props.onSourceSelectionChange)} itemTemplate={sourceItemTemplate}

--- a/components/lib/progressbar/ProgressBar.d.ts
+++ b/components/lib/progressbar/ProgressBar.d.ts
@@ -4,17 +4,16 @@ type ProgressBarModeType = 'determinate' | 'indeterminate';
 
 type ProgressBarValueType = string | number | undefined | null;
 
-export interface ProgressBarProps {
-    id?: string;
+export interface ProgressBarProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: ProgressBarValueType;
     showValue?: boolean;
     unit?: string;
-    style?: object;
-    className?: string;
     mode?: ProgressBarModeType;
     color?: string;
     displayValueTemplate?(value: ProgressBarValueType): React.ReactNode;
     children?: React.ReactNode;
 }
 
-export declare class ProgressBar extends React.Component<ProgressBarProps, any> { }
+export declare class ProgressBar extends React.Component<ProgressBarProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/progressbar/ProgressBar.js
+++ b/components/lib/progressbar/ProgressBar.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const ProgressBar = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const createLabel = () => {
         if (props.showValue && props.value != null) {
@@ -18,7 +19,7 @@ export const ProgressBar = React.memo(React.forwardRef((props, ref) => {
         const label = createLabel();
 
         return (
-            <div role="progressbar" id={props.id} className={className} style={props.style} aria-valuemin="0" aria-valuenow={props.value} aria-valuemax="100" {...otherProps}>
+            <div role="progressbar" id={props.id} ref={elementRef} className={className} style={props.style} aria-valuemin="0" aria-valuenow={props.value} aria-valuemax="100" {...otherProps}>
                 <div className="p-progressbar-value p-progressbar-value-animate" style={{ width: props.value + '%', display: 'block', backgroundColor: props.color }}></div>
                 {label}
             </div>
@@ -30,13 +31,18 @@ export const ProgressBar = React.memo(React.forwardRef((props, ref) => {
         const className = classNames('p-progressbar p-component p-progressbar-indeterminate', props.className);
 
         return (
-            <div role="progressbar" id={props.id} className={className} style={props.style} {...otherProps}>
+            <div role="progressbar" id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
                 <div className="p-progressbar-indeterminate-container">
                     <div className="p-progressbar-value p-progressbar-value-animate" style={{ backgroundColor: props.color }}></div>
                 </div>
             </div>
         )
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     if (props.mode === 'determinate')
         return createDeterminate();

--- a/components/lib/progressspinner/ProgressSpinner.d.ts
+++ b/components/lib/progressspinner/ProgressSpinner.d.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
-export interface ProgressSpinnerProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface ProgressSpinnerProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     strokeWidth?: string;
     fill?: string;
     animationDuration?: string;
     children?: React.ReactNode;
 }
 
-export declare class ProgressSpinner extends React.Component<ProgressSpinnerProps, any> { }
+export declare class ProgressSpinner extends React.Component<ProgressSpinnerProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/progressspinner/ProgressSpinner.js
+++ b/components/lib/progressspinner/ProgressSpinner.js
@@ -2,11 +2,17 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const ProgressSpinner = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, ProgressSpinner.defaultProps);
     const className = classNames('p-progress-spinner', props.className);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <div id={props.id} style={props.style} className={className} role="alert" aria-busy {...otherProps}>
+        <div id={props.id} ref={elementRef} style={props.style} className={className} role="alert" aria-busy {...otherProps}>
             <svg className="p-progress-spinner-svg" viewBox="25 25 50 50" style={{ animationDuration: props.animationDuration }}>
                 <circle className="p-progress-spinner-circle" cx="50" cy="50" r="20" fill={props.fill} strokeWidth={props.strokeWidth} strokeMiterlimit="10" />
             </svg>

--- a/components/lib/radiobutton/RadioButton.d.ts
+++ b/components/lib/radiobutton/RadioButton.d.ts
@@ -18,17 +18,13 @@ interface RadioButtonChangeParams {
 }
 
 export interface RadioButtonProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
-    id?: string;
     inputRef?: React.Ref<HTMLInputElement>;
     inputId?: string;
     name?: string;
     value?: any;
     checked?: boolean;
-    style?: object;
-    className?: string;
     disabled?: boolean;
     required?: boolean;
-    tabIndex?: number;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     onChange?(e: RadioButtonChangeParams): void;
@@ -37,4 +33,6 @@ export interface RadioButtonProps extends Omit<React.DetailedHTMLProps<React.Inp
 
 export declare class RadioButton extends React.Component<RadioButtonProps, any> {
     public select(e?: React.SyntheticEvent): void;
+    public getElement(): HTMLDivElement;
+    public getInput(): HTMLInputElement;
 }

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -53,6 +53,8 @@ export const RadioButton = React.memo(React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         select,
+        getElement: () => elementRef.current,
+        getInput: () => inputRef.current,
         ...props
     }));
 

--- a/components/lib/rating/Rating.d.ts
+++ b/components/lib/rating/Rating.d.ts
@@ -16,18 +16,17 @@ interface RatingChangeParams {
 }
 
 export interface RatingProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'> {
-    id?: string;
     value?: number;
     disabled?: boolean;
     readOnly?: boolean;
     stars?: number;
     cancel?: boolean;
-    style?: object;
-    className?: string;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     onChange?(e: RatingChangeParams): void;
     children?: React.ReactNode;
 }
 
-export declare class Rating extends React.Component<RatingProps, any> { }
+export declare class Rating extends React.Component<RatingProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/rating/Rating.js
+++ b/components/lib/rating/Rating.js
@@ -76,6 +76,11 @@ export const Rating = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, Rating.defaultProps);
     const className = classNames('p-rating', {

--- a/components/lib/scrollpanel/ScrollPanel.d.ts
+++ b/components/lib/scrollpanel/ScrollPanel.d.ts
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
-export interface ScrollPanelProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface ScrollPanelProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     children?: React.ReactNode;
 }
 
-export declare class ScrollPanel extends React.Component<ScrollPanelProps, any> { }
+export declare class ScrollPanel extends React.Component<ScrollPanelProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getContent(): HTMLDivElement;
+    public getXBar(): HTMLDivElement;
+    public getYBar(): HTMLDivElement;
+}

--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -150,6 +150,10 @@ export const ScrollPanel = React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         refresh,
+        getElement: () => containerRef.current,
+        getContent: () => contentRef.current,
+        getXBar: () => xBarRef.current,
+        getYBar: () => yBarRef.current,
         ...props
     }));
 

--- a/components/lib/scrolltop/ScrollTop.d.ts
+++ b/components/lib/scrolltop/ScrollTop.d.ts
@@ -19,4 +19,6 @@ export interface ScrollTopProps {
     children?: React.ReactNode;
 }
 
-export declare class ScrollTop extends React.Component<ScrollTopProps, any> { }
+export declare class ScrollTop extends React.Component<ScrollTopProps, any> { 
+    public getElement(): HTMLButtonElement;
+}

--- a/components/lib/scrolltop/ScrollTop.js
+++ b/components/lib/scrolltop/ScrollTop.js
@@ -49,6 +49,11 @@ export const ScrollTop = React.memo(React.forwardRef((props, ref) => {
         props.onHide && props.onHide();
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => scrollElementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         if (props.target === 'window')
             bindDocumentScrollListener();

--- a/components/lib/selectbutton/SelectButton.d.ts
+++ b/components/lib/selectbutton/SelectButton.d.ts
@@ -19,7 +19,6 @@ interface SelectButtonChangeParams {
 }
 
 export interface SelectButtonProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'unselectable' | 'onChange' | 'ref'> {
-    id?: string;
     value?: any;
     options?: SelectItemOptionsType;
     optionLabel?: string;
@@ -29,8 +28,6 @@ export interface SelectButtonProps extends Omit<React.DetailedHTMLProps<React.In
     multiple?: boolean;
     unselectable?: boolean;
     disabled?: boolean;
-    style?: object;
-    className?: string;
     dataKey?: string;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
@@ -40,4 +37,6 @@ export interface SelectButtonProps extends Omit<React.DetailedHTMLProps<React.In
     children?: React.ReactNode;
 }
 
-export declare class SelectButton extends React.Component<SelectButtonProps, any> { }
+export declare class SelectButton extends React.Component<SelectButtonProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/selectbutton/SelectButton.js
+++ b/components/lib/selectbutton/SelectButton.js
@@ -90,6 +90,11 @@ export const SelectButton = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, SelectButton.defaultProps);
     const className = classNames('p-selectbutton p-buttonset p-component', props.className);

--- a/components/lib/sidebar/Sidebar.d.ts
+++ b/components/lib/sidebar/Sidebar.d.ts
@@ -7,10 +7,7 @@ type SidebarTemplateType = React.ReactNode | ((props: SidebarProps) => React.Rea
 
 type SidebarAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface SidebarProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface SidebarProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     maskStyle?: object;
     maskClassName?: string;
     visible?: boolean;
@@ -31,4 +28,8 @@ export interface SidebarProps {
     children?: React.ReactNode;
 }
 
-export declare class Sidebar extends React.Component<SidebarProps, any> { }
+export declare class Sidebar extends React.Component<SidebarProps, any> { 
+    public getElement(): HTMLDivElement;
+    public getMask(): HTMLElement;
+    public getCloseIcon(): HTMLButtonElement;
+}

--- a/components/lib/sidebar/Sidebar.js
+++ b/components/lib/sidebar/Sidebar.js
@@ -85,6 +85,13 @@ export const Sidebar = React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => sidebarRef.current,
+        gteMask: () => maskRef.current,
+        getCloseIcon: () => closeIconRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         if (props.visible) {
             setMaskVisibleState(true);

--- a/components/lib/skeleton/Skeleton.d.ts
+++ b/components/lib/skeleton/Skeleton.d.ts
@@ -4,16 +4,16 @@ type SkeletonShapeType = 'rectangle' | 'circle';
 
 type SkeletonAnimationType = 'wave' | 'none';
 
-export interface SkeletonProps {
+export interface SkeletonProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     shape?: SkeletonShapeType;
     size?: string;
     width?: string;
     height?: string;
     borderRadius?: string;
     animation?: SkeletonAnimationType;
-    style?: object;
-    className?: string;
     children?: React.ReactNode;
 }
 
-export declare class Skeleton extends React.Component<SkeletonProps, any> { }
+export declare class Skeleton extends React.Component<SkeletonProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/skeleton/Skeleton.js
+++ b/components/lib/skeleton/Skeleton.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Skeleton = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, Skeleton.defaultProps);
     const style = props.size ?
         { width: props.size, height: props.size, borderRadius: props.borderRadius } :
@@ -11,7 +12,12 @@ export const Skeleton = React.memo(React.forwardRef((props, ref) => {
         'p-skeleton-none': props.animation === 'none'
     }, props.className);
 
-    return <div style={style} className={className} {...otherProps}></div>
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
+    return <div ref={elementRef} style={style} className={className} {...otherProps}></div>
 }));
 
 Skeleton.displayName = 'Skeleton';

--- a/components/lib/slidemenu/SlideMenu.d.ts
+++ b/components/lib/slidemenu/SlideMenu.d.ts
@@ -4,12 +4,9 @@ import { CSSTransitionProps } from '../csstransition';
 
 type SlideMenuAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface SlideMenuProps {
-    id?: string;
+export interface SlideMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     popup?: boolean;
-    style?: object;
-    className?: string;
     easing?: string;
     effectDuration?: number;
     backLabel?: string;
@@ -28,4 +25,5 @@ export declare class SlideMenu extends React.Component<SlideMenuProps, any> {
     public show(event: React.SyntheticEvent): void;
     public hide(event: React.SyntheticEvent): void;
     public toggle(event: React.SyntheticEvent): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -89,6 +89,7 @@ export const SlideMenu = React.memo(React.forwardRef((props, ref) => {
         toggle,
         show,
         hide,
+        getElement: () => menuRef.current,
         ...props
     }));
 

--- a/components/lib/slider/Slider.d.ts
+++ b/components/lib/slider/Slider.d.ts
@@ -12,21 +12,19 @@ interface SliderChangeParams {
 interface SliderSlideEndParams extends SliderChangeParams { }
 
 export interface SliderProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'value' | 'ref'> {
-    id?: string;
     value?: SliderValueType;
     min?: number;
     max?: number;
     orientation?: SliderOrientationType;
     step?: number;
     range?: boolean;
-    style?: object;
-    className?: string;
     disabled?: boolean;
-    tabIndex?: number;
     ariaLabelledBy?: string;
     onChange?(e: SliderChangeParams): void;
     onSlideEnd?(e: SliderSlideEndParams): void;
     children?: React.ReactNode;
 }
 
-export declare class Slider extends React.Component<SliderProps, any> { }
+export declare class Slider extends React.Component<SliderProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -243,6 +243,11 @@ export const Slider = React.memo(React.forwardRef((props, ref) => {
         )
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Slider.defaultProps);
     const className = classNames('p-slider p-component', props.className, {
         'p-disabled': props.disabled,

--- a/components/lib/speeddial/SpeedDial.d.ts
+++ b/components/lib/speeddial/SpeedDial.d.ts
@@ -17,12 +17,9 @@ interface SpeedDialButtonOptions {
     visible: boolean;
 }
 
-export interface SpeedDialProps {
-    id?: string;
+export interface SpeedDialProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     visible?: boolean;
-    style?: object;
-    className?: string;
     direction?: SpeedDialDirectionType;
     transitionDelay?: number;
     type?: SpeedDialType;
@@ -48,4 +45,5 @@ export interface SpeedDialProps {
 export declare class SpeedDial extends React.Component<SpeedDialProps, any> {
     public show(): void;
     public hide(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/speeddial/SpeedDial.js
+++ b/components/lib/speeddial/SpeedDial.js
@@ -148,6 +148,7 @@ export const SpeedDial = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         show,
         hide,
+        getElement: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/splitbutton/SplitButton.d.ts
+++ b/components/lib/splitbutton/SplitButton.d.ts
@@ -6,23 +6,19 @@ import { IconType, TemplateType } from '../utils';
 
 type SplitButtonAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface SplitButtonProps {
-    id?: string;
+export interface SplitButtonProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     label?: string;
     icon?: IconType<SplitButtonProps>;
     loading?: boolean;
     loadingIcon?: IconType<ButtonProps>;
     model?: MenuItem[];
     disabled?: boolean;
-    style?: object;
-    className?: string;
     buttonClassName?: string;
     menuStyle?: object;
     menuClassName?: string;
     menuButtonClassName?: string;
     buttonProps?: any;
     menuButtonProps?: any;
-    tabIndex?: number;
     appendTo?: SplitButtonAppendToType;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
@@ -38,4 +34,5 @@ export interface SplitButtonProps {
 export declare class SplitButton extends React.Component<SplitButtonProps, any> {
     public show(): void;
     public hide(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -82,6 +82,7 @@ export const SplitButton = React.memo(React.forwardRef((props, ref) => {
     React.useImperativeHandle(ref, () => ({
         show,
         hide,
+        getElement: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/splitter/Splitter.d.ts
+++ b/components/lib/splitter/Splitter.d.ts
@@ -19,10 +19,7 @@ interface SplitterPanelProps {
 
 export declare class SplitterPanel extends React.Component<SplitterPanelProps, any> { }
 
-export interface SplitterProps {
-    id?: string;
-    className?: string;
-    style?: object;
+export interface SplitterProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     layout?: SplitterLayoutType;
     gutterSize?: number;
     stateKey?: string;
@@ -31,4 +28,6 @@ export interface SplitterProps {
     children?: React.ReactNode;
 }
 
-export declare class Splitter extends React.Component<SplitterProps, any> { }
+export declare class Splitter extends React.Component<SplitterProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -171,6 +171,11 @@ export const Splitter = React.memo(React.forwardRef((props, ref) => {
         window.removeEventListener('touchend', onGutterTouchEnd);
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         let panelElements = [...elementRef.current.children].filter(child => DomHandler.hasClass(child, 'p-splitter-panel'));
         panelElements.map(panelElement => {

--- a/components/lib/steps/Steps.d.ts
+++ b/components/lib/steps/Steps.d.ts
@@ -7,15 +7,14 @@ interface StepsSelectParams {
     index: number;
 }
 
-export interface StepsProps {
-    id?: string;
+export interface StepsProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model: MenuItem[];
     activeIndex?: number;
     readOnly?: boolean;
-    style?: object;
-    className?: string;
     onSelect?(e: StepsSelectParams): void;
     children?: React.ReactNode;
 }
 
-export declare class Steps extends React.Component<StepsProps, any> { }
+export declare class Steps extends React.Component<StepsProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/steps/Steps.js
+++ b/components/lib/steps/Steps.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Steps = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const itemClick = (event, item, index) => {
         if (props.readOnly || item.disabled) {
@@ -88,6 +89,11 @@ export const Steps = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Steps.defaultProps);
     const className = classNames('p-steps p-component', {
         'p-readonly': props.readOnly
@@ -95,7 +101,7 @@ export const Steps = React.memo(React.forwardRef((props, ref) => {
     const items = createItems();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {items}
         </div>
     )

--- a/components/lib/styleclass/StyleClass.d.ts
+++ b/components/lib/styleclass/StyleClass.d.ts
@@ -16,4 +16,7 @@ export interface StyleClassProps {
     children?: React.ReactNode;
 }
 
-export declare class StyleClass extends React.Component<StyleClassProps, any> { }
+export declare class StyleClass extends React.Component<StyleClassProps, any> { 
+    public getElement(): HTMLElement;
+    public getTarget(): HTMLElement;
+}

--- a/components/lib/styleclass/StyleClass.js
+++ b/components/lib/styleclass/StyleClass.js
@@ -166,6 +166,12 @@ export const StyleClass = React.forwardRef((props, ref) => {
         return !elementRef.current.isSameNode(event.target) && !elementRef.current.contains(event.target) && !targetRef.current.contains(event.target)
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        getTarget: () => targetRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         init();
     });

--- a/components/lib/tabmenu/TabMenu.d.ts
+++ b/components/lib/tabmenu/TabMenu.d.ts
@@ -7,14 +7,13 @@ interface TabMenuTabChangeParams {
     index: number;
 }
 
-export interface TabMenuProps {
-    id?: string;
+export interface TabMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     activeIndex?: number;
-    style?: object;
-    className?: string;
     onTabChange?(e: TabMenuTabChangeParams): void;
     children?: React.ReactNode;
 }
 
-export declare class TabMenu extends React.Component<TabMenuProps, any> { }
+export declare class TabMenu extends React.Component<TabMenuProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/tabmenu/TabMenu.js
+++ b/components/lib/tabmenu/TabMenu.js
@@ -4,6 +4,7 @@ import { classNames, DomHandler, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const TabMenu = React.memo(React.forwardRef((props, ref) => {
     const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
+    const elementRef = React.useRef(null);
     const inkbarRef = React.useRef(null);
     const navRef = React.useRef(null);
     const tabsRef = React.useRef({});
@@ -48,6 +49,11 @@ export const TabMenu = React.memo(React.forwardRef((props, ref) => {
         inkbarRef.current.style.width = DomHandler.getWidth(tabHeader) + 'px';
         inkbarRef.current.style.left = DomHandler.getOffset(tabHeader).left - DomHandler.getOffset(navRef.current).left + 'px';
     }
+
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
 
     React.useEffect(() => {
         updateInkBar();
@@ -104,7 +110,7 @@ export const TabMenu = React.memo(React.forwardRef((props, ref) => {
         const items = createItems();
 
         return (
-            <div id={props.id} className={className} style={props.style} {...otherProps}>
+            <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
                 <ul ref={navRef} className="p-tabmenu-nav p-reset" role="tablist">
                     {items}
                     <li ref={inkbarRef} className="p-tabmenu-ink-bar"></li>

--- a/components/lib/tabview/TabView.d.ts
+++ b/components/lib/tabview/TabView.d.ts
@@ -44,11 +44,8 @@ interface TabViewTabCloseParams {
     index: number;
 }
 
-export interface TabViewProps {
-    id?: string;
+export interface TabViewProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     activeIndex?: number;
-    style?: object;
-    className?: string;
     renderActiveOnly?: boolean;
     scrollable?: boolean;
     panelContainerStyle?: object;
@@ -61,4 +58,5 @@ export interface TabViewProps {
 // tslint:disable-next-line:max-classes-per-file
 export declare class TabView extends React.Component<TabViewProps, any> {
     public reset(): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -11,6 +11,7 @@ export const TabView = React.forwardRef((props, ref) => {
     const [forwardIsDisabledState, setForwardIsDisabledState] = React.useState(false);
     const [hiddenTabsState, setHiddenTabsState] = React.useState([]);
     const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
+    const elementRef = React.useRef(null);
     const contentRef = React.useRef(null);
     const navRef = React.useRef(null);
     const inkbarRef = React.useRef(null);
@@ -147,6 +148,7 @@ export const TabView = React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         reset,
+        getElement: () => elementRef.current,
         ...props
     }));
 
@@ -285,7 +287,7 @@ export const TabView = React.forwardRef((props, ref) => {
     const nextButton = createNextButton();
 
     return (
-        <div className={className} {...otherProps}>
+        <div ref={elementRef} className={className} {...otherProps}>
             <div className="p-tabview-nav-container">
                 {prevButton}
                 {navigator}

--- a/components/lib/tag/Tag.d.ts
+++ b/components/lib/tag/Tag.d.ts
@@ -3,14 +3,14 @@ import { IconType } from '../utils';
 
 type TagSeverityType = 'success' | 'info' | 'warn' | 'error';
 
-export interface TagProps {
+export interface TagProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>, 'ref'> {
     value?: React.ReactNode;
     severity?: TagSeverityType;
     rounded?: boolean;
     icon?: IconType<TagProps>;
-    style?: object;
-    className?: string;
     children?: React.ReactNode;
 }
 
-export declare class Tag extends React.Component<TagProps, any> { }
+export declare class Tag extends React.Component<TagProps, any> { 
+    public getElement(): HTMLSpanElement;
+}

--- a/components/lib/tag/Tag.js
+++ b/components/lib/tag/Tag.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, IconUtils, ObjectUtils } from '../utils/Utils';
 
 export const Tag = React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, Tag.defaultProps);
     const className = classNames('p-tag p-component', {
         [`p-tag-${props.severity}`]: props.severity !== null,
@@ -9,8 +10,13 @@ export const Tag = React.forwardRef((props, ref) => {
     }, props.className);
     const icon = IconUtils.getJSXIcon(props.icon, { className: 'p-tag-icon' }, { props });
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <span className={className} style={props.style} {...otherProps}>
+        <span ref={elementRef} className={className} style={props.style} {...otherProps}>
             {icon}
             <span className="p-tag-value">{props.value}</span>
             <span>{props.children}</span>

--- a/components/lib/terminal/Terminal.d.ts
+++ b/components/lib/terminal/Terminal.d.ts
@@ -1,12 +1,11 @@
 import * as React from 'react';
 
-export interface TerminalProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface TerminalProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     welcomeMessage?: string;
     prompt?: string;
     children?: React.ReactNode;
 }
 
-export declare class Terminal extends React.Component<TerminalProps, any> {}
+export declare class Terminal extends React.Component<TerminalProps, any> {
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/terminal/Terminal.js
+++ b/components/lib/terminal/Terminal.js
@@ -54,6 +54,11 @@ export const Terminal = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     React.useEffect(() => {
         const response = (res) => {
             if (commandsState && commandsState.length > 0) {

--- a/components/lib/tieredmenu/TieredMenu.d.ts
+++ b/components/lib/tieredmenu/TieredMenu.d.ts
@@ -4,12 +4,9 @@ import { CSSTransitionProps } from '../csstransition';
 
 type TieredMenuAppendToType = 'self' | HTMLElement | undefined | null;
 
-export interface TieredMenuProps {
-    id?: string;
+export interface TieredMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     model?: MenuItem[];
     popup?: boolean;
-    style?: object;
-    className?: string;
     autoZIndex?: boolean;
     baseZIndex?: number;
     appendTo?: TieredMenuAppendToType;
@@ -21,4 +18,5 @@ export interface TieredMenuProps {
 
 export declare class TieredMenu extends React.Component<TieredMenuProps, any> {
     public toggle(event: React.SyntheticEvent): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -74,6 +74,7 @@ export const TieredMenu = React.memo(React.forwardRef((props, ref) => {
         toggle,
         show,
         hide,
+        getElement: () => menuRef.current,
         ...props
     }));
 

--- a/components/lib/timeline/Timeline.d.ts
+++ b/components/lib/timeline/Timeline.d.ts
@@ -6,18 +6,17 @@ type TimelineLayoutType = 'vertical' | 'horizontal';
 
 type TimelineTemplateType = React.ReactNode | ((item: any, index: number) => React.ReactNode);
 
-export interface TimelineProps {
-    id?: string;
+export interface TimelineProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     value?: any[];
     align?: TimelineAlignType;
     layout?: TimelineLayoutType;
     dataKey?: string;
-    className?: string;
-    style?: object;
     opposite?: TimelineTemplateType;
     marker?: TimelineTemplateType;
     content?: TimelineTemplateType;
     children?: React.ReactNode;
 }
 
-export declare class Timeline extends React.Component<TimelineProps, any> { }
+export declare class Timeline extends React.Component<TimelineProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/timeline/Timeline.js
+++ b/components/lib/timeline/Timeline.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Timeline = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
 
     const getKey = (item, index) => {
         return props.dataKey ? ObjectUtils.resolveFieldData(item, props.dataKey) : `pr_id__${index}`;
@@ -31,6 +32,11 @@ export const Timeline = React.memo(React.forwardRef((props, ref) => {
         });
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const otherProps = ObjectUtils.findDiffKeys(props, Timeline.defaultProps);
     const className = classNames('p-timeline p-component', {
         [`p-timeline-${props.align}`]: true,
@@ -40,7 +46,7 @@ export const Timeline = React.memo(React.forwardRef((props, ref) => {
     const events = createEvents();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {events}
         </div>
     )

--- a/components/lib/toast/Toast.d.ts
+++ b/components/lib/toast/Toast.d.ts
@@ -23,10 +23,7 @@ export interface ToastMessage {
     contentStyle?: object;
 }
 
-export interface ToastProps {
-    id?: string;
-    className?: string;
-    style?: object;
+export interface ToastProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     baseZIndex?: number;
     position?: ToastPositionType;
     transitionOptions?: CSSTransitionProps;
@@ -42,4 +39,5 @@ export declare class Toast extends React.Component<ToastProps, any> {
     public show(message: ToastMessageType): void;
     public clear(): void;
     public replace(message: ToastMessageType): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -69,6 +69,7 @@ export const Toast = React.memo(React.forwardRef((props, ref) => {
         show,
         replace,
         clear,
+        getElement: () => containerRef.current,
         ...props
     }));
 

--- a/components/lib/togglebutton/ToggleButton.d.ts
+++ b/components/lib/togglebutton/ToggleButton.d.ts
@@ -18,17 +18,13 @@ interface ToggleButtonChangeParams {
     target: ToggleButtonChangeTargetOptions;
 }
 
-export interface ToggleButtonProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'> {
-    id?: string;
+export interface ToggleButtonProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'ref'> {
     onIcon?: IconType<ToggleButtonProps>;
     offIcon?: IconType<ToggleButtonProps>;
     onLabel?: string;
     offLabel?: string;
     iconPos?: ToggleButtonIconPositionType;
-    style?: object;
-    className?: string;
     checked?: boolean;
-    tabIndex?: number;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     onChange?(e: ToggleButtonChangeParams): void;
@@ -37,4 +33,6 @@ export interface ToggleButtonProps extends Omit<React.DetailedHTMLProps<React.In
     children?: React.ReactNode;
 }
 
-export declare class ToggleButton extends React.Component<ToggleButtonProps, any> { }
+export declare class ToggleButton extends React.Component<ToggleButtonProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -46,6 +46,11 @@ export const ToggleButton = React.memo(React.forwardRef((props, ref) => {
         return null;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const tabIndex = !props.disabled && props.tabIndex;
     const otherProps = ObjectUtils.findDiffKeys(props, ToggleButton.defaultProps);

--- a/components/lib/toolbar/Toolbar.d.ts
+++ b/components/lib/toolbar/Toolbar.d.ts
@@ -2,13 +2,12 @@ import * as React from 'react';
 
 type ToolbarTemplateType = React.ReactNode | ((props: ToolbarProps) => React.ReactNode);
 
-export interface ToolbarProps {
-    id?: string;
-    style?: object;
-    className?: string;
+export interface ToolbarProps extends Omit<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'ref'> {
     left?: ToolbarTemplateType;
     right?: ToolbarTemplateType;
     children?: React.ReactNode;
 }
 
-export declare class Toolbar extends React.Component<ToolbarProps, any> { }
+export declare class Toolbar extends React.Component<ToolbarProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/toolbar/Toolbar.js
+++ b/components/lib/toolbar/Toolbar.js
@@ -2,13 +2,19 @@ import * as React from 'react';
 import { classNames, ObjectUtils } from '../utils/Utils';
 
 export const Toolbar = React.memo(React.forwardRef((props, ref) => {
+    const elementRef = React.useRef(null);
     const otherProps = ObjectUtils.findDiffKeys(props, Toolbar.defaultProps);
     const toolbarClass = classNames('p-toolbar p-component', props.className);
     const left = ObjectUtils.getJSXElement(props.left, props);
     const right = ObjectUtils.getJSXElement(props.right, props);
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     return (
-        <div id={props.id} className={toolbarClass} style={props.style} role="toolbar" {...otherProps}>
+        <div id={props.id} ref={elementRef} className={toolbarClass} style={props.style} role="toolbar" {...otherProps}>
             <div className="p-toolbar-group-left">
                 {left}
             </div>

--- a/components/lib/tooltip/Tooltip.d.ts
+++ b/components/lib/tooltip/Tooltip.d.ts
@@ -14,4 +14,6 @@ export declare class Tooltip extends React.Component<TooltipProps, any> {
     public updateTargetEvents(target: HTMLElement): void;
     public loadTargetEvents(target: HTMLElement): void;
     public unloadTargetEvents(target: HTMLElement): void;
+    public getElement(): HTMLElement;
+    public getTarget(): HTMLElement | null;
 }

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -433,6 +433,8 @@ export const Tooltip = React.memo(React.forwardRef((props, ref) => {
         updateTargetEvents,
         loadTargetEvents,
         unloadTargetEvents,
+        getElement: () => elementRef.current,
+        getTarget: () => currentTargetRef.current,
         ...props
     }));
 

--- a/components/lib/tree/Tree.d.ts
+++ b/components/lib/tree/Tree.d.ts
@@ -147,4 +147,5 @@ export interface TreeProps {
 
 export declare class Tree extends React.Component<TreeProps, any> {
     public filter<T>(value: T): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -5,6 +5,7 @@ import { UITreeNode } from './UITreeNode';
 export const Tree = React.memo(React.forwardRef((props, ref) => {
     const [filterValueState, setFilterValueState] = React.useState('');
     const [expandedKeysState, setExpandedKeysState] = React.useState(props.expandedKeys);
+    const elementRef = React.useRef(null);
     const filteredNodes = React.useRef([]);
     const dragState = React.useRef(null);
     const filterChanged = React.useRef(false);
@@ -287,6 +288,7 @@ export const Tree = React.memo(React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         filter,
+        getElement: () => elementRef.current,
         ...props
     }));
 
@@ -415,7 +417,7 @@ export const Tree = React.memo(React.forwardRef((props, ref) => {
     const footer = createFooter();
 
     return (
-        <div id={props.id} className={className} style={props.style} {...otherProps}>
+        <div id={props.id} ref={elementRef} className={className} style={props.style} {...otherProps}>
             {loader}
             {header}
             {content}

--- a/components/lib/treeselect/TreeSelect.d.ts
+++ b/components/lib/treeselect/TreeSelect.d.ts
@@ -64,16 +64,12 @@ interface TreeSelectFilterValueChangeParams {
 }
 
 export interface TreeSelectProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange'|'value' | 'ref'> {
-    id?: string;
     value?: TreeSelectSelectionKeys;
     name?: string;
-    style?: object;
-    className?: string;
     disabled?: boolean;
     options?: TreeNode[];
     scrollHeight?: string;
     placeholder?: string;
-    tabIndex?: number;
     inputId?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -108,4 +104,6 @@ export interface TreeSelectProps extends Omit<React.DetailedHTMLProps<React.Inpu
     children?: React.ReactNode;
 }
 
-export declare class TreeSelect extends React.Component<TreeSelectProps, any> { }
+export declare class TreeSelect extends React.Component<TreeSelectProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -277,6 +277,11 @@ export const TreeSelect = React.memo(React.forwardRef((props, ref) => {
         return selectedNodes;
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     useMountEffect(() => {
         updateTreeState();
     });

--- a/components/lib/treetable/TreeTable.d.ts
+++ b/components/lib/treetable/TreeTable.d.ts
@@ -176,4 +176,5 @@ export interface TreeTableProps extends Omit<React.DetailedHTMLProps<React.Input
 
 export declare class TreeTable extends React.Component<TreeTableProps, any> {
     public filter<T>(value: T, field: string, mode: TreeTableFilterMatchModeType): void;
+    public getElement(): HTMLDivElement;
 }

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -792,6 +792,7 @@ export const TreeTable = React.forwardRef((props, ref) => {
 
     React.useImperativeHandle(ref, () => ({
         filter,
+        getElement: () => elementRef.current,
         ...props
     }));
 

--- a/components/lib/tristatecheckbox/TriStateCheckbox.d.ts
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.d.ts
@@ -16,17 +16,15 @@ interface TriStateCheckboxChangeParams {
 }
 
 export interface TriStateCheckboxProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onChange' | 'value'> {
-    id?: string;
     value?: boolean | undefined | null;
-    style?: object;
-    className?: string;
     disabled?: boolean;
     readOnly?: boolean;
-    tabIndex?: number;
     tooltip?: string;
     tooltipOptions?: TooltipOptions;
     onChange?(e: TriStateCheckboxChangeParams): void;
     children?: React.ReactNode;
 }
 
-export declare class TriStateCheckbox extends React.Component<TriStateCheckboxProps, any> { }
+export declare class TriStateCheckbox extends React.Component<TriStateCheckboxProps, any> { 
+    public getElement(): HTMLDivElement;
+}

--- a/components/lib/tristatecheckbox/TriStateCheckbox.js
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.js
@@ -52,6 +52,11 @@ export const TriStateCheckbox = React.memo(React.forwardRef((props, ref) => {
         }
     }
 
+    React.useImperativeHandle(ref, () => ({
+        getElement: () => elementRef.current,
+        ...props
+    }));
+
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
     const otherProps = ObjectUtils.findDiffKeys(props, TriStateCheckbox.defaultProps);
     const className = classNames('p-tristatecheckbox p-checkbox p-component', props.className);


### PR DESCRIPTION
###Defect Fixes
Fix #2963: Expose ref and element

@mertsincan i think i got this right and tested it.  This exposes props the way PrimeReact 7 did as well as adds `elementRef` and `getElement()` exposed through `ref`.

So now you can do something like this...

```xml
<Dropdown ref={ref} ..>
```

```ts
ref.current.getElement();
```

To get the VirtualScroller of the Datatable...

```xml
<Datatable ref={ref} ..>
```

```ts
const virtualScroller = ref.current.getVirtualScroller();
```