### PR TITLE
Fix #3150: RestoreTableState must restore column widths

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -306,6 +306,7 @@ export const DataTable = React.forwardRef((props, ref) => {
             if (props.resizableColumns) {
                 columnWidthsState.current = restoredState.columnWidths;
                 tableWidthState.current = restoredState.tableWidth;
+                restoreColumnWidths();
             }
 
             if (props.reorderableColumns) {


### PR DESCRIPTION
###Defect Fixes
Fix #3150: RestoreTableState must restore column widths