### PR TITLE
Fix #4581: Fix DomHandler getScrollable to always include body or window

### DIFF
--- a/components/lib/hooks/useOverlayScrollListener.js
+++ b/components/lib/hooks/useOverlayScrollListener.js
@@ -1,10 +1,9 @@
 /* eslint-disable */
 import * as React from 'react';
+import PrimeReact, { PrimeReactContext } from '../api/Api';
 import { DomHandler, ObjectUtils } from '../utils/Utils';
 import { usePrevious } from './usePrevious';
 import { useUnmountEffect } from './useUnmountEffect';
-import { PrimeReactContext } from '../api/Api';
-import PrimeReact from '../api/Api';
 
 export const useOverlayScrollListener = ({ target, listener, options, when = true }) => {
     const targetRef = React.useRef(null);
@@ -20,7 +19,8 @@ export const useOverlayScrollListener = ({ target, listener, options, when = tru
         }
 
         if (!listenerRef.current && targetRef.current) {
-            const nodes = (scrollableParents.current = DomHandler.getScrollableParents(targetRef.current, context ? context.hideOverlaysOnDocumentScrolling : PrimeReact.hideOverlaysOnDocumentScrolling));
+            const hideOnScroll = context ? context.hideOverlaysOnDocumentScrolling : PrimeReact.hideOverlaysOnDocumentScrolling;
+            const nodes = (scrollableParents.current = DomHandler.getScrollableParents(targetRef.current, hideOnScroll));
 
             listenerRef.current = (event) => listener && listener(event);
             nodes.forEach((node) => node.addEventListener('scroll', listenerRef.current, options));

--- a/components/lib/utils/DomHandler.js
+++ b/components/lib/utils/DomHandler.js
@@ -553,14 +553,15 @@ export default class DomHandler {
                     }
                 }
 
+                // BODY
                 if (parent.nodeType === 1 && overflowCheck(parent)) {
                     addScrollableParent(parent);
                 }
             }
         }
 
-        // if no parents make it the window
-        if (scrollableParents.length === 0) {
+        // we should always at least have the body or window
+        if (!scrollableParents.some((node) => node === document.body || node === window)) {
             scrollableParents.push(window);
         }
 


### PR DESCRIPTION
Fix #4581: Fix DomHandler getScrollable to always include body or window
