### PR TITLE
Fix Chart initialized in unmounted component

### DIFF
--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -39,6 +39,7 @@ const PrimeReactChart = React.memo(
                     if (!canvasRef.current) {
                         return;
                     }
+
                     if (module) {
                         if (module.default) {
                             // WebPack

--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -34,6 +34,11 @@ const PrimeReactChart = React.memo(
                 import('chart.js/auto').then((module) => {
                     destroyChart();
 
+                    // In case that the Chart component has been unmounted during asynchronous loading of ChartJS,
+                    // the canvasRef will not be available anymore, and no Chart should be created.
+                    if (!canvasRef.current) {
+                        return;
+                    }
                     if (module) {
                         if (module.default) {
                             // WebPack


### PR DESCRIPTION
The `initChart` method will in some case asynchronously create a chart object (after loading `chart.js/auto`). If during the asynchronous process the Chart component was already unmounted, the Chart will still be created, but for a `null` canvas. As a consequence, a zombie Chart is created that is never cleaned up.

**Context/Usage**

We have a simple usage of a line chart, which is rendered for each detail of a master-detail view. That means switching the selection between the entries in the master view will each time unmount the Chart component and then create a new one with different curve data.

The mentioned issue can be provoked already with a minimal Chart as this (but also with actual configuration and data):
```
        <Chart
               type="line"
               data={{labels: [], datasets: []}}
               options={{}}/>
```

**Issue**

#3725 

Oftentimes we see these two errors in the log while switching from one detail to the other:

![image](https://user-images.githubusercontent.com/9335593/204862874-0020fff7-e978-4ca2-b261-2c08ee3f9006.png)

![image](https://user-images.githubusercontent.com/9335593/204862942-10f81f9d-667c-4497-98af-76d285a5dd0b.png)
