### PR TITLE
Fix #4244: BodyRow add rowindex to key

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -298,7 +298,7 @@ export const BodyRow = React.memo((props) => {
     const createContent = () => {
         return props.columns.map((col, i) => {
             if (shouldRenderBodyCell(props.value, col, props.index)) {
-                const key = `${getColumnProp(col, 'columnKey') || getColumnProp(col, 'field')}_${i}`;
+                const key = `${props.rowIndex}_${getColumnProp(col, 'columnKey') || getColumnProp(col, 'field')}_${i}`;
                 const rowSpan = props.rowGroupMode === 'rowspan' ? calculateRowGroupSize(props.value, col, props.index) : null;
 
                 return (


### PR DESCRIPTION
Fix #4244: BodyRow add rowindex to key
