### PR TITLE
Fix #4350: Update messages examples and useMountEffect

### DIFF
--- a/components/doc/messages/basicdoc.js
+++ b/components/doc/messages/basicdoc.js
@@ -1,14 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useMountEffect } from '../../lib/hooks/Hooks';
 import { Messages } from '../../lib/messages/Messages';
-import { DocSectionText } from '../common/docsectiontext';
 import { DocSectionCode } from '../common/docsectioncode';
+import { DocSectionText } from '../common/docsectiontext';
 
 export function BasicDoc(props) {
     const msgs = useRef(null);
 
-    useEffect(() => {
-        msgs.current.show({ sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false });
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    useMountEffect(() => {
+        msgs.current && msgs.current.show({ id: '1', sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false });
+    });
 
     const code = {
         basic: `
@@ -16,16 +17,17 @@ export function BasicDoc(props) {
         `,
         javascript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function BasicDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show(
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false }
         );
-    }, []); 
+    }); 
 
     return (
         <div className="card flex justify-content-center">
@@ -36,16 +38,17 @@ export default function BasicDemo() {
         `,
         typescript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function BasicDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show(
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false }
         );
-    }, []);
+    });
 
     return (
         <div className="card flex justify-content-center">

--- a/components/doc/messages/closeabledoc.js
+++ b/components/doc/messages/closeabledoc.js
@@ -1,17 +1,18 @@
-import { useEffect, useRef } from 'react';
-import { DocSectionText } from '../common/docsectiontext';
-import { DocSectionCode } from '../common/docsectioncode';
+import { useRef } from 'react';
+import { useMountEffect } from '../../lib/hooks/Hooks';
 import { Messages } from '../../lib/messages/Messages';
+import { DocSectionCode } from '../common/docsectioncode';
+import { DocSectionText } from '../common/docsectiontext';
 
 export function ClosableDoc(props) {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Closable Message' },
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Not Closable Message', closable: false }
         ]);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    });
 
     const code = {
         basic: `
@@ -22,17 +23,18 @@ msgs.current.show([
         `,
         javascript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function ClosableDemo() {
     const msgs = useRef(null);
     
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Closable Message'},
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Not Closable Message', closable: false}
         ]);
-    }, []);
+    });
 
     return (
         <div className="card">
@@ -43,18 +45,19 @@ export default function ClosableDemo() {
         `,
         typescript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function ClosableDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current?.show([
             msgs.current.show([
                 { sticky: true, severity: 'success', summary: 'Success', detail: 'Closable Message'},
                 { sticky: true, severity: 'info', summary: 'Info', detail: 'Not Closable Message', closable: false}
             ]);
-    }, []);
+    };
 
     return (
         <div className="card">

--- a/components/doc/messages/severitydoc.js
+++ b/components/doc/messages/severitydoc.js
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
+import { useMountEffect } from '../../lib/hooks/Hooks';
 import { Messages } from '../../lib/messages/Messages';
 import { DocSectionCode } from '../common/docsectioncode';
 import { DocSectionText } from '../common/docsectiontext';
@@ -6,14 +7,14 @@ import { DocSectionText } from '../common/docsectiontext';
 export function SeverityDoc(props) {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
         ]);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    });
 
     const code = {
         basic: `
@@ -25,20 +26,21 @@ msgs.current.show([
 ]);
         `,
         javascript: `
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function SeverityDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             {sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false},
             {sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false},
             {sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false},
             {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false}
         ]);
-    }, []);
+    });
 
     return (
         <Messages ref={msgs} />
@@ -46,20 +48,21 @@ export default function SeverityDemo() {
 }
         `,
         typescript: `
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function SeverityDemo() {
     const msgs = useRef<Messages>(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current?.show([
             {sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content'},
             {sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content'},
             {sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content'},
             {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content'}
         ]);
-    }, []);
+    });
 
     return (
         <Messages ref={msgs} />

--- a/components/doc/messages/stickydoc.js
+++ b/components/doc/messages/stickydoc.js
@@ -1,46 +1,46 @@
-import { useEffect, useRef } from 'react';
-import { DocSectionText } from '../common/docsectiontext';
-import { DocSectionCode } from '../common/docsectioncode';
+import { useRef } from 'react';
+import { useMountEffect } from '../../lib/hooks/Hooks';
 import { Messages } from '../../lib/messages/Messages';
+import { DocSectionCode } from '../common/docsectioncode';
+import { DocSectionText } from '../common/docsectiontext';
 
 export function StickyDoc(props) {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
         ]);
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    });
 
     const code = {
         basic: `
-useEffect(() => {
-    msgs.current.show([
+msgs.current.show([
         { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
         { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
         { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
         { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
-    ]);
-}, []);
+]);
         `,
         javascript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function StickyDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show([
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
         ]);
-    }, []);
+    });
 
     return (
         <div className="card">
@@ -51,19 +51,20 @@ export default function StickyDemo() {
         `,
         typescript: `
 import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function StickyDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current?.show([
             { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
             { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
         ]);
-    }, []);
+    });
 
     return (
         <div className="card">

--- a/components/doc/messages/templatedoc.js
+++ b/components/doc/messages/templatedoc.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
+import { useMountEffect } from '../../lib/hooks/Hooks';
 import { Messages } from '../../lib/messages/Messages';
 import { DocSectionCode } from '../common/docsectioncode';
 import { DocSectionText } from '../common/docsectiontext';
@@ -6,7 +7,7 @@ import { DocSectionText } from '../common/docsectiontext';
 export function TemplateDoc(props) {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show({
             severity: 'info',
             sticky: true,
@@ -17,11 +18,10 @@ export function TemplateDoc(props) {
                 </React.Fragment>
             )
         });
-    }, []);
+    });
 
     const code = {
         basic: `
-useEffect(() => {
     msgs.current.show({
         severity: 'info',
         sticky: true,
@@ -32,16 +32,16 @@ useEffect(() => {
             </React.Fragment>
         )
     });
-}, []);
         `,
         javascript: `
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function TemplateDemo() {
     const msgs = useRef(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current.show({
             severity: 'info', sticky: true, content: (
                 <React.Fragment>
@@ -50,7 +50,7 @@ export default function TemplateDemo() {
                 </React.Fragment>
             )
         });
-    }, []);
+    });
 
     return (
         <div className="card">
@@ -60,13 +60,14 @@ export default function TemplateDemo() {
 }
         `,
         typescript: `
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react'; 
+import { useMountEffect } from 'primereact/hooks';
 import { Messages } from 'primereact/messages';
 
 export default function TemplateDemo() {
     const msgs = useRef<Messages>(null);
 
-    useEffect(() => {
+    useMountEffect(() => {
         msgs.current?.show({
             severity: 'info', sticky: true, content: (
                 <React.Fragment>
@@ -75,7 +76,7 @@ export default function TemplateDemo() {
                 </React.Fragment>
             )
         });
-    }, []);
+    });
 
     return (
         <div className="card">

--- a/components/lib/hooks/useMountEffect.js
+++ b/components/lib/hooks/useMountEffect.js
@@ -1,5 +1,20 @@
 /* eslint-disable */
 import * as React from 'react';
 
-export const useMountEffect = (fn) => React.useEffect(fn, []);
+/**
+ * Custom hook to run a mount effect only once. Accounts for React 18 Strict Mode by making sure it only runs exactly once.
+ * @param {*} fn the callback function
+ * @returns the hook
+ */
+export const useMountEffect = (fn) => {
+    const mounted = React.useRef(false);
+    return React.useEffect(() => {
+        if (!mounted.current) {
+            mounted.current = true;
+            return fn && fn();
+        }
+
+        return;
+    }, []);
+};
 /* eslint-enable */

--- a/components/lib/toast/toast.d.ts
+++ b/components/lib/toast/toast.d.ts
@@ -16,6 +16,10 @@ import { IconType } from '../utils/utils';
  */
 export interface ToastMessage {
     /**
+     * Unique id of the message.
+     */
+    id?: string | undefined;
+    /**
      * Severity of the message.
      */
     severity?: 'success' | 'info' | 'warn' | 'error' | undefined;


### PR DESCRIPTION
Fix #4350: Update messages examples and useMountEffect
