### PR TITLE
Fix #3310: RowExpansionTemplate allow for custom rendering

### DIFF
--- a/components/doc/datatable/index.js
+++ b/components/doc/datatable/index.js
@@ -3301,7 +3301,7 @@ export const DataTableStateDemo = () => {
                                     <td>rowExpansionTemplate</td>
                                     <td>function</td>
                                     <td>null</td>
-                                    <td>Function that receives the row data as the parameter and returns the expanded row content.</td>
+                                    <td>Function that receives the row data as the parameter and returns the expanded row content. You can override the rendering of the content by setting options.customRendering = true.</td>
                                 </tr>
                                 <tr>
                                     <td>expandedRows</td>

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -903,14 +903,22 @@ export const TableBody = React.memo(
 
         const createExpansion = (rowData, index, expanded, colSpan) => {
             if (expanded && !(isSubheaderGrouping && props.expandableRowGroups)) {
-                const content = ObjectUtils.getJSXElement(props.rowExpansionTemplate, rowData, { index });
                 const id = `${props.tableSelector}_content_${index}_expanded`;
+                const options = { index, customRendering: false };
+                let content = ObjectUtils.getJSXElement(props.rowExpansionTemplate, rowData, options);
 
-                return (
-                    <tr id={id} className="p-datatable-row-expansion" role="row">
+                // check if the user wants complete control of the rendering
+                if (!options.customRendering) {
+                    content = (
                         <td role="cell" colSpan={colSpan}>
                             {content}
                         </td>
+                    );
+                }
+
+                return (
+                    <tr id={id} className="p-datatable-row-expansion" role="row">
+                        {content}
                     </tr>
                 );
             }

--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -206,6 +206,7 @@ interface DataTableRowReorderParams {
 
 interface DataTableRowExpansionTemplate {
     index: number;
+    customRendering: boolean;
 }
 
 interface DataTableRowClassNameOptions {


### PR DESCRIPTION
### Feature Requests
Fix #3310: RowExpansionTemplate allow for custom rendering

This will allow you to take control of the rendering like this..

```ts
const rowExpansionTemplate = (data, options) => {
    options.customRendering = true;

    return (
      <>
        <td colSpan={2}>name xx</td>
        <td style={{ background: "lightblue" }}>price template expanded</td>
      </>
    );
  };
```
