### PR TITLE
Fix #4235: Tabview check for conditionally rendered panels

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -31,7 +31,7 @@ export const TabView = React.forwardRef((inProps, ref) => {
     const getTabProp = (tab, name) => TabPanelBase.getCProp(tab, name);
 
     const shouldUseTab = (tab, index) => {
-        return ObjectUtils.isValidChild(tab, 'TabPanel') && hiddenTabsState.every((_i) => _i !== index);
+        return tab && ObjectUtils.isValidChild(tab, 'TabPanel') && hiddenTabsState.every((_i) => _i !== index);
     };
 
     const findVisibleActiveTab = (i) => {


### PR DESCRIPTION
Fix #4235: Tabview check for conditionally rendered panels

The `tab` can actually be the value `false`.
