### PR TITLE
Fix #2202: Dropdown allow search by + key

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -246,6 +246,9 @@ export const Dropdown = React.memo(React.forwardRef((props, ref) => {
         }
 
         const char = event.key;
+        if (char === 'Shift' || char === 'Control' || char === 'Alt') {
+            return;
+        }
 
         if (currentSearchChar.current === char)
             searchValue.current = char;


### PR DESCRIPTION
###Defect Fixes
Fix #2202: Dropdown allow search by + key

This issue is that "Shift" was being caught first and the second char "+" was being appended to make the `searchCurrent` = "Shift+" instead of "+".  So this fix ignores the original modifier capture.