### PR TITLE
Fix #4465: KeyFilter Android fix

### DIFF
--- a/components/doc/keyfilter/presetsdoc.js
+++ b/components/doc/keyfilter/presetsdoc.js
@@ -6,11 +6,14 @@ export function PresetsDoc(props) {
     const code = {
         basic: `
 <InputText keyfilter="int" />
+<InputText keyfilter="pint" />
 <InputText keyfilter="num" />
+<InputText keyfilter="pnum" />
 <InputText keyfilter="money" />
 <InputText keyfilter="hex" />
 <InputText keyfilter="alpha" />
 <InputText keyfilter="alphanum" />
+<InputText keyfilter="email" />
         `,
         javascript: `
 import React from 'react'; 
@@ -39,7 +42,7 @@ export default function PresetsDemo() {
                     <InputText id="money" keyfilter="money" className="w-full" />
                 </div>
             </div>
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-3 mb-4">
                 <div className="flex-auto">
                     <label htmlFor="hex" className="font-bold block mb-2">
                         Hex
@@ -57,6 +60,26 @@ export default function PresetsDemo() {
                         Alphanumeric
                     </label>
                     <InputText id="alphanumeric" keyfilter="alphanum" className="w-full" />
+                </div>
+            </div>
+            <div className="flex flex-wrap gap-3">
+                <div className="flex-auto">
+                    <label htmlFor="pint" className="font-bold block mb-2">
+                            Positive Integer
+                    </label>
+                    <InputText id="pint" keyfilter="pint" className="w-full" />
+                </div>
+                <div className="flex-auto">
+                    <label htmlFor="pnum" className="font-bold block mb-2">
+                            Positive Number
+                    </label>
+                    <InputText id="pnum" keyfilter="pnum" className="w-full" />
+                </div>
+                <div className="flex-auto">
+                    <label htmlFor="email" className="font-bold block mb-2">
+                            Email
+                    </label>
+                    <InputText id="email" keyfilter="email" className="w-full" />
                 </div>
             </div>
         </div>
@@ -90,7 +113,7 @@ export default function PresetsDemo() {
                     <InputText id="money" keyfilter="money" className="w-full" />
                 </div>
             </div>
-            <div className="flex flex-wrap gap-3">
+            <div className="flex flex-wrap gap-3 mb-4">
                 <div className="flex-auto">
                     <label htmlFor="hex" className="font-bold block mb-2">
                         Hex
@@ -108,6 +131,26 @@ export default function PresetsDemo() {
                         Alphanumeric
                     </label>
                     <InputText id="alphanumeric" keyfilter="alphanum" className="w-full" />
+                </div>
+            </div>
+            <div className="flex flex-wrap gap-3">
+                <div className="flex-auto">
+                    <label htmlFor="pint" className="font-bold block mb-2">
+                            Positive Integer
+                    </label>
+                    <InputText id="pint" keyfilter="pint" className="w-full" />
+                </div>
+                <div className="flex-auto">
+                    <label htmlFor="pnum" className="font-bold block mb-2">
+                            Positive Number
+                    </label>
+                    <InputText id="pnum" keyfilter="pnum" className="w-full" />
+                </div>
+                <div className="flex-auto">
+                    <label htmlFor="email" className="font-bold block mb-2">
+                            Email
+                    </label>
+                    <InputText id="email" keyfilter="email" className="w-full" />
                 </div>
             </div>
         </div>
@@ -144,7 +187,7 @@ export default function PresetsDemo() {
                         <InputText id="money" keyfilter="money" className="w-full" />
                     </div>
                 </div>
-                <div className="flex flex-wrap gap-3">
+                <div className="flex flex-wrap gap-3 mb-4">
                     <div className="flex-auto">
                         <label htmlFor="hex" className="font-bold block mb-2">
                             Hex
@@ -162,6 +205,26 @@ export default function PresetsDemo() {
                             Alphanumeric
                         </label>
                         <InputText id="alphanumeric" keyfilter="alphanum" className="w-full" />
+                    </div>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                    <div className="flex-auto">
+                        <label htmlFor="pint" className="font-bold block mb-2">
+                            Positive Integer
+                        </label>
+                        <InputText id="pint" keyfilter="pint" className="w-full" />
+                    </div>
+                    <div className="flex-auto">
+                        <label htmlFor="pnum" className="font-bold block mb-2">
+                            Positive Number
+                        </label>
+                        <InputText id="pnum" keyfilter="pnum" className="w-full" />
+                    </div>
+                    <div className="flex-auto">
+                        <label htmlFor="email" className="font-bold block mb-2">
+                            Email
+                        </label>
+                        <InputText id="email" keyfilter="email" className="w-full" />
                     </div>
                 </div>
             </div>

--- a/components/lib/inputtext/InputText.js
+++ b/components/lib/inputtext/InputText.js
@@ -20,6 +20,14 @@ export const InputText = React.memo(
             }
         };
 
+        const onBeforeInput = (event) => {
+            props.onBeforeInput && props.onBeforeInput(event);
+
+            if (props.keyfilter) {
+                KeyFilter.onBeforeInput(event, props.keyfilter, props.validateOnly);
+            }
+        };
+
         const onInput = (event) => {
             const target = event.target;
             let validatePattern = true;
@@ -61,9 +69,10 @@ export const InputText = React.memo(
             {
                 ref: elementRef,
                 className,
-                onInput: (e) => onInput(e),
-                onKeyDown: (e) => onKeyDown(e),
-                onPaste: (e) => onPaste(e)
+                onBeforeInput: onBeforeInput,
+                onInput: onInput,
+                onKeyDown: onKeyDown,
+                onPaste: onPaste
             },
             InputTextBase.getOtherProps(props),
             ptm('root')

--- a/components/lib/inputtext/InputTextBase.js
+++ b/components/lib/inputtext/InputTextBase.js
@@ -7,6 +7,7 @@ export const InputTextBase = ComponentBase.extend({
         validateOnly: false,
         tooltip: null,
         tooltipOptions: null,
+        onBeforeInput: null,
         onInput: null,
         onKeyDown: null,
         onPaste: null,

--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -47,6 +47,14 @@ export const InputTextarea = React.memo(
             }
         };
 
+        const onBeforeInput = (event) => {
+            props.onBeforeInput && props.onBeforeInput(event);
+
+            if (props.keyfilter) {
+                KeyFilter.onBeforeInput(event, props.keyfilter, props.validateOnly);
+            }
+        };
+
         const onPaste = (event) => {
             props.onPaste && props.onPaste(event);
 
@@ -122,6 +130,7 @@ export const InputTextarea = React.memo(
                 onBlur: onBlur,
                 onKeyUp: onKeyUp,
                 onKeyDown: onKeyDown,
+                onBeforeInput: onBeforeInput,
                 onInput: onInput,
                 onPaste: onPaste
             },

--- a/components/lib/inputtextarea/InputTextareaBase.js
+++ b/components/lib/inputtextarea/InputTextareaBase.js
@@ -7,6 +7,7 @@ export const InputTextareaBase = ComponentBase.extend({
         keyfilter: null,
         onBlur: null,
         onFocus: null,
+        onBeforeInput: null,
         onInput: null,
         onKeyDown: null,
         onKeyUp: null,

--- a/components/lib/keyfilter/KeyFilter.js
+++ b/components/lib/keyfilter/KeyFilter.js
@@ -1,3 +1,5 @@
+import { DomHandler } from '../utils/Utils';
+
 export const KeyFilter = {
     /* eslint-disable */
     DEFAULT_MASKS: {
@@ -17,8 +19,18 @@ export const KeyFilter = {
         return KeyFilter.DEFAULT_MASKS[keyfilter] ? KeyFilter.DEFAULT_MASKS[keyfilter] : keyfilter;
     },
 
+    onBeforeInput(e, keyfilter, validateOnly) {
+        // android devices must use beforeinput https://stackoverflow.com/questions/36753548/keycode-on-android-is-always-229
+        if (validateOnly || !DomHandler.isAndroid()) {
+            return;
+        }
+
+        this.validateKey(e, e.data, keyfilter);
+    },
+
     onKeyPress(e, keyfilter, validateOnly) {
-        if (validateOnly) {
+        // non android devices use keydown
+        if (validateOnly || DomHandler.isAndroid()) {
             return;
         }
 
@@ -26,17 +38,7 @@ export const KeyFilter = {
             return;
         }
 
-        const isPrintableKey = e.key.length === 1;
-
-        if (!isPrintableKey) {
-            return;
-        }
-
-        const regex = this.getRegex(keyfilter);
-
-        if (!regex.test(e.key)) {
-            e.preventDefault();
-        }
+        this.validateKey(e, e.key, keyfilter);
     },
 
     onPaste(e, keyfilter, validateOnly) {
@@ -55,6 +57,24 @@ export const KeyFilter = {
                 return false;
             }
         });
+    },
+
+    validateKey(e, key, keyfilter) {
+        if (key === null || key === undefined) {
+            return;
+        }
+
+        const isPrintableKey = key.length === 1;
+
+        if (!isPrintableKey) {
+            return;
+        }
+
+        const regex = this.getRegex(keyfilter);
+
+        if (!regex.test(key)) {
+            e.preventDefault();
+        }
     },
 
     validate(e, keyfilter) {


### PR DESCRIPTION
Fix #4465: KeyFilter Android fix
Fix #981

Because Android chooses not to implement `e.key` in onKeyDown then `onBeforeInput` is the recommendation to use for Android and check `e.data` value.