### PR TITLE
Fix #3197: Confirm Dialog/Popup only callback once

### DIFF
--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -50,7 +50,9 @@ export const ConfirmDialog = React.memo(
 
         const hide = (result) => {
             setVisibleState(false);
-            callbackFromProp('onHide', result);
+            if (result) {
+                callbackFromProp('onHide', result);
+            }
         };
 
         const confirm = (updatedProps) => {

--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -85,7 +85,9 @@ export const ConfirmPopup = React.memo(
             setVisibleState(false);
             OverlayService.off('overlay-click', overlayEventListener.current);
             overlayEventListener.current = null;
-            callbackFromProp('onHide', result);
+            if (result) {
+                callbackFromProp('onHide', result);
+            }
         };
 
         const onEnter = () => {

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -117,7 +117,11 @@ export default class ObjectUtils {
     }
 
     static getPropValue(obj, ...params) {
-        return this.isFunction(obj) ? obj(...params) : obj;
+        let methodParams = params;
+        if (params && params.length === 1) {
+            methodParams = params[0];
+        }
+        return this.isFunction(obj) ? obj(...methodParams) : obj;
     }
 
     static getRefElement(ref) {


### PR DESCRIPTION
### Defect Fixes
Fix #3197: Confirm Dialog/Popup only callback once

If array of params only has 1 param just pass the 1 param not an array.  Only call `onHide` if result != null
