### PR TITLE
Fixes #3270: Accordion return null if idState is not set.

### DIFF
--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -5,13 +5,13 @@ import { classNames, IconUtils, ObjectUtils, UniqueComponentId } from '../utils/
 
 export const AccordionTab = () => {};
 
+const shouldUseTab = (tab) => tab && tab.props.__TYPE === 'AccordionTab';
+
 export const Accordion = React.forwardRef((props, ref) => {
     const [idState, setIdState] = React.useState(props.id);
     const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
     const elementRef = React.useRef(null);
     const activeIndex = props.onTabChange ? props.activeIndex : activeIndexState;
-
-    const shouldUseTab = (tab) => tab && tab.props.__TYPE === 'AccordionTab';
 
     const onTabHeaderClick = (event, tab, index) => {
         if (!tab.props.disabled) {
@@ -55,6 +55,10 @@ export const Accordion = React.forwardRef((props, ref) => {
             setIdState(UniqueComponentId());
         }
     });
+
+    if (!idState) {
+        return null;
+    }
 
     const createTabHeader = (tab, selected, index) => {
         const style = { ...(tab.props.style || {}), ...(tab.props.headerStyle || {}) };


### PR DESCRIPTION
If the id prop is not set, then idState is null, which is then resolved by the useMountEffect. However this null value has been used to key AccordionTabs, which then get remounted.

This change doesn't generate any AccordionTabs if the idState is not set, resulting in only one mounting of the children.
