### PR TITLE
Fix #3755: Dialog maximized should have no margin

### DIFF
--- a/components/lib/dialog/Dialog.css
+++ b/components/lib/dialog/Dialog.css
@@ -163,6 +163,7 @@
 .p-dialog-maximized {
     transition: none;
     transform: none;
+    margin: 0 !important;
     width: 100vw !important;
     height: 100vh !important;
     max-height: 100%;


### PR DESCRIPTION
### Defect Fixes
Fix #3755: Dialog maximized should have no margin
