### PR TITLE
Fix #3476: DataTable: TypeError when adding and starting editing a new row

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -463,13 +463,14 @@ export const BodyCell = React.memo((props) => {
         }
     }, [props.editingMeta]);
 
-    useUpdateEffect(() => {
+    React.useEffect(() => {
         if (props.editMode === 'cell' || props.editMode === 'row') {
             const callbackParams = getCellCallbackParams();
             const params = { ...callbackParams, editing: editingState, editingKey };
 
             props.onEditingMetaChange(params);
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editingState]);
 
     useUnmountEffect(() => {


### PR DESCRIPTION
#3476
1. The cause seems to be that `editingMeta` was not initialized in this specific case.
2. `editingMeta` will be updated by `useUpdateEffect` hook, when `BodyCell`'s `editingState` changed.
3. in this case, `BodyCell`  is not mounted yet, so, the update logic will not be executed  

 Therefore，I try change `useUpdateEffect`  to `React.useEffect`, it works well.