### PR TITLE
Fix #4327: Datatable allow custom filter icons

### DIFF
--- a/components/lib/datatable/ColumnFilter.js
+++ b/components/lib/datatable/ColumnFilter.js
@@ -5,15 +5,15 @@ import { ColumnBase } from '../column/ColumnBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { Dropdown } from '../dropdown/Dropdown';
 import { useOverlayListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
+import { FilterIcon } from '../icons/filter';
+import { FilterSlashIcon } from '../icons/filterslash';
+import { PlusIcon } from '../icons/plus';
+import { TrashIcon } from '../icons/trash';
 import { InputText } from '../inputtext/InputText';
 import { OverlayService } from '../overlayservice/OverlayService';
 import { Portal } from '../portal/Portal';
 import { Ripple } from '../ripple/Ripple';
-import { classNames, DomHandler, IconUtils, ObjectUtils, ZIndexUtils } from '../utils/Utils';
-import { FilterIcon } from '../icons/filter';
-import { FilterSlashIcon } from '../icons/filterslash';
-import { TrashIcon } from '../icons/trash';
-import { PlusIcon } from '../icons/plus';
+import { DomHandler, IconUtils, ObjectUtils, ZIndexUtils, classNames } from '../utils/Utils';
 
 export const ColumnFilter = React.memo((props) => {
     const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
@@ -484,7 +484,7 @@ export const ColumnFilter = React.memo((props) => {
 
     const createMenuButton = () => {
         const iconProps = { 'aria-hidden': true };
-        const icon = props.columnFilterIcon || <FilterIcon {...iconProps} />;
+        const icon = props.filterIcon || <FilterIcon {...iconProps} />;
         const columnFilterIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
 
         if (showMenuButton()) {

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1459,6 +1459,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 filterDisplay={props.filterDisplay}
                 filters={filters}
                 filtersStore={filtersStore}
+                filterIcon={props.filterIcon}
+                filterClearIcon={props.filterClearIcon}
                 onFilterChange={onFilterChange}
                 onFilterApply={onFilterApply}
                 showSelectAll={props.showSelectAll}

--- a/components/lib/datatable/DataTableBase.js
+++ b/components/lib/datatable/DataTableBase.js
@@ -33,6 +33,8 @@ export const DataTableBase = {
         filterDisplay: 'menu',
         filterLocale: undefined,
         filters: null,
+        filterIcon: null,
+        filterClearIcon: null,
         first: 0,
         footer: null,
         footerColumnGroup: null,

--- a/components/lib/datatable/HeaderCell.js
+++ b/components/lib/datatable/HeaderCell.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
 import { usePrevious } from '../hooks/Hooks';
+import { SortAltIcon } from '../icons/sortalt';
+import { SortAmountDownIcon } from '../icons/sortamountdown';
+import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 import { Tooltip } from '../tooltip/Tooltip';
 import { classNames, DomHandler, IconUtils, ObjectUtils } from '../utils/Utils';
 import { ColumnFilter } from './ColumnFilter';
 import { HeaderCheckbox } from './HeaderCheckbox';
-import { SortAltIcon } from '../icons/sortalt';
-import { SortAmountDownIcon } from '../icons/sortamountdown';
-import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 
 export const HeaderCell = React.memo((props) => {
     const [styleObjectState, setStyleObjectState] = React.useState({});
@@ -247,7 +247,18 @@ export const HeaderCell = React.memo((props) => {
 
     const createFilter = () => {
         if (props.filterDisplay === 'menu' && getColumnProp('filter')) {
-            return <ColumnFilter display="menu" column={props.column} filters={props.filters} onFilterChange={props.onFilterChange} onFilterApply={props.onFilterApply} filtersStore={props.filtersStore} />;
+            return (
+                <ColumnFilter
+                    display="menu"
+                    column={props.column}
+                    filters={props.filters}
+                    onFilterChange={props.onFilterChange}
+                    onFilterApply={props.onFilterApply}
+                    filtersStore={props.filtersStore}
+                    filterIcon={props.filterIcon}
+                    filterClearIcon={props.filterClearIcon}
+                />
+            );
         }
 
         return null;

--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -826,6 +826,14 @@ export interface DataTableProps<TValue extends DataTableValueArray> extends Omit
      */
     filterLocale?: string | undefined;
     /**
+     * Icon to display the current filtering status.
+     */
+    filterIcon?: IconType<DataTable<TValue>> | undefined;
+    /**
+     * Icon to display when the filter can be cleared.
+     */
+    filterClearIcon?: IconType<DataTable<TValue>> | undefined;
+    /**
      * An array of FilterMetadata objects to provide external filters.
      */
     filters?: DataTableFilterMeta | undefined;


### PR DESCRIPTION
Fix #4327: Datatable allow custom filter icons
