### PR TITLE
Removes border radius for maximized Dialog

### DIFF
--- a/components/lib/dialog/Dialog.css
+++ b/components/lib/dialog/Dialog.css
@@ -166,6 +166,11 @@
     left: 0px !important;
 }
 
+.p-dialog-maximized .p-dialog-content:last-of-type,
+.p-dialog-maximized .p-dialog-header {
+    border-radius: 0;
+}
+
 .p-dialog-maximized .p-dialog-content {
     flex-grow: 1;
 }


### PR DESCRIPTION
themes with dialog radius add top radius on .p-dialog-header and bottom radius on p.dialog-content:last-of-type.

### Defect Fixes

Fix #4310 
#<4310>


### Things I haven't tested
I'm a new contributor, I haven't played around much with themes yet so I haven't tested how that plays along with other themes overwrite. If there's any guidance to be given here I'm all ears.

### Result with default theme
https://user-images.githubusercontent.com/1691052/235313572-08319db4-af37-4a46-b10f-5c204ab55aaf.mov

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
