### PR TITLE
Fix #3051: Column filter showing as filtered when empty

### DIFF
--- a/components/lib/datatable/ColumnFilter.js
+++ b/components/lib/datatable/ColumnFilter.js
@@ -33,7 +33,11 @@ export const ColumnFilter = React.memo((props) => {
     });
 
     const hasFilter = () => {
-        return filterStoreModel && filterModel && (filterStoreModel.operator ? filterStoreModel.constraints[0].value !== filterModel.constraints[0].value : filterStoreModel.value !== filterModel.value);
+        if (!filterStoreModel || !filterModel)
+            return false;
+        return filterStoreModel.operator ? 
+               !isFilterBlank(filterModel.constraints[0].value) && filterStoreModel.constraints[0].value !== filterModel.constraints[0].value :
+               !isFilterBlank(filterModel.value) && filterStoreModel.value !== filterModel.value;
     }
 
     const hasRowFilter = () => {


### PR DESCRIPTION
###Defect Fixes
Fix #3051: Column filter showing as filtered when empty

We need to check that the filter is `empty` also