### PR TITLE
Fix #3779: ConfirmPopup call onHide when clicking outside overlay

### DIFF
--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -43,7 +43,7 @@ export const ConfirmPopup = React.memo(
             overlay: overlayRef,
             listener: (event, { type, valid }) => {
                 if (valid) {
-                    type === 'outside' ? props.dismissable && !isPanelClicked.current && hide() : hide();
+                    type === 'outside' ? props.dismissable && !isPanelClicked.current && hide('hide') : hide('hide');
                 }
 
                 isPanelClicked.current = false;


### PR DESCRIPTION
### Defect Fixes
Fix #3779: ConfirmPopup call onHide when clicking outside overlay
