### PR TITLE
Fix #3430/#2996: Datatable global filter has old value

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -976,10 +976,10 @@ export const DataTable = React.forwardRef((props, ref) => {
         setD_filtersState(filters);
     };
 
-    const onFilterApply = () => {
+    const onFilterApply = (filtersToApply) => {
         clearTimeout(filterTimeout.current);
         filterTimeout.current = setTimeout(() => {
-            let filters = cloneFilters(d_filtersState);
+            const filters = cloneFilters(filtersToApply || d_filtersState);
 
             if (props.onFilter) {
                 props.onFilter(createEvent({ filters }));
@@ -1130,7 +1130,7 @@ export const DataTable = React.forwardRef((props, ref) => {
         props.filterDisplay === 'menu' && meta && meta.operator ? (filters[field].constraints[index] = constraint) : (filters[field] = constraint);
 
         setD_filtersState(filters);
-        onFilterApply();
+        onFilterApply(filters);
     };
 
     const reset = () => {
@@ -1333,7 +1333,7 @@ export const DataTable = React.forwardRef((props, ref) => {
 
     useUpdateEffect(() => {
         if (props.globalFilter) {
-            filter(props.globalFilter, 'global', 'contains');
+            filter(props.globalFilter, 'global', props.globalFilterMatchMode);
         }
     }, [props.globalFilter]);
 


### PR DESCRIPTION
### Defect Fixes
Fix #3430/#2996: Datatable global filter has old value

Basically it was using a hook `setD_filtersState(filters);` and then calling `onFilterApply()` but the old `d_filterState` is there because the hook has not completed yet.  So a simple solution to overload the `onFilterApply()` to take a real time collection or if NULL use the `d_filterState`
