### PR TITLE
Fix #3497: Ripple fix for touchable devices

### DIFF
--- a/components/lib/ripple/Ripple.js
+++ b/components/lib/ripple/Ripple.js
@@ -7,6 +7,7 @@ export const Ripple = React.memo(
     React.forwardRef(() => {
         const inkRef = React.useRef(null);
         const targetRef = React.useRef(null);
+        const isTouchable = DomHandler.isTouchDevice();
 
         const getTarget = () => {
             return inkRef.current && inkRef.current.parentElement;
@@ -15,13 +16,20 @@ export const Ripple = React.memo(
         const bindEvents = () => {
             if (targetRef.current) {
                 targetRef.current.addEventListener('mousedown', onMouseDown);
+                isTouchable && targetRef.current.addEventListener('touchstart', onTouchStart);
             }
         };
 
         const unbindEvents = () => {
             if (targetRef.current) {
                 targetRef.current.removeEventListener('mousedown', onMouseDown);
+                isTouchable && targetRef.current.removeEventListener('touchstart', onTouchStart);
             }
+        };
+
+        const onTouchStart = (event) => {
+            this.onMouseDown(event);
+            event.preventDefault();
         };
 
         const onMouseDown = (event) => {


### PR DESCRIPTION
### Defect Fixes
Fix #3497: Ripple fix for touchable devices

Performs onTouchStart only if its a mobile device and calls event.preventDefault to prevent it from going to MouseDown.
