### PR TITLE
filter's overlay refer ripple of Layout config

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -61,7 +61,9 @@ export default function Layout(props) {
         else document.body.classList.remove('blocked-scroll');
     }, [sidebarActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    PrimeReact.ripple = true;
+    useEffect(() => {
+        PrimeReact.ripple = ripple;
+    }, [ripple]);
 
     return (
         <div className={wrapperClassName}>


### PR DESCRIPTION
Layout config is not applied PrimeReact.ripple, so it always becomes true in the filter's createOverlay.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
