### PR TITLE
Fix #4289: InputMask autoClear doc default

### DIFF
--- a/components/lib/inputmask/inputmask.d.ts
+++ b/components/lib/inputmask/inputmask.d.ts
@@ -52,7 +52,7 @@ export interface InputMaskProps extends Omit<InputTextProps, 'onChange'> {
     slotChar?: string | undefined;
     /**
      * Clears the incomplete value on blur.
-     * @defaultValue false
+     * @defaultValue true
      */
     autoClear?: boolean | undefined;
     /**


### PR DESCRIPTION
Fix #4289: InputMask autoClear doc default
