### PR TITLE
Fix handling of expandedRows property for both object and array cases in Expandable Row Groups with Row Expansion

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -89,7 +89,7 @@ export const TableBody = React.memo(
 
                         if (props.expandedRows) {
                             if (Array.isArray(props.expandedRows)) {
-                                expanded = props.expandedRows.some(row => ObjectUtils.resolveFieldData(row, props.dataKey) === rowId);
+                                expanded = props.expandedRows.some((row) => ObjectUtils.resolveFieldData(row, props.dataKey) === rowId);
                             } else {
                                 expanded = props.expandedRows[rowId] !== undefined;
                             }

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -83,8 +83,22 @@ export const TableBody = React.memo(
                 if (isSubheaderGrouping && props.expandableRowGroups) {
                     return isRowGroupExpanded(rowData);
                 } else {
-                    if (props.dataKey) return props.expandedRows ? props.expandedRows[ObjectUtils.resolveFieldData(rowData, props.dataKey)] !== undefined : false;
-                    else return findIndex(props.expandedRows, rowData) !== -1;
+                    if (props.dataKey) {
+                        const rowId = ObjectUtils.resolveFieldData(rowData, props.dataKey);
+                        let expanded = false;
+
+                        if (props.expandedRows) {
+                            if (Array.isArray(props.expandedRows)) {
+                                expanded = props.expandedRows.some(row => ObjectUtils.resolveFieldData(row, props.dataKey) === rowId);
+                            } else {
+                                expanded = props.expandedRows[rowId] !== undefined;
+                            }
+                        }
+
+                        return expanded;
+                    } else {
+                        return findIndex(props.expandedRows, rowData) !== -1;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR addresses the issue where it was impossible to implement Expandable Row Groups with Row Expansion in the PrimeReact DataTable component due to incorrect handling of the expandedRows property when it's an object or an array. The changes include:

Updating the onRowToggle function to work with both object and array cases.
Modifying the expanded row check to use Array.isArray() and handle both cases accordingly.
This fix ensures proper row expansion and collapse behavior in the PrimeReact DataTable component, allowing for Expandable Row Groups with Row Expansion to be implemented successfully, regardless of the expandedRows data structure.

Defect Fixes
This PR resolves issue #2213 and #1510 "Impossible to implement Expandable Row Groups with Row Expansion". Please see the  [DataTable - Impossible to implement Expandable Row Groups with Row Expansion](https://github.com/primefaces/primereact/issues/2213) for a detailed description of the problem.

Fix #2213
Fix #1510