### PR TITLE
Fix #3054: Checkbox prevent click propagation

### DIFF
--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -30,6 +30,7 @@ export const Checkbox = React.memo(React.forwardRef((props, ref) => {
 
             inputRef.current.checked = !checked;
             DomHandler.focus(inputRef.current);
+            event.preventDefault();
         }
     }
 


### PR DESCRIPTION
###Defect Fixes
Fix #3054: Checkbox prevent click propagation

Don't let the click bubble out if the onChange is handled.