### PR TITLE
Fix #4339: Allow control of cell editor

### DIFF
--- a/components/lib/column/column.d.ts
+++ b/components/lib/column/column.d.ts
@@ -769,7 +769,7 @@ export interface ColumnProps {
      */
     onBeforeCellEditHide?(event: ColumnEvent): void;
     /**
-     * Callback to invoke before the cell editor is shown.
+     * Callback to invoke before the cell editor is shown. To prevent editor from showing return false or originalEvent.preventDefault().
      * @param {ColumnEvent} event - Custom event.
      */
     onBeforeCellEditShow?(event: ColumnEvent): void;
@@ -784,7 +784,7 @@ export interface ColumnProps {
      */
     onCellEditComplete?(event: ColumnEvent): void;
     /**
-     * Callback to invoke when cell edit is initiated.
+     * Callback to invoke when cell edit is initiated. To prevent editor from showing return false or originalEvent.preventDefault().
      * @param {ColumnEvent} event - Custom event.
      */
     onCellEditInit?(event: ColumnEvent): void;

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -275,7 +275,15 @@ export const BodyCell = React.memo((props) => {
             const cellEditValidatorEvent = getColumnProp('cellEditValidatorEvent');
 
             if (onBeforeCellEditShow) {
-                onBeforeCellEditShow(params);
+                // if user returns false do not show the editor
+                if (onBeforeCellEditShow(params) === false) {
+                    return;
+                }
+
+                // if user prevents default stop the editor
+                if (event && event.defaultPrevented) {
+                    return;
+                }
             }
 
             // If the data is sorted using sort icon, it has been added to wait for the sort operation when any cell is wanted to be opened.
@@ -283,7 +291,14 @@ export const BodyCell = React.memo((props) => {
                 setEditingState(true);
 
                 if (onCellEditInit) {
-                    onCellEditInit(params);
+                    if (onCellEditInit(params) === false) {
+                        return;
+                    }
+
+                    // if user prevents default stop the editor
+                    if (event && event.defaultPrevented) {
+                        return;
+                    }
                 }
 
                 if (cellEditValidatorEvent === 'click') {


### PR DESCRIPTION
Fix #4339: Allow control of cell editor

You can now `return false;` or `originalEvent.preventDefault()` to stop the editor from displaying.

```js
const onBeforeCellEditShow = (e) => {
        let { rowData, newValue, field, originalEvent: event } = e;

        // do not show the cell editor just for the price field
        if (field === 'price') {
            event.preventDefault();
        }
};
```
