### PR TITLE
fix #3376: DataTable crash during third party drag and drop handling

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -633,6 +633,7 @@ export const DataTable = React.forwardRef((props, ref) => {
 
             return;
         }
+        if (!props.reorderableColumns) return;
 
         colReorderIconWidth.current = DomHandler.getHiddenElementOuterWidth(reorderIndicatorUpRef.current);
         colReorderIconHeight.current = DomHandler.getHiddenElementOuterHeight(reorderIndicatorUpRef.current);

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -633,6 +633,7 @@ export const DataTable = React.forwardRef((props, ref) => {
 
             return;
         }
+
         if (!props.reorderableColumns) return;
 
         colReorderIconWidth.current = DomHandler.getHiddenElementOuterWidth(reorderIndicatorUpRef.current);


### PR DESCRIPTION
### Defect Fixes
fix #3376: DataTable crash during third party drag and drop handling

To avoid the crash, exit the DragStart handler when reorderableColumns is not true.