### PR TITLE
Fix #4562: SlideMenu fix back button on long menus

### DIFF
--- a/components/doc/slidemenu/basicdoc.js
+++ b/components/doc/slidemenu/basicdoc.js
@@ -272,7 +272,7 @@ export default function BasicDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <SlideMenu model={items} viewportHeight={220} menuWidth={175}></SlideMenu>
+            <SlideMenu model={items} viewportHeight={205} menuWidth={175}></SlideMenu>
         </div>
     )
 }
@@ -416,7 +416,7 @@ export default function BasicDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <SlideMenu model={items} viewportHeight={220} menuWidth={175}></SlideMenu>
+            <SlideMenu model={items} viewportHeight={205} menuWidth={175}></SlideMenu>
         </div>
     )
 }
@@ -431,7 +431,7 @@ export default function BasicDemo() {
                 </p>
             </DocSectionText>
             <div className="card flex justify-content-center">
-                <SlideMenu model={items} viewportHeight={220} menuWidth={175}></SlideMenu>
+                <SlideMenu model={items} viewportHeight={210} menuWidth={175}></SlideMenu>
             </div>
             <DocSectionCode code={code} />
         </>

--- a/components/lib/slidemenu/SlideMenu.css
+++ b/components/lib/slidemenu/SlideMenu.css
@@ -64,7 +64,6 @@
 }
 
 .p-slidemenu-backward {
-    position: absolute;
     bottom: 0;
     width: 100%;
     padding: 0.25em;

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PrimeReactContext } from '../api/Api';
+import PrimeReact, { PrimeReactContext } from '../api/Api';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { useOverlayListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { ChevronLeftIcon } from '../icons/chevronleft';
@@ -8,7 +8,6 @@ import { Portal } from '../portal/Portal';
 import { DomHandler, IconUtils, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
 import { SlideMenuBase } from './SlideMenuBase';
 import { SlideMenuSub } from './SlideMenuSub';
-import PrimeReact from '../api/Api';
 
 export const SlideMenu = React.memo(
     React.forwardRef((inProps, ref) => {
@@ -120,7 +119,8 @@ export const SlideMenu = React.memo(
 
         const createBackward = () => {
             const className = classNames('p-slidemenu-backward', {
-                'p-hidden': levelState === 0
+                'p-hidden-space': levelState === 0,
+                'p-slidemenu-separator': levelState > 0
             });
 
             const iconClassName = 'p-slidemenu-backward-icon';
@@ -218,8 +218,8 @@ export const SlideMenu = React.memo(
                                     ptm={ptm}
                                 />
                             </div>
-                            {backward}
                         </div>
+                        {backward}
                     </div>
                 </CSSTransition>
             );


### PR DESCRIPTION
Fix #4562: SlideMenu fix back button on long menus

![image](https://github.com/primefaces/primereact/assets/4399574/f2a45fe5-a1dd-43f3-af9c-2fcc79f9d3e5)



