### PR TITLE
Fix #2526: DataTable contextmenu selection highlight

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -344,7 +344,7 @@ export const BodyRow = React.memo((props) => {
 
     const rowClassName = ObjectUtils.getPropValue(props.rowClassName, props.rowData, { props: props.tableProps });
     const className = classNames(rowClassName, {
-        'p-highlight': !props.allowCellSelection && props.selected,
+        'p-highlight': (!props.allowCellSelection && props.selected) || props.contextMenuSelected,
         'p-highlight-contextmenu': props.contextMenuSelected,
         'p-selectable-row': props.allowRowSelection && props.isSelectable({ data: props.rowData, index: props.index }),
         'p-row-odd': props.index % 2 !== 0


### PR DESCRIPTION
### Defect Fixes
Fix #2526: DataTable contextmenu selection highlight

![image](https://user-images.githubusercontent.com/4399574/202794208-d1ffe20a-0c3a-408e-871b-420f87652412.png)
