### PR TITLE
Fix #3122: Dialog/Sidebar/Overlay prevent animation flickering

### DIFF
--- a/components/lib/dialog/Dialog.css
+++ b/components/lib/dialog/Dialog.css
@@ -16,6 +16,10 @@
     display: flex;
 }
 
+.p-dialog:not([class*='p-dialog-']) {
+    display: none;
+}
+
 .p-dialog-mask.p-component-overlay {
     pointer-events: auto;
 }

--- a/components/lib/overlaypanel/OverlayPanel.css
+++ b/components/lib/overlaypanel/OverlayPanel.css
@@ -3,6 +3,10 @@
     margin-top: 10px;
 }
 
+.p-overlaypanel:not([class*='p-overlaypanel-']) {
+    display: none;
+}
+
 .p-overlaypanel-flipped {
     margin-top: 0;
     margin-bottom: 10px;

--- a/components/lib/sidebar/Sidebar.css
+++ b/components/lib/sidebar/Sidebar.css
@@ -16,6 +16,10 @@
     display: flex;
 }
 
+.p-sidebar:not([class*="p-sidebar-"]){
+    display: none;
+}
+
 .p-sidebar-mask.p-component-overlay {
     pointer-events: auto;
 }


### PR DESCRIPTION
###Defect Fixes
Fix #3122: Dialog/Sidebar default to hidden before animating