### PR TITLE
Add Tab Support to InputNumber (within Datatable)

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -341,7 +341,7 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
                 }
                 break;
 
-            //enter
+            //enter and tab
             case 13:
             case 9:
                 newValueStr = validateValue(parseValue(inputValue));

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -343,6 +343,7 @@ export const InputNumber = React.memo(React.forwardRef((props, ref) => {
 
             //enter
             case 13:
+            case 9:
                 newValueStr = validateValue(parseValue(inputValue));
                 inputRef.current.value = formatValue(newValueStr);
                 inputRef.current.setAttribute('aria-valuenow', newValueStr);


### PR DESCRIPTION
When editing an inputnumber in the "cell" edit mode within a datatable, tab does not trigger the onCellEditComplete (or validators), because it is missing from the switch list. I found the same issue with the same solution in PrimeVue: https://github.com/primefaces/primevue/pull/1954/files.

###Defect Fixes
https://github.com/primefaces/primereact/issues/3109