### PR TITLE
Fix #3543: TreeTableHeader: Warning: Each child in a list should have a unique "key" prop.

### DIFF
--- a/components/lib/treetable/TreeTableHeader.js
+++ b/components/lib/treetable/TreeTableHeader.js
@@ -230,10 +230,9 @@ export const TreeTableHeader = React.memo((props) => {
             const resizer = createResizer(column);
 
             return (
-                <>
+                <React.Fragment key={column.columnKey || column.field || options.index}>
                     <th
                         ref={headerCellRef}
-                        key={column.columnKey || column.field || options.index}
                         className={className}
                         style={column.props.headerStyle || column.props.style}
                         tabIndex={column.props.sortable ? props.tabIndex : null}
@@ -255,7 +254,7 @@ export const TreeTableHeader = React.memo((props) => {
                         {filterElement}
                     </th>
                     {hasTooltip && <Tooltip target={headerCellRef} content={headerTooltip} {...column.props.headerTooltipOptions} />}
-                </>
+                </React.Fragment>
             );
         }
     };


### PR DESCRIPTION
Fix #3543: TreeTableHeader: Warning: Each child in a list should have a unique "key" prop