### PR TITLE
Fix #4626: Calendar allow month after year localization

### DIFF
--- a/components/doc/calendar/localedoc.js
+++ b/components/doc/calendar/localedoc.js
@@ -10,6 +10,7 @@ export function LocaleDoc(props) {
 
     addLocale('es', {
         firstDayOfWeek: 1,
+        showMonthAfterYear: true,
         dayNames: ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
         dayNamesShort: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
         dayNamesMin: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
@@ -33,6 +34,7 @@ export default function LocaleDemo() {
 
     addLocale('es', {
         firstDayOfWeek: 1,
+        showMonthAfterYear: true,
         dayNames: ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
         dayNamesShort: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
         dayNamesMin: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],
@@ -59,6 +61,7 @@ export default function LocaleDemo() {
 
     addLocale('es', {
         firstDayOfWeek: 1,
+        showMonthAfterYear: true,
         dayNames: ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
         dayNamesShort: ['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb'],
         dayNamesMin: ['D', 'L', 'M', 'X', 'J', 'V', 'S'],

--- a/components/lib/api/Locale.js
+++ b/components/lib/api/Locale.js
@@ -39,6 +39,7 @@ let locales = {
         today: 'Today',
         weekHeader: 'Wk',
         firstDayOfWeek: 0,
+        showMonthAfterYear: false,
         dateFormat: 'mm/dd/yy',
         weak: 'Weak',
         medium: 'Medium',

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2834,11 +2834,12 @@ export const Calendar = React.memo(
                 },
                 ptm('title')
             );
+            const showMonthAfterYear = localeOption('showMonthAfterYear', props.locale);
 
             return (
                 <div {...titleProps}>
-                    {month}
-                    {year}
+                    {showMonthAfterYear ? year : month}
+                    {showMonthAfterYear ? month : year}
                     {decade}
                 </div>
             );

--- a/components/lib/hooks/useLocale.js
+++ b/components/lib/hooks/useLocale.js
@@ -42,6 +42,7 @@ let locales = {
         today: 'Today',
         weekHeader: 'Wk',
         firstDayOfWeek: 0,
+        showMonthAfterYear: true,
         dateFormat: 'mm/dd/yy',
         weak: 'Weak',
         medium: 'Medium',
@@ -53,11 +54,51 @@ let locales = {
             trueLabel: 'True',
             falseLabel: 'False',
             nullLabel: 'Not Selected',
-            pageLabel: 'Page',
+            star: '1 star',
+            stars: '{star} stars',
+            selectAll: 'All items selected',
+            unselectAll: 'All items unselected',
+            close: 'Close',
+            previous: 'Previous',
+            next: 'Next',
+            navigation: 'Navigation',
+            scrollTop: 'Scroll Top',
+            moveTop: 'Move Top',
+            moveUp: 'Move Up',
+            moveDown: 'Move Down',
+            moveBottom: 'Move Bottom',
+            moveToTarget: 'Move to Target',
+            moveToSource: 'Move to Source',
+            moveAllToTarget: 'Move All to Target',
+            moveAllToSource: 'Move All to Source',
+            pageLabel: 'Page {page}',
             firstPageLabel: 'First Page',
             lastPageLabel: 'Last Page',
             nextPageLabel: 'Next Page',
             previousPageLabel: 'Previous Page',
+            rowsPerPageLabel: 'Rows per page',
+            jumpToPageDropdownLabel: 'Jump to Page Dropdown',
+            jumpToPageInputLabel: 'Jump to Page Input',
+            selectRow: 'Row Selected',
+            unselectRow: 'Row Unselected',
+            expandRow: 'Row Expanded',
+            collapseRow: 'Row Collapsed',
+            showFilterMenu: 'Show Filter Menu',
+            hideFilterMenu: 'Hide Filter Menu',
+            filterOperator: 'Filter Operator',
+            filterConstraint: 'Filter Constraint',
+            editRow: 'Row Edit',
+            saveEdit: 'Save Edit',
+            cancelEdit: 'Cancel Edit',
+            listView: 'List View',
+            gridView: 'Grid View',
+            slide: 'Slide',
+            slideNumber: '{slideNumber}',
+            zoomImage: 'Zoom Image',
+            zoomIn: 'Zoom In',
+            zoomOut: 'Zoom Out',
+            rotateRight: 'Rotate Right',
+            rotateLeft: 'Rotate Left',
             selectLabel: 'Select',
             unselectLabel: 'Unselect',
             expandLabel: 'Expand',
@@ -105,13 +146,35 @@ export const useLocale = () => {
         }
     };
 
-    const ariaLabel = (key) => {
+    /**
+     * Find an ARIA label in the locale by key.  If options are passed it will replace all options:
+     * ```ts
+     * const ariaValue = "Page {page}, User {user}, Role {role}";
+     * const options = { page: 2, user: "John", role: "Admin" };
+     * const result = ariaLabel('yourLabel', { page: 2, user: "John", role: "Admin" })
+     * console.log(result); // Output: Page 2, User John, Role Admin
+     * ```
+     * @param {string} ariaKey key of the ARIA label to look up in locale.
+     * @param {any} options JSON options like { page: 2, user: "John", role: "Admin" }
+     * @returns the ARIA label with replaced values
+     */
+    const ariaLabel = (ariaKey, options) => {
         const _locale = (context && context.locale) || PrimeReact.locale;
 
         try {
-            return localeOptions(_locale)['aria'][key];
+            let ariaLabel = localeOptions(_locale)['aria'][ariaKey];
+
+            if (ariaLabel) {
+                for (const key in options) {
+                    if (options.hasOwnProperty(key)) {
+                        ariaLabel = ariaLabel.replace(`{${key}}`, options[key]);
+                    }
+                }
+            }
+
+            return ariaLabel;
         } catch (error) {
-            throw new Error(`The ${key} option is not found in the current locale('${_locale}').`);
+            throw new Error(`The ${ariaKey} option is not found in the current locale('${_locale}').`);
         }
     };
 


### PR DESCRIPTION
Fix #4626: Calendar allow month after year localization

![image](https://github.com/primefaces/primereact/assets/4399574/de856027-a299-4d71-956a-ffbaf2de6cfa)

