### PR TITLE
Fix #3107: ImperativeHandle put props first

### DIFF
--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -48,8 +48,8 @@ export const Accordion = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -454,12 +454,12 @@ export const AutoComplete = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         search,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
         getInput: () => inputRef.current,
-        getVirtualScroller: () => virtualScrollerRef.current,
-        ...props
+        getVirtualScroller: () => virtualScrollerRef.current
     }));
 
     const createSimpleAutoComplete = () => {

--- a/components/lib/avatar/Avatar.js
+++ b/components/lib/avatar/Avatar.js
@@ -19,8 +19,8 @@ export const Avatar = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Avatar.defaultProps);

--- a/components/lib/avatargroup/AvatarGroup.js
+++ b/components/lib/avatargroup/AvatarGroup.js
@@ -7,8 +7,8 @@ export const AvatarGroup = React.forwardRef((props, ref) => {
     const className = classNames('p-avatar-group p-component', props.className);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/badge/Badge.js
+++ b/components/lib/badge/Badge.js
@@ -13,8 +13,8 @@ export const Badge = React.memo(React.forwardRef((props, ref) => {
     }, props.className);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -64,10 +64,10 @@ export const BlockUI = React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         block,
         unblock,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createMask = () => {

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -112,8 +112,8 @@ export const BreadCrumb = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, BreadCrumb.defaultProps);

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2486,6 +2486,7 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         getCurrentDateTime,
@@ -2493,8 +2494,7 @@ export const Calendar = React.memo(React.forwardRef((props, ref) => {
         updateViewDate,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     const createBackwardNavigator = (isVisible) => {

--- a/components/lib/captcha/Captcha.js
+++ b/components/lib/captcha/Captcha.js
@@ -81,10 +81,10 @@ export const Captcha = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         reset,
         getResponse,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Captcha.defaultProps);

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -287,8 +287,8 @@ export const Carousel = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -183,11 +183,11 @@ export const CascadeSelect = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
         getInput: () => inputRef.current,
-        getLabel: () => labelRef.current,
-        ...props
+        getLabel: () => labelRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -47,13 +47,13 @@ const PrimeReactChart = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getCanvas: () => canvasRef.current,
         getChart: () => chartRef.current,
         getBase64Image: () => chartRef.current.toBase64Image(),
         getElement: () => elementRef.current,
         generateLegend: () => chartRef.current && chartRef.current.generateLegend(),
-        refresh: () => chartRef.current && chartRef.current.update(),
-        ...props
+        refresh: () => chartRef.current && chartRef.current.update()
     }));
 
     React.useEffect(() => {

--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -47,9 +47,9 @@ export const Checkbox = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/chip/Chip.js
+++ b/components/lib/chip/Chip.js
@@ -56,8 +56,8 @@ export const Chip = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return visibleState && createElement();

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -178,9 +178,9 @@ export const Chips = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -438,12 +438,12 @@ export const ColorPicker = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -94,8 +94,8 @@ export const ConfirmDialog = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
-        confirm,
-        ...props
+        props,
+        confirm
     }));
 
     const createFooter = () => {

--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -179,8 +179,8 @@ export const ConfirmPopup = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
-        confirm,
-        ...props
+        props,
+        confirm
     }));
 
     const createContent = () => {

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -164,10 +164,10 @@ export const ContextMenu = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
-        getElement: () => menuRef.current,
-        ...props
+        getElement: () => menuRef.current
     }));
 
     const createContextMenu = () => {

--- a/components/lib/datascroller/DataScroller.js
+++ b/components/lib/datascroller/DataScroller.js
@@ -142,11 +142,11 @@ export const DataScroller = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         load,
         reset,
         getElement: () => elementRef.current,
-        getContent: () => contentRef.current,
-        ...props
+        getContent: () => contentRef.current
     }));
 
     const createHeader = () => {

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1324,6 +1324,7 @@ export const DataTable = React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         reset,
         resetScroll,
         exportCSV,
@@ -1334,8 +1335,7 @@ export const DataTable = React.forwardRef((props, ref) => {
         clearState,
         getElement: () => elementRef.current,
         getTable: () => tableRef.current,
-        getVirtualScroller: () => virtualScrollerRef.current,
-        ...props
+        getVirtualScroller: () => virtualScrollerRef.current
     }));
 
     const createLoader = () => {

--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -197,8 +197,8 @@ export const DataView = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const data = processData();

--- a/components/lib/deferredcontent/DeferredContent.js
+++ b/components/lib/deferredcontent/DeferredContent.js
@@ -33,8 +33,8 @@ export const DeferredContent = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -399,14 +399,14 @@ export const Dialog = React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         resetPosition,
         getElement: () => dialogRef.current,
         getMask: () => maskRef.current,
         getContent: () => contentRef.current,
         getHeader: () => headerRef.current,
         getFooter: () => footerRef.current,
-        getCloseButton: () => closeRef.current,
-        ...props
+        getCloseButton: () => closeRef.current
     }));
 
     const createCloseIcon = () => {

--- a/components/lib/divider/Divider.js
+++ b/components/lib/divider/Divider.js
@@ -15,8 +15,8 @@ export const Divider = React.forwardRef((props, ref) => {
     }, props.className);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/dock/Dock.js
+++ b/components/lib/dock/Dock.js
@@ -103,8 +103,8 @@ export const Dock = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Dock.defaultProps);

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -552,13 +552,13 @@ export const Dropdown = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
         getInput: () => inputRef.current,
-        getFocusInput: () => focusInputRef.current,
-        ...props
+        getFocusInput: () => focusInputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/editor/Editor.js
+++ b/components/lib/editor/Editor.js
@@ -111,11 +111,11 @@ export const Editor = React.memo(React.forwardRef((props, ref) => {
     }, [props.value]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getQuill: () => quill.current,
         getElement: () => elementRef.current,
         getContent: () => contentRef.current,
-        getToolbar: () => toolbarRef.current,
-        ...props
+        getToolbar: () => toolbarRef.current
     }));
 
     const createToolbarHeader = () => {

--- a/components/lib/fieldset/Fieldset.js
+++ b/components/lib/fieldset/Fieldset.js
@@ -104,9 +104,9 @@ export const Fieldset = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getContent: () => contentRef.current,
-        ...props
+        getContent: () => contentRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Fieldset.defaultProps);

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -313,12 +313,12 @@ export const FileUpload = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         upload,
         clear,
         formatSize,
         getInput: () => fileInputRef.current,
-        getContent: () => contentRef.current,
-        ...props
+        getContent: () => contentRef.current
     }));
 
     const createChooseButton = () => {

--- a/components/lib/fullcalendar/FullCalendar.js
+++ b/components/lib/fullcalendar/FullCalendar.js
@@ -24,8 +24,8 @@ export const FullCalendar = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -102,14 +102,14 @@ export const Galleria = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         isAutoPlayActive,
         startSlideShow,
         stopSlideShow,
         getElement: () => elementRef.current,
-        getPreviewContent: () => previewContentRef.current,
-        ...props
+        getPreviewContent: () => previewContentRef.current
     }));
 
     const createHeader = () => {

--- a/components/lib/gmap/GMap.js
+++ b/components/lib/gmap/GMap.js
@@ -111,9 +111,9 @@ export const GMap = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getMap,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, GMap.defaultProps);

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -146,9 +146,9 @@ export const Image = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getImage: () => imageRef.current,
-        ...props
+        getImage: () => imageRef.current
     }));
 
     const { src, alt, width, height } = props;

--- a/components/lib/inplace/Inplace.js
+++ b/components/lib/inplace/Inplace.js
@@ -99,8 +99,8 @@ export const Inplace = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Inplace.defaultProps);

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -506,8 +506,8 @@ export const InputMask = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -934,10 +934,10 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getFormatter,
         getElement: () => elementRef.current,
-        getInput: () => elementRef.current,
-        ...props
+        getInput: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/inputswitch/InputSwitch.js
+++ b/components/lib/inputswitch/InputSwitch.js
@@ -48,9 +48,9 @@ export const InputSwitch = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getInput: () => elementRef.current,
-        ...props
+        getInput: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -131,8 +131,8 @@ export const Knob = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Knob.defaultProps);

--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -256,9 +256,9 @@ export const ListBox = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getVirtualScroller: () => virtualScrollerRef.current,
-        ...props
+        getVirtualScroller: () => virtualScrollerRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -168,8 +168,8 @@ export const MegaMenu = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -313,12 +313,12 @@ export const Mention = React.memo(React.forwardRef((props, ref) => {
     ), [props.value, props.defaultValue, inputRef]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -122,12 +122,12 @@ export const Menu = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         toggle,
         show,
         hide,
         getElement: () => menuRef.current,
-        getTarget: () => targetRef.current,
-        ...props
+        getTarget: () => targetRef.current
     }));
 
     const createSubmenu = (submenu, index) => {

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -49,12 +49,12 @@ export const Menubar = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         toggle,
         useCustomContent,
         getElement: () => elementRef.current,
         getRootMenu: () => rootMenuRef.current,
-        getMenuButton: () => menuButtonRef.current,
-        ...props
+        getMenuButton: () => menuButtonRef.current
     }));
 
     const createStartContent = () => {

--- a/components/lib/message/Message.js
+++ b/components/lib/message/Message.js
@@ -26,8 +26,8 @@ export const Message = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Message.defaultProps);

--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -44,11 +44,11 @@ export const Messages = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         replace,
         clear,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Messages.defaultProps);

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -500,12 +500,12 @@ export const MultiSelect = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -77,8 +77,8 @@ export const MultiStateCheckbox = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -147,8 +147,8 @@ export const OrderList = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useUpdateEffect(() => {

--- a/components/lib/organizationchart/OrganizationChart.js
+++ b/components/lib/organizationchart/OrganizationChart.js
@@ -63,8 +63,8 @@ export const OrganizationChart = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, OrganizationChart.defaultProps);

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -174,11 +174,11 @@ export const OverlayPanel = React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         toggle,
         show,
         hide,
-        getElement: () => overlayRef.current,
-        ...props
+        getElement: () => overlayRef.current
     }));
 
     const createCloseIcon = () => {

--- a/components/lib/paginator/Paginator.js
+++ b/components/lib/paginator/Paginator.js
@@ -97,8 +97,8 @@ export const Paginator = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useUpdateEffect(() => {

--- a/components/lib/panel/Panel.js
+++ b/components/lib/panel/Panel.js
@@ -45,9 +45,9 @@ export const Panel = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getContent: () => contentRef.current,
-        ...props
+        getContent: () => contentRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -74,8 +74,8 @@ export const PanelMenu = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -209,10 +209,10 @@ export const Password = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
         getOverlay: () => overlayRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/picklist/PickList.js
+++ b/components/lib/picklist/PickList.js
@@ -183,8 +183,8 @@ export const PickList = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useUpdateEffect(() => {

--- a/components/lib/progressbar/ProgressBar.js
+++ b/components/lib/progressbar/ProgressBar.js
@@ -40,8 +40,8 @@ export const ProgressBar = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     if (props.mode === 'determinate')

--- a/components/lib/progressspinner/ProgressSpinner.js
+++ b/components/lib/progressspinner/ProgressSpinner.js
@@ -7,8 +7,8 @@ export const ProgressSpinner = React.memo(React.forwardRef((props, ref) => {
     const className = classNames('p-progress-spinner', props.className);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -53,10 +53,10 @@ export const RadioButton = React.memo(React.forwardRef((props, ref) => {
     }, [inputRef, props.inputRef]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         select,
         getElement: () => elementRef.current,
-        getInput: () => inputRef.current,
-        ...props
+        getInput: () => inputRef.current
     }));
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);

--- a/components/lib/rating/Rating.js
+++ b/components/lib/rating/Rating.js
@@ -77,8 +77,8 @@ export const Rating = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);

--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -149,12 +149,12 @@ export const ScrollPanel = React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         refresh,
         getElement: () => containerRef.current,
         getContent: () => contentRef.current,
         getXBar: () => xBarRef.current,
-        getYBar: () => yBarRef.current,
-        ...props
+        getYBar: () => yBarRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, ScrollPanel.defaultProps);

--- a/components/lib/scrolltop/ScrollTop.js
+++ b/components/lib/scrolltop/ScrollTop.js
@@ -50,8 +50,8 @@ export const ScrollTop = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => scrollElementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/selectbutton/SelectButton.js
+++ b/components/lib/selectbutton/SelectButton.js
@@ -91,8 +91,8 @@ export const SelectButton = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);

--- a/components/lib/sidebar/Sidebar.js
+++ b/components/lib/sidebar/Sidebar.js
@@ -86,10 +86,10 @@ export const Sidebar = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => sidebarRef.current,
         gteMask: () => maskRef.current,
-        getCloseIcon: () => closeIconRef.current,
-        ...props
+        getCloseIcon: () => closeIconRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/skeleton/Skeleton.js
+++ b/components/lib/skeleton/Skeleton.js
@@ -13,8 +13,8 @@ export const Skeleton = React.memo(React.forwardRef((props, ref) => {
     }, props.className);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return <div ref={elementRef} style={style} className={className} {...otherProps}></div>

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -86,11 +86,11 @@ export const SlideMenu = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         toggle,
         show,
         hide,
-        getElement: () => menuRef.current,
-        ...props
+        getElement: () => menuRef.current
     }));
 
     const createBackward = () => {

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -244,8 +244,8 @@ export const Slider = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Slider.defaultProps);

--- a/components/lib/speeddial/SpeedDial.js
+++ b/components/lib/speeddial/SpeedDial.js
@@ -146,10 +146,10 @@ export const SpeedDial = React.memo(React.forwardRef((props, ref) => {
     }, [visibleState]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createItem = (item, index) => {

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -80,10 +80,10 @@ export const SplitButton = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         hide,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createItems = () => {

--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -172,8 +172,8 @@ export const Splitter = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/steps/Steps.js
+++ b/components/lib/steps/Steps.js
@@ -90,8 +90,8 @@ export const Steps = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Steps.defaultProps);

--- a/components/lib/styleclass/StyleClass.js
+++ b/components/lib/styleclass/StyleClass.js
@@ -164,9 +164,9 @@ export const StyleClass = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElement: () => elementRef.current,
-        getTarget: () => targetRef.current,
-        ...props
+        getTarget: () => targetRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/tabmenu/TabMenu.js
+++ b/components/lib/tabmenu/TabMenu.js
@@ -51,8 +51,8 @@ export const TabMenu = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -147,9 +147,9 @@ export const TabView = React.forwardRef((props, ref) => {
     }, [props.activeIndex]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         reset,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createTabHeader = (tab, index) => {

--- a/components/lib/tag/Tag.js
+++ b/components/lib/tag/Tag.js
@@ -11,8 +11,8 @@ export const Tag = React.forwardRef((props, ref) => {
     const icon = IconUtils.getJSXIcon(props.icon, { className: 'p-tag-icon' }, { props });
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/terminal/Terminal.js
+++ b/components/lib/terminal/Terminal.js
@@ -55,8 +55,8 @@ export const Terminal = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     React.useEffect(() => {

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -71,11 +71,11 @@ export const TieredMenu = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         toggle,
         show,
         hide,
-        getElement: () => menuRef.current,
-        ...props
+        getElement: () => menuRef.current
     }));
 
     const createElement = () => {

--- a/components/lib/timeline/Timeline.js
+++ b/components/lib/timeline/Timeline.js
@@ -33,8 +33,8 @@ export const Timeline = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const otherProps = ObjectUtils.findDiffKeys(props, Timeline.defaultProps);

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -66,11 +66,11 @@ export const Toast = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         show,
         replace,
         clear,
-        getElement: () => containerRef.current,
-        ...props
+        getElement: () => containerRef.current
     }));
 
     const createElement = () => {

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -47,8 +47,8 @@ export const ToggleButton = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);

--- a/components/lib/toolbar/Toolbar.js
+++ b/components/lib/toolbar/Toolbar.js
@@ -9,8 +9,8 @@ export const Toolbar = React.memo(React.forwardRef((props, ref) => {
     const right = ObjectUtils.getJSXElement(props.right, props);
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     return (

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -437,12 +437,12 @@ export const Tooltip = React.memo(React.forwardRef((props, ref) => {
     });
 
     React.useImperativeHandle(ref, () => ({
+        props,
         updateTargetEvents,
         loadTargetEvents,
         unloadTargetEvents,
         getElement: () => elementRef.current,
-        getTarget: () => currentTargetRef.current,
-        ...props
+        getTarget: () => currentTargetRef.current
     }));
 
     const createElement = () => {

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -295,9 +295,9 @@ export const Tree = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         filter,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createRootChild = (node, index, last) => {

--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -282,8 +282,8 @@ export const TreeSelect = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     useMountEffect(() => {

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -791,9 +791,9 @@ export const TreeTable = React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
+        props,
         filter,
-        getElement: () => elementRef.current,
-        ...props
+        getElement: () => elementRef.current
     }));
 
     const createTableHeader = (columns, columnGroup) => {

--- a/components/lib/tristatecheckbox/TriStateCheckbox.js
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.js
@@ -53,8 +53,8 @@ export const TriStateCheckbox = React.memo(React.forwardRef((props, ref) => {
     }
 
     React.useImperativeHandle(ref, () => ({
-        getElement: () => elementRef.current,
-        ...props
+        props,
+        getElement: () => elementRef.current
     }));
 
     const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);

--- a/components/lib/virtualscroller/VirtualScroller.js
+++ b/components/lib/virtualscroller/VirtualScroller.js
@@ -513,12 +513,12 @@ export const VirtualScroller = React.memo(React.forwardRef((props, ref) => {
     }, [props.orientation]);
 
     React.useImperativeHandle(ref, () => ({
+        props,
         getElementRef,
         scrollTo,
         scrollToIndex,
         scrollInView,
-        getRenderedRange,
-        ...props
+        getRenderedRange
     }));
 
     const createLoaderItem = (index, extOptions = {}) => {


### PR DESCRIPTION
###Defect Fixes
Fix #3107: ImperativeHandle put props first

So the properties don't clobber methods like `filter`