### PR TITLE
Fix #4405: onColumnResize end should use absolute value of delta

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -502,7 +502,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     };
 
     const onColumnResizeEnd = () => {
-        let delta = resizeHelperRef.current.offsetLeft - lastResizeHelperX.current;
+        let delta = Math.abs(resizeHelperRef.current.offsetLeft - lastResizeHelperX.current);
         let columnWidth = resizeColumnElement.current.offsetWidth;
         let newColumnWidth = columnWidth + delta;
         let minWidth = resizeColumnElement.current.style.minWidth || 15;


### PR DESCRIPTION
Fix #4405: onColumnResize end should use absolute value of delta
