### PR TITLE
Fix #3693: Datatable allow responsive stack and scrollable

### DIFF
--- a/components/lib/hooks/Hooks.js
+++ b/components/lib/hooks/Hooks.js
@@ -1,13 +1,14 @@
-import { usePrevious } from './usePrevious';
-import { useMountEffect } from './useMountEffect';
-import { useUpdateEffect } from './useUpdateEffect';
-import { useUnmountEffect } from './useUnmountEffect';
 import { useEventListener } from './useEventListener';
+import { useInterval } from './useInterval';
+import { useMediaQuery } from './useMediaQuery';
+import { useMountEffect } from './useMountEffect';
 import { useOverlayListener } from './useOverlayListener';
 import { useOverlayScrollListener } from './useOverlayScrollListener';
+import { usePrevious } from './usePrevious';
 import { useResizeListener } from './useResizeListener';
-import { useInterval } from './useInterval';
-import { useStorage, useLocalStorage, useSessionStorage } from './useStorage';
+import { useLocalStorage, useSessionStorage, useStorage } from './useStorage';
 import { useTimeout } from './useTimeout';
+import { useUnmountEffect } from './useUnmountEffect';
+import { useUpdateEffect } from './useUpdateEffect';
 
-export { usePrevious, useMountEffect, useUpdateEffect, useUnmountEffect, useEventListener, useOverlayListener, useOverlayScrollListener, useResizeListener, useInterval, useStorage, useLocalStorage, useSessionStorage, useTimeout };
+export { usePrevious, useMediaQuery, useMountEffect, useUpdateEffect, useUnmountEffect, useEventListener, useOverlayListener, useOverlayScrollListener, useResizeListener, useInterval, useStorage, useLocalStorage, useSessionStorage, useTimeout };

--- a/components/lib/hooks/hooks.d.ts
+++ b/components/lib/hooks/hooks.d.ts
@@ -27,6 +27,7 @@ export declare function useMountEffect(effect: React.EffectCallback): void;
 export declare function useUpdateEffect(effect: React.EffectCallback, deps?: React.DependencyList): void;
 export declare function useUnmountEffect(effect: React.EffectCallback): void;
 export declare function useEventListener(options: EventOptions): any[];
+export declare function useMediaQuery(query: string, initialValue?: boolean): boolean;
 export declare function useOverlayListener(options: OverlayEventOptions): any[];
 export declare function useOverlayScrollListener(options: EventOptions): any[];
 export declare function useResizeListener(options: ResizeEventOptions): any[];

--- a/components/lib/hooks/useMediaQuery.js
+++ b/components/lib/hooks/useMediaQuery.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook to notify when media queries are satisfied.
+ *
+ * @param {*} query the media query like '(min-width: 900px)'
+ * @param {*} initialValue override the initial value if you don't want it detected
+ * @returns boolean if the media query matches
+ */
+export function useMediaQuery(query, initialValue) {
+    const [matches, setMatches] = useState(getInitialValue(query, initialValue));
+    const queryRef = useRef();
+
+    useEffect(() => {
+        if ('matchMedia' in window) {
+            queryRef.current = window.matchMedia(query);
+            setMatches(queryRef.current.matches);
+
+            return attachMediaListener(queryRef.current, (event) => setMatches(event.matches));
+        }
+
+        return undefined;
+    }, [query]);
+
+    return matches;
+}
+
+function attachMediaListener(query, callback) {
+    query.addEventListener('change', callback);
+
+    return () => query.removeEventListener('change', callback);
+}
+
+function getInitialValue(query, initialValue) {
+    if (typeof initialValue === 'boolean') {
+        return initialValue;
+    }
+
+    if (typeof window !== 'undefined' && 'matchMedia' in window) {
+        return window.matchMedia(query).matches;
+    }
+
+    return false;
+}


### PR DESCRIPTION
### Defect Fixes
Fix #3693: Datatable allow responsive stack and scrollable

Adds a new `useMediaQuery` hook so we can dynamically be notified when media query breakpoints are hit and change the scrollable state from `true` to `false` when a responsive breakpoint is hit.  This allows `responsiveLayout="stack"` to be used in conjuction with `scrollable` giving end users much better UI/UX experience per screen size!
