### PR TITLE
Fix #3392: MultiSelect - Add useOptionAsValue prop

### DIFF
--- a/api-generator/components/multiselect.js
+++ b/api-generator/components/multiselect.js
@@ -280,6 +280,12 @@ const MultiSelectProps = [
         type: 'boolean',
         default: 'false',
         description: 'Whether all data is selected.'
+    },
+    {
+        name: 'useOptionAsValue',
+        type: 'boolean',
+        default: 'false',
+        description: 'Defaults to the option itself as the value of an option. Overrides the optionValue prop.'
     }
 ];
 

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -385,6 +385,10 @@ export const MultiSelect = React.memo(
         };
 
         const getOptionValue = (option) => {
+            if (props.useOptionAsValue) {
+                return option;
+            }
+
             if (props.optionValue) {
                 const data = ObjectUtils.resolveFieldData(option, props.optionValue);
 
@@ -419,7 +423,7 @@ export const MultiSelect = React.memo(
         };
 
         const isOptionValueUsed = (option) => {
-            return props.optionValue || (option && option['value'] !== undefined);
+            return (!props.useOptionAsValue && props.optionValue) || (option && option['value'] !== undefined);
         };
 
         const checkValidity = () => {
@@ -700,6 +704,7 @@ MultiSelect.defaultProps = {
     tooltip: null,
     tooltipOptions: null,
     transitionOptions: null,
+    useOptionAsValue: false,
     value: null,
     virtualScrollerOptions: null
 };

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -131,6 +131,7 @@ export interface MultiSelectProps extends Omit<React.DetailedHTMLProps<React.Inp
     onFilter?(e: MultiSelectFilterParams): void;
     onSelectAll?(e: MultiSelectAllParams): void;
     children?: React.ReactNode;
+    useOptionAsValue?: boolean;
 }
 
 export declare class MultiSelect extends React.Component<MultiSelectProps, any> {


### PR DESCRIPTION
**Fix [#3392](https://github.com/primefaces/primereact/issues/3392)**

- MultiSelect: not selecting correct value when "options" objects contain property "value".  
- [Example](https://codesandbox.io/s/compassionate-sea-9qmxhs?file=/src/App.tsx) of the issue.
- Related to [this line](https://github.com/primefaces/primereact/blob/master/components/lib/multiselect/MultiSelect.js#L394).  

**Desired Behavior**
`option` is returned as the value, even if `option['value']` is defined. 

**Approach to Resolving Issue**
To not break backwards compatibility, I decided to take an additive approach, and add a prop `useOptionAsValue`, as an override for determining the value from an option.  I tested locally using the example in the [codesandbox link](https://codesandbox.io/s/compassionate-sea-9qmxhs?file=/src/App.tsx) above.  See screenshots below.

**Current Behavior:**
![Screen Shot 2022-10-10 at 2 02 01 PM](https://user-images.githubusercontent.com/873400/194954632-3bd83ad3-3932-4d5c-aa03-5d117715c2a3.png)
![Screen Shot 2022-10-10 at 2 01 49 PM](https://user-images.githubusercontent.com/873400/194955425-7dcf8b1f-62a0-4f65-a963-91b1f578c674.png)

**Behavior After Changes:**
![Screen Shot 2022-10-10 at 2 03 54 PM](https://user-images.githubusercontent.com/873400/194954633-cc98f50a-a723-4c29-97f8-c03040eb10f6.png)
![Screen Shot 2022-10-10 at 2 04 08 PM](https://user-images.githubusercontent.com/873400/194955536-3af1950e-a08e-41fa-9eb8-435fc3dcf10d.png)

