### PR TITLE
Fix #4062 mismatch between PrimeIcons JavaScript object and its TypeScript definition

### DIFF
--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -79,8 +79,8 @@ export interface PrimeIconsOptions {
     readonly ARROW_UP: string;
     readonly ARROW_UP_LEFT: string;
     readonly ARROW_UP_RIGHT: string;
-    readonly ARROW_H: string;
-    readonly ARROW_V: string;
+    readonly ARROWS_H: string;
+    readonly ARROWS_V: string;
     readonly AT: string;
     readonly BACKWARD: string;
     readonly BAN: string;


### PR DESCRIPTION
Fix #4062

See https://github.com/primefaces/primereact/blob/master/components/lib/api/PrimeIcons.js