### PR TITLE
Fix #3080: StyleClass improved handling of visible elements

### DIFF
--- a/components/lib/styleclass/StyleClass.js
+++ b/components/lib/styleclass/StyleClass.js
@@ -55,10 +55,7 @@ export const StyleClass = React.forwardRef((props, ref) => {
                     DomHandler.addClass(targetRef.current, props.toggleClassName);
             }
             else {
-                if (targetRef.current.offsetParent === null)
-                    enter();
-                else
-                    leave();
+                DomHandler.isVisible(targetRef.current) ? leave() : enter();
             }
         }
     });

--- a/components/lib/utils/DomHandler.js
+++ b/components/lib/utils/DomHandler.js
@@ -746,7 +746,12 @@ export default class DomHandler {
     }
 
     static isVisible(element) {
-        return element && element.offsetParent != null;
+        // https://stackoverflow.com/a/59096915/502366 (in future use IntersectionObserver)
+        return element && ( 
+            element.clientHeight !== 0 ||
+            element.getClientRects().length !== 0 ||
+            getComputedStyle(element).display !== 'none'
+        );
     }
 
     static isExist(element) {


### PR DESCRIPTION
###Defect Fixes
Fix #3080: StyleClass improved handling of visible elements based on Stack Overflow that explains all 4 scenarios: // https://stackoverflow.com/a/59096915/502366 (in future use IntersectionObserver)

Improved checking of `DomHandler.isVisible` to account for more scenarios.