### PR TITLE
fix: chips to have type string instead of any for the value since HTM…

### DIFF
--- a/components/lib/chips/chips.d.ts
+++ b/components/lib/chips/chips.d.ts
@@ -83,7 +83,7 @@ interface ChipsRemovableOptions {
     /**
      * Current value
      */
-    value: any;
+    value: string;
     /**
      * Current index
      */
@@ -106,7 +106,7 @@ interface ChipsAddEvent {
     /**
      * Added item value
      */
-    value: any;
+    value: string;
 }
 
 /**
@@ -121,7 +121,7 @@ interface ChipsRemoveEvent {
     /**
      * Removed item value
      */
-    value: any;
+    value: string;
 }
 
 /**
@@ -130,7 +130,7 @@ interface ChipsRemoveEvent {
  * @extends {FormEvent}
  * @event
  */
-interface ChipsChangeEvent extends FormEvent<any[]> {}
+interface ChipsChangeEvent extends FormEvent<string[]> { }
 
 /**
  * Defines valid properties in Chips component. In addition to these, all properties of HTMLDivElement can be used in this component.
@@ -161,7 +161,7 @@ export interface ChipsProps extends Omit<React.DetailedHTMLProps<React.InputHTML
     /**
      * Value of the component.
      */
-    value?: any[] | undefined;
+    value?: string[] | undefined;
     /**
      * Maximum number of entries allowed.
      */

--- a/components/lib/chips/chips.d.ts
+++ b/components/lib/chips/chips.d.ts
@@ -130,7 +130,7 @@ interface ChipsRemoveEvent {
  * @extends {FormEvent}
  * @event
  */
-interface ChipsChangeEvent extends FormEvent<string[]> { }
+interface ChipsChangeEvent extends FormEvent<string[]> {}
 
 /**
  * Defines valid properties in Chips component. In addition to these, all properties of HTMLDivElement can be used in this component.


### PR DESCRIPTION
…LInputElement will return string

@melloware I tried to make it generic but since the input element is string it was throwing a type error unless you do T extends string. So I just made them strings instead. The any type is problematic as usual and causing type errors for me. 

If you need me to submit an issue I could as well. 

Fix #4551
