### PR TITLE
Fix #3687: Tooltip prevent scrollbar flickering

### DIFF
--- a/components/lib/tooltip/Tooltip.css
+++ b/components/lib/tooltip/Tooltip.css
@@ -1,6 +1,9 @@
 .p-tooltip {
     position: absolute;
     padding: .25em .5rem;
+    /* #3687: Tooltip prevent scrollbar flickering */
+    top: -9999px;
+    left: -9999px;
 }
 
 .p-tooltip.p-tooltip-right,


### PR DESCRIPTION
### Defect Fixes
Fix #3687: Tooltip prevent scrollbar flickering
