### PR TITLE
Feature #3678 TreeSelect: nodeTemplate property

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -43795,6 +43795,14 @@
                             "type": "ReactNode | Function",
                             "default": "",
                             "description": "The template of selected values."
+                        },
+                        {
+                            "name": "nodeTemplate",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ReactNode | Function",
+                            "default": "false",
+                            "description": "Template of internally used tree component node element."
                         }
                     ]
                 },

--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -517,6 +517,7 @@ export const TreeSelect = React.memo(
                         filterLocale={props.filterLocale}
                         showHeader={false}
                         onFilterValueChange={onFilterValueChange}
+                        nodeTemplate={props.nodeTemplate}
                         pt={ptm('tree')}
                     ></Tree>
 

--- a/components/lib/treeselect/TreeSelectBase.js
+++ b/components/lib/treeselect/TreeSelectBase.js
@@ -48,6 +48,7 @@ export const TreeSelectBase = ComponentBase.extend({
         transitionOptions: null,
         value: null,
         valueTemplate: null,
+        nodeTemplate: false,
         children: undefined
     }
 });

--- a/components/lib/treeselect/treeselect.d.ts
+++ b/components/lib/treeselect/treeselect.d.ts
@@ -9,7 +9,7 @@
  */
 import * as React from 'react';
 import { CSSTransitionProps } from '../csstransition';
-import { TreePassThroughOptions } from '../tree/tree';
+import { TreeNodeTemplateOptions, TreePassThroughOptions } from '../tree/tree';
 import { TreeNode } from '../treenode';
 import { FormEvent } from '../ts-helpers';
 import { IconType, PassThroughType } from '../utils/utils';
@@ -442,6 +442,11 @@ export interface TreeSelectProps extends Omit<React.DetailedHTMLProps<React.Inpu
      * The template of selected values.
      */
     valueTemplate?: React.ReactNode | ((selectedNodes: TreeNode | TreeNode[], props: TreeSelectProps) => React.ReactNode);
+    /**
+     * Template of internally used tree component node element.
+     * @defaultValue false
+     */
+    nodeTemplate?: React.ReactNode | ((node: TreeNode, options: TreeNodeTemplateOptions) => React.ReactNode);
     /**
      * Callback to invoke when selection changes.
      * @param {TreeSelectChangeEvent} event - Custom change event.


### PR DESCRIPTION
### Feature Requests

Fixes #3678 - add the nodeTemplate property to the `TreeSelect` component and pass it on to the `Tree` component 
