### PR TITLE
Fix #4193: Add the possibility to have an empty message template even with virtualscroll

### DIFF
--- a/components/lib/dropdown/DropdownPanel.js
+++ b/components/lib/dropdown/DropdownPanel.js
@@ -167,7 +167,8 @@ export const DropdownPanel = React.memo(
                         itemTemplate: (item, options) => item && createItem(item, options.index, options),
                         contentTemplate: (options) => {
                             const className = classNames('p-dropdown-items', options.className);
-                            const content = isEmptyFilter ? createEmptyMessage() : options.children;
+                            const emptyMessage = props.hasFilter ? props.emptyFilterMessage : props.emptyMessage;
+                            const content = isEmptyFilter ? createEmptyMessage(emptyMessage) : options.children;
 
                             return (
                                 <ul ref={options.contentRef} style={options.style} className={className} role="listbox">

--- a/components/lib/dropdown/dropdown.d.ts
+++ b/components/lib/dropdown/dropdown.d.ts
@@ -155,7 +155,7 @@ export interface DropdownProps extends Omit<React.DetailedHTMLProps<React.InputH
      * The template of filter element.
      * @deprecated Since v9.3.0
      */
-    filterTemplate?: React.ReactNode | ((options: DropdownFilterOptions) => React.ReactNode) | undefined;
+    filterTemplate?: React.ReactNode | ((options: { filterOptions: DropdownFilterOptions }) => React.ReactNode) | undefined;
     /**
      * Reference of the focusable input element.
      */


### PR DESCRIPTION
### Defect Fixes
Fix #4193 Add the possibility to have an empty message template even with virtualscroll #4193 
Fix error in Typescript typing
