### PR TITLE
Fix #4046: Tooltip escape calls to querySelector

### DIFF
--- a/components/lib/styleclass/StyleClass.js
+++ b/components/lib/styleclass/StyleClass.js
@@ -149,7 +149,7 @@ export const StyleClass = React.forwardRef((inProps, ref) => {
                 return elementRef.current.parentElement.parentElement;
 
             default:
-                return document.querySelector(props.selector);
+                return document.querySelector(CSS.escape(props.selector));
         }
     };
 

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PrimeReact from '../api/Api';
 import { useMountEffect, useOverlayScrollListener, useResizeListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { Portal } from '../portal/Portal';
-import { classNames, DomHandler, ObjectUtils, ZIndexUtils } from '../utils/Utils';
+import { DomHandler, ObjectUtils, ZIndexUtils, classNames } from '../utils/Utils';
 import { TooltipBase } from './TooltipBase';
 
 export const Tooltip = React.memo(
@@ -373,7 +373,7 @@ export const Tooltip = React.memo(
                     operation(target);
                 } else {
                     const setEvent = (target) => {
-                        let element = DomHandler.find(document, target);
+                        let element = DomHandler.find(document, CSS.escape(target));
 
                         element.forEach((el) => {
                             operation(el);


### PR DESCRIPTION
### Defect Fixes
Fix #4046: Escape calls to querySelector

useId from React generates an id like `:r0:` which the colons make it an invalid selector which must be escaped.

It needs to be escaped with CSS.escape: https://drafts.csswg.org/cssom/#the-css.escape%28%29-method

