### PR TITLE
Fix #4486: PassThrough Image does not support referrerpolicy

### DIFF
--- a/components/lib/avatar/avatar.d.ts
+++ b/components/lib/avatar/avatar.d.ts
@@ -38,7 +38,7 @@ export interface AvatarPassThroughOptions {
     /**
      * Uses to pass attributes to the image's DOM element.
      */
-    image?: AvatarPassThroughType<React.HTMLAttributes<HTMLImageElement>>;
+    image?: AvatarPassThroughType<React.ImgHTMLAttributes<HTMLImageElement>>;
 }
 
 /**

--- a/components/lib/chip/chip.d.ts
+++ b/components/lib/chip/chip.d.ts
@@ -31,7 +31,7 @@ export interface ChipPassThroughOptions {
     /**
      * Uses to pass attributes to the image's DOM element.
      */
-    image?: ChipPassThroughType<React.HTMLAttributes<HTMLImageElement>>;
+    image?: ChipPassThroughType<React.ImgHTMLAttributes<HTMLImageElement>>;
     /**
      * Uses to pass attributes to the icon's DOM element.
      */

--- a/components/lib/fileupload/fileupload.d.ts
+++ b/components/lib/fileupload/fileupload.d.ts
@@ -8,11 +8,11 @@
  *
  */
 import * as React from 'react';
-import { IconType, PassThroughType } from '../utils';
+import { BadgePassThroughOptions } from '../badge/badge';
 import { ButtonPassThroughOptions } from '../button/button';
 import { MessagePassThroughOptions } from '../message/message';
 import { ProgressBarPassThroughOptions } from '../progressbar/progressbar';
-import { BadgePassThroughOptions } from '../badge/badge';
+import { IconType, PassThroughType } from '../utils';
 
 export declare type FileUploadPassThroughType<T> = PassThroughType<T, FileUploadPassThroughMethodOptions>;
 
@@ -84,7 +84,7 @@ export interface FileUploadPassThroughOptions {
     /**
      * Uses to pass attributes to the thumbnail's DOM element.
      */
-    thumbnail?: FileUploadPassThroughType<React.HTMLAttributes<HTMLImageElement>>;
+    thumbnail?: FileUploadPassThroughType<React.ImgHTMLAttributes<HTMLImageElement>>;
     /**
      * Uses to pass attributes to the details's DOM element.
      */

--- a/components/lib/image/image.d.ts
+++ b/components/lib/image/image.d.ts
@@ -32,7 +32,7 @@ export interface ImagePassThroughOptions {
     /**
      * Uses to pass attributes to the image's DOM element.
      */
-    image?: ImagePassThroughType<React.HTMLAttributes<HTMLImageElement>>;
+    image?: ImagePassThroughType<React.ImgHTMLAttributes<HTMLImageElement>>;
     /**
      * Uses to pass attributes to the button's DOM element.
      */
@@ -104,7 +104,7 @@ export interface ImagePassThroughOptions {
     /**
      * Uses to pass attributes to the preview's DOM element.
      */
-    preview?: ImagePassThroughType<React.HTMLAttributes<HTMLImageElement>>;
+    preview?: ImagePassThroughType<React.ImgHTMLAttributes<HTMLImageElement>>;
 }
 
 /**


### PR DESCRIPTION
Fix #4486: Avatar Image passthrough typescript
