### PR TITLE
Fix primefaces#2514: Fix sortFunction ignored on initial sort

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1236,6 +1236,13 @@ export const DataTable = React.forwardRef((props, ref) => {
                 const sortField = (localState && localState.sortField) || getSortField();
                 const sortOrder = (localState && localState.sortOrder) || getSortOrder();
                 const multiSortMeta = (localState && localState.multiSortMeta) || getMultiSortMeta();
+                var columns = getColumns();
+                var sortColumn = columns.find((col) => col.props.field === sortField);
+
+                if (sortColumn) {
+                    columnSortable.current = sortColumn.props.sortable;
+                    columnSortFunction.current = sortColumn.props.sortFunction;
+                }
 
                 if (ObjectUtils.isNotEmpty(filters) || props.globalFilter) {
                     data = filterLocal(data, filters);

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1236,8 +1236,8 @@ export const DataTable = React.forwardRef((props, ref) => {
                 const sortField = (localState && localState.sortField) || getSortField();
                 const sortOrder = (localState && localState.sortOrder) || getSortOrder();
                 const multiSortMeta = (localState && localState.multiSortMeta) || getMultiSortMeta();
-                var columns = getColumns();
-                var sortColumn = columns.find((col) => col.props.field === sortField);
+                const columns = getColumns();
+                const sortColumn = columns.find((col) => col.props.field === sortField);
 
                 if (sortColumn) {
                     columnSortable.current = sortColumn.props.sortable;


### PR DESCRIPTION
If `sortField` is specified, determine and set `columnSortable` and `columnSortFunction` refs when processing data.  Otherwise, the refs are false and undefined, which results in the `sortFunction` not being run initially.

###Defect Fixes
primefaces#2514