### PR TITLE
feat: add emptyMessage prop

### DIFF
--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -188,7 +188,7 @@ export const MultiSelectPanel = React.memo(
             if (ObjectUtils.isNotEmpty(props.visibleOptions)) {
                 return props.visibleOptions.map(createItem);
             } else {
-                 return props.hasFilter ? createEmptyFilter() : createEmptyContent();
+                return props.hasFilter ? createEmptyFilter() : createEmptyContent();
             }
         };
 

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -123,6 +123,19 @@ export const MultiSelectPanel = React.memo(
             return <li {...emptyMessageProps}>{emptyFilterMessage}</li>;
         };
 
+        const createEmptyContent = () => {
+            const emptyMessage = ObjectUtils.getJSXElement(props.emptyMessage, props) || localeOption('emptyMessage');
+
+            const emptyMessageProps = mergeProps(
+                {
+                    className: 'p-multiselect-empty-message'
+                },
+                props.ptm('emptyMessage')
+            );
+
+            return <li {...emptyMessageProps}>{emptyMessage}</li>;
+        };
+
         const createItem = (option, index, scrollerOptions = {}) => {
             const style = { height: scrollerOptions.props ? scrollerOptions.props.itemSize : undefined };
 
@@ -174,11 +187,13 @@ export const MultiSelectPanel = React.memo(
         const createItems = () => {
             if (ObjectUtils.isNotEmpty(props.visibleOptions)) {
                 return props.visibleOptions.map(createItem);
-            } else if (props.hasFilter) {
-                return createEmptyFilter();
+            } else {
+                if (props.hasFilter) {
+                    return createEmptyFilter();
+                } else {
+                    return createEmptyContent();
+                }
             }
-
-            return null;
         };
 
         const createContent = () => {

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -188,11 +188,7 @@ export const MultiSelectPanel = React.memo(
             if (ObjectUtils.isNotEmpty(props.visibleOptions)) {
                 return props.visibleOptions.map(createItem);
             } else {
-                if (props.hasFilter) {
-                    return createEmptyFilter();
-                } else {
-                    return createEmptyContent();
-                }
+                 return props.hasFilter ? createEmptyFilter() : createEmptyContent();
             }
         };
 

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -430,6 +430,10 @@ export interface MultiSelectProps extends Omit<React.DetailedHTMLProps<React.Inp
      */
     emptyFilterMessage?: React.ReactNode | ((props: MultiSelectProps) => React.ReactNode);
     /**
+     * Text to display when there are no options available. Defaults to global value in Locale configuration.
+     */
+    emptyMessage?: string;
+    /**
      * When specified, displays an input field to filter the items on keyup.
      * @defaultValue true
      */


### PR DESCRIPTION
Closes #4610

## Changing `createItems`:
I thought we need to check like this:
1. If `visibleOptions` is present then execute `props.visibleOptions.map(createItem)`
2. If no `visibleOptions` and `hasFilter` then execute `createEmptyFilter` function
3. Else execute `createEmptyContent` function 

See:
https://github.com/primefaces/primereact/blob/5a92f2193cd53947d6adee553bcb19adf439e5ae/components/lib/multiselect/MultiSelectPanel.js#L187-L197

@melloware could you please verify what I thought above is what we want exactly?