### PR TITLE
Fix #4578: Calendar overlay size should be based on original view

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1521,7 +1521,7 @@ export const Calendar = React.memo(
                 if (appendDisabled()) {
                     DomHandler.relativePosition(overlayRef.current, inputRef.current);
                 } else {
-                    if (currentView === 'date') {
+                    if (props.view === 'date') {
                         overlayRef.current.style.width = DomHandler.getOuterWidth(overlayRef.current) + 'px';
                         overlayRef.current.style.minWidth = DomHandler.getOuterWidth(inputRef.current) + 'px';
                     } else {
@@ -3033,37 +3033,6 @@ export const Calendar = React.memo(
             return months;
         };
 
-        const createMonthViewMonth = (index) => {
-            const className = classNames('p-monthpicker-month', { 'p-highlight': isMonthSelected(index), 'p-disabled': !isSelectable(0, index, currentYear) });
-            const monthNamesShort = localeOption('monthNamesShort', props.locale);
-            const monthName = monthNamesShort[index];
-            const monthProps = mergeProps(
-                {
-                    className,
-                    onClick: (event) => onMonthSelect(event, index),
-                    onKeyDown: (event) => onMonthCellKeydown(event, index)
-                },
-                ptm('month')
-            );
-
-            return (
-                <span {...monthProps} key={monthName}>
-                    {monthName}
-                    <Ripple />
-                </span>
-            );
-        };
-
-        const createMonthViewMonths = () => {
-            let months = [];
-
-            for (let i = 0; i <= 11; i++) {
-                months.push(createMonthViewMonth(i));
-            }
-
-            return months;
-        };
-
         const monthPickerValues = () => {
             let monthPickerValues = [];
             const monthNamesShort = localeOption('monthNamesShort', props.locale);
@@ -3586,7 +3555,8 @@ export const Calendar = React.memo(
                             const monthProps = mergeProps(
                                 {
                                     className: classNames('p-monthpicker-month', { 'p-highlight': isMonthSelected(i), 'p-disabled': !isSelectable(0, i, currentYear) }),
-                                    onClick: (event) => onMonthSelect(event, i)
+                                    onClick: (event) => onMonthSelect(event, i),
+                                    onKeyDown: (event) => onMonthCellKeydown(event, i)
                                 },
                                 ptm('month')
                             );


### PR DESCRIPTION
Fix #4578: Calendar overlay size should be based on original view
