### PR TITLE
Fix #3659: AutoComplete use deepEquals for comparison

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -115,7 +115,7 @@ export const AutoComplete = React.memo(
 
         const updateModel = (event, value) => {
             // #2176 only call change if value actually changed
-            if (selectedItem && selectedItem.current === value) {
+            if (selectedItem && ObjectUtils.deepEquals(selectedItem.current, value)) {
                 return;
             }
 


### PR DESCRIPTION
### Defect Fixes
Fix #3659: AutoComplete use deepEquals for comparison
