### PR TITLE
Fix #3190: Menubar mobile view hamburger menu

### DIFF
--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -78,7 +78,7 @@ export const Menubar = React.memo(
         };
 
         const createMenuButton = () => {
-            if (props.model.length < 1) {
+            if (props.model && props.model.length < 1) {
                 return null;
             }
             /* eslint-disable */

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -78,6 +78,9 @@ export const Menubar = React.memo(
         };
 
         const createMenuButton = () => {
+            if (props.model.length < 1) {
+                return null;
+            }
             /* eslint-disable */
             const button = (
                 <a ref={menuButtonRef} href={'#'} role="button" tabIndex={0} className="p-menubar-button" onClick={toggle}>


### PR DESCRIPTION
Hamburger menu not showing when item is absent. 