### PR TITLE
Fix #3935: Dropdown allow onClick prevent default

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -67,6 +67,13 @@ export const Dropdown = React.memo(
                 return;
             }
 
+            props.onClick && props.onClick(event);
+
+            // do not continue if the user defined click wants to prevent it
+            if (event.defaultPrevented) {
+                return;
+            }
+
             if (DomHandler.hasClass(event.target, 'p-dropdown-clear-icon') || event.target.tagName === 'INPUT') {
                 return;
             } else if (!overlayRef.current || !(overlayRef.current && overlayRef.current.contains(event.target))) {


### PR DESCRIPTION
### Defect Fixes
Fix #3935: Dropdown allow onClick prevent default

this allows a user to do the following and prevent the dropdown panel from being shown.

```ts
onClick={(e) => {
      console.log('clicked');
      e.preventDefault(); // stop the panel display
}
```
