### PR TITLE
Fix #3114: PrimeReact.nullSortOrder to control NULL sorting

### DIFF
--- a/components/lib/api/Api.d.ts
+++ b/components/lib/api/Api.d.ts
@@ -27,6 +27,7 @@ interface APIOptions {
     autoZIndex?: boolean;
     zIndex?: ZIndexOptions;
     filterMatchModeOptions?: FilterMatchModeOptions;
+    nullSortOrder?: number;
 }
 
 declare const PrimeReact: APIOptions;

--- a/components/lib/api/PrimeReact.js
+++ b/components/lib/api/PrimeReact.js
@@ -16,6 +16,8 @@ export default class PrimeReact {
 
     static nonce = null;
 
+    static nullSortOrder = 1;
+
     static zIndex = {
         modal: 1100,
         overlay: 1000,

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -1,3 +1,5 @@
+import PrimeReact from '../api/Api';
+
 export default class ObjectUtils {
 
     static equals(obj1, obj2, field) {
@@ -196,14 +198,16 @@ export default class ObjectUtils {
         if (emptyValue1 && emptyValue2)
             result = 0;
         else if (emptyValue1)
-            result = order; // sort nulls at bottom like Excel
+            result = order;
         else if (emptyValue2)
-            result = -order; // sort nulls at bottom like Excel
+            result = -order;
         else if (typeof value1 === 'string' && typeof value2 === 'string')
             result = value1.localeCompare(value2, locale, { numeric: true });
         else
             result = (value1 < value2) ? -1 : (value1 > value2) ? 1 : 0;
 
-        return order * result;
+        // nullSortOrder == 1 means Excel like sort nulls at bottom
+        const nullSortOrder = PrimeReact.nullSortOrder === 1 ? order: PrimeReact.nullSortOrder;
+        return nullSortOrder * result;
     }
 }

--- a/pages/setup/index.js
+++ b/pages/setup/index.js
@@ -321,6 +321,16 @@ PrimeReact.cssTransition = false; // Default value is true.
 `}
 </CodeHighlight>
 
+                <h5>nullSortOrder</h5>
+                <p>Used to determine how NULL values are sorted.  A value of <i>1</i> means sort like Excel with all NULL values at the bottom of the list.
+                   A value of <i>-1</i> sorts NULL at the top of the list in ascending mode and at the bottom of the list in descending mode.</p>
+<CodeHighlight lang="js">
+{`
+import PrimeReact from 'primereact/api';
+
+PrimeReact.nullSortOrder = -1; // Default value is 1 for Excel like sorting.
+`}
+</CodeHighlight>
                 <h5>Locale</h5>
                 <p>PrimeReact provides a Locale API to support i18n and l7n, visit the <Link href="/locale">Locale</Link> documentation for more information.</p>
 


### PR DESCRIPTION
###Defect Fixes
Fix #3114: PrimeReact.nullSortOrder to control NULL sorting

```js
PrimeReact.nullSortOrder = 1; // Excel like sorting with all nulls at the bottom (default)
```

```js
PrimeReact.nullSortOrder = -1; // NULL at top ascending, bottom descending like PrimeReact < 8.2.0
```