### PR TITLE
fixing select all issue in multiselect component

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -397,17 +397,21 @@ export const MultiSelect = React.memo(
                 const options = visibleOptions.filter((option) => !isOptionDisabled(option));
 
                 if (props.optionGroupLabel) {
+                    let anyOptionLeftUnchecked = false
                     for (let optionGroup of options) {
                         const visibleOptionsGroupChildren = getOptionGroupChildren(optionGroup).filter((option) => !isOptionDisabled(option));
-
-                        return !visibleOptionsGroupChildren.some((option) => !isSelected(option));
+                        
+                        if(visibleOptionsGroupChildren.some((option) => !isSelected(option)) === true) {
+                            anyOptionLeftUnchecked = true
+                        }
                     }
+
+                    return !anyOptionLeftUnchecked
                 } else {
+
                     return !options.some((option) => !isSelected(option));
                 }
             }
-
-            return true;
         };
 
         const getOptionLabel = (option) => {

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -397,16 +397,16 @@ export const MultiSelect = React.memo(
                 const options = visibleOptions.filter((option) => !isOptionDisabled(option));
 
                 if (props.optionGroupLabel) {
-                    let anyOptionLeftUnchecked = false
+                    let anyOptionLeftUnchecked = false;
                     for (let optionGroup of options) {
                         const visibleOptionsGroupChildren = getOptionGroupChildren(optionGroup).filter((option) => !isOptionDisabled(option));
                         
                         if(visibleOptionsGroupChildren.some((option) => !isSelected(option)) === true) {
-                            anyOptionLeftUnchecked = true
+                            anyOptionLeftUnchecked = true;
                         }
                     }
 
-                    return !anyOptionLeftUnchecked
+                    return !anyOptionLeftUnchecked;
                 } else {
 
                     return !options.some((option) => !isSelected(option));

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -401,15 +401,14 @@ export const MultiSelect = React.memo(
 
                     for (let optionGroup of options) {
                         const visibleOptionsGroupChildren = getOptionGroupChildren(optionGroup).filter((option) => !isOptionDisabled(option));
-                        
-                        if(visibleOptionsGroupChildren.some((option) => !isSelected(option)) === true) {
+
+                        if (visibleOptionsGroupChildren.some((option) => !isSelected(option)) === true) {
                             areAllSelected = false;
                         }
                     }
 
                     return areAllSelected;
                 } else {
-
                     return !options.some((option) => !isSelected(option));
                 }
             }

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -397,16 +397,16 @@ export const MultiSelect = React.memo(
                 const options = visibleOptions.filter((option) => !isOptionDisabled(option));
 
                 if (props.optionGroupLabel) {
-                    let anyOptionLeftUnchecked = false;
+                    let areAllSelected = true;
                     for (let optionGroup of options) {
                         const visibleOptionsGroupChildren = getOptionGroupChildren(optionGroup).filter((option) => !isOptionDisabled(option));
                         
                         if(visibleOptionsGroupChildren.some((option) => !isSelected(option)) === true) {
-                            anyOptionLeftUnchecked = true;
+                            areAllSelected = false;
                         }
                     }
 
-                    return !anyOptionLeftUnchecked;
+                    return areAllSelected;
                 } else {
 
                     return !options.some((option) => !isSelected(option));

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -398,6 +398,7 @@ export const MultiSelect = React.memo(
 
                 if (props.optionGroupLabel) {
                     let areAllSelected = true;
+
                     for (let optionGroup of options) {
                         const visibleOptionsGroupChildren = getOptionGroupChildren(optionGroup).filter((option) => !isOptionDisabled(option));
                         


### PR DESCRIPTION
Fixes #4535 
**Issue description:** Select All checkbox was getting auto-selected even when only a single group of items were checked.
Expected behavior: Select All checkboxes should only be selected when all the items in the multi-select groups are selected.

**Root cause:** The for loop was immediately returning while only a single group iteration was finished rather than waiting on all the groups of checkboxes as they all have to be selected for Select All to be checked. 

**Fix applied:** The code block now will not return immediately while looping through the single group, rather it will set a flag once any item from any of the groups (being checked in the loop) is unchecked. and returning finally when all the iteration on each group is finished.