### PR TITLE
Fix #3817: Row reorder fixes from PrimeNG

### DIFF
--- a/components/doc/datatable/reorderdoc.js
+++ b/components/doc/datatable/reorderdoc.js
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { DataTable } from '../../lib/datatable/DataTable';
-import { Column } from '../../lib/column/Column';
-import { Toast } from '../../lib/toast/Toast';
+import React, { useEffect, useRef, useState } from 'react';
 import { ProductService } from '../../../service/ProductService';
+import { Column } from '../../lib/column/Column';
+import { DataTable } from '../../lib/datatable/DataTable';
+import { Toast } from '../../lib/toast/Toast';
 import { DocSectionCode } from '../common/docsectioncode';
 import { DocSectionText } from '../common/docsectiontext';
 
@@ -37,7 +37,7 @@ export function ReorderDoc(props) {
 
     const code = {
         basic: `
-<DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll">
+<DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll" paginator rows={5}>
     <Column rowReorder style={{width: '3em'}} />
     {dynamicColumns}
 </DataTable>
@@ -83,7 +83,7 @@ const ReorderDoc = () => {
             <Toast ref={toast}></Toast>
 
             <div className="card">
-                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll">
+                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll" paginator rows={5}>
                     <Column rowReorder style={{width: '3em'}} />
                     {dynamicColumns}
                 </DataTable>
@@ -133,7 +133,7 @@ const ReorderDoc = () => {
             <Toast ref={toast}></Toast>
 
             <div className="card">
-                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll">
+                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll" paginator rows={5}>
                     <Column rowReorder style={{width: '3em'}} />
                     {dynamicColumns}
                 </DataTable>
@@ -151,7 +151,7 @@ const ReorderDoc = () => {
             </DocSectionText>
             <div className="card">
                 <Toast ref={toast}></Toast>
-                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll">
+                <DataTable value={products} reorderableColumns reorderableRows onRowReorder={onRowReorder} onColReorder={onColReorder} responsiveLayout="scroll" paginator rows={5}>
                     <Column rowReorder style={{ width: '3em' }} />
                     {dynamicColumns}
                 </DataTable>

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -654,7 +654,7 @@ export const TableBody = React.memo(
 
             if (droppedRowIndex.current != null) {
                 let dropIndex = draggedRowIndex.current > droppedRowIndex.current ? droppedRowIndex.current : droppedRowIndex.current === 0 ? 0 : droppedRowIndex.current - 1;
-                let val = [...props.value];
+                let val = [...props.tableProps.value];
 
                 ObjectUtils.reorderArray(val, draggedRowIndex.current, dropIndex);
 
@@ -663,7 +663,7 @@ export const TableBody = React.memo(
                         originalEvent: event,
                         value: val,
                         dragIndex: draggedRowIndex.current,
-                        dropIndex: droppedRowIndex.current
+                        dropIndex: dropIndex
                     });
                 }
             }

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -130,15 +130,10 @@ export default class ObjectUtils {
     }
 
     static reorderArray(value, from, to) {
-        let target;
-
         if (value && from !== to) {
             if (to >= value.length) {
-                target = to - value.length;
-
-                while (target-- + 1) {
-                    value.push(undefined);
-                }
+                to %= value.length;
+                from %= value.length;
             }
 
             value.splice(to, 0, value.splice(from, 1)[0]);


### PR DESCRIPTION
### Defect Fixes
Fix #3817: Row reorder fixes from PrimeNG

Looks like NG had this issue in 2019 and resolved it.  tested and the broken scenario is now working and column and other reordering is also working.
