### PR TITLE
Fix #4221: Mention target must always be input textarea

### DIFF
--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -182,6 +182,7 @@ export const Mention = React.memo(
                 const nextText = value.substring(triggerState.index + currentText.length);
 
                 inputRef.current.value = `${prevText}${selectedText} ${nextText}`;
+                event.target = inputRef.current;
                 props.onChange && props.onChange(event);
             }
 


### PR DESCRIPTION
Fix #4221: Mention target must always be input textarea

When using mouse event.target was `<li>` and when using ENTER on keyboard it was `<textarea>` the target should always be `textarea`
