### PR TITLE
Fix #4462: TabView do not scroll into view on page load

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { ariaLabel } from '../api/Api';
 import { useMountEffect, useUpdateEffect } from '../hooks/Hooks';
-import { Ripple } from '../ripple/Ripple';
-import { classNames, IconUtils, DomHandler, ObjectUtils, UniqueComponentId, mergeProps } from '../utils/Utils';
-import { TabPanelBase, TabViewBase } from './TabViewBase';
-import { ChevronRightIcon } from '../icons/chevronright';
 import { ChevronLeftIcon } from '../icons/chevronleft';
+import { ChevronRightIcon } from '../icons/chevronright';
 import { TimesIcon } from '../icons/times';
+import { Ripple } from '../ripple/Ripple';
+import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, classNames, mergeProps } from '../utils/Utils';
+import { TabPanelBase, TabViewBase } from './TabViewBase';
 
 export const TabPanel = () => {};
 
@@ -180,7 +180,9 @@ export const TabView = React.forwardRef((inProps, ref) => {
     }, [hiddenTabsState]);
 
     useUpdateEffect(() => {
-        updateScrollBar(props.activeIndex);
+        if (props.activeIndex !== activeIndexState) {
+            updateScrollBar(props.activeIndex);
+        }
     }, [props.activeIndex]);
 
     React.useImperativeHandle(ref, () => ({


### PR DESCRIPTION
Fix #4462: TabView do not scroll into view on page load
