### PR TITLE
Fix #4629: TreeTable do not allow reorder over frozen column

### DIFF
--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
-import PrimeReact, { FilterService } from '../api/Api';
-import { PrimeReactContext } from '../api/Api';
+import PrimeReact, { FilterService, PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { useEventListener } from '../hooks/Hooks';
 import { ArrowDownIcon } from '../icons/arrowdown';
 import { ArrowUpIcon } from '../icons/arrowup';
 import { SpinnerIcon } from '../icons/spinner';
 import { Paginator } from '../paginator/Paginator';
-import { classNames, DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
+import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 import { TreeTableBase } from './TreeTableBase';
 import { TreeTableBody } from './TreeTableBody';
 import { TreeTableFooter } from './TreeTableFooter';
@@ -451,10 +450,10 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     };
 
     const onColumnDragOver = (e) => {
-        const event = e.originalEvent;
+        const { originalEvent: event, column } = e;
         const dropHeader = findParentHeader(event.currentTarget);
 
-        if (props.reorderableColumns && draggedColumnEl.current && dropHeader) {
+        if (props.reorderableColumns && draggedColumnEl.current && dropHeader && !getColumnProp(column, 'frozen')) {
             event.preventDefault();
             let containerOffset = DomHandler.getOffset(elementRef.current);
             let dropHeaderOffset = DomHandler.getOffset(dropHeader);

--- a/components/lib/treetable/TreeTableHeader.js
+++ b/components/lib/treetable/TreeTableHeader.js
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
 import { ColumnGroupBase } from '../columngroup/ColumnGroupBase';
+import { SortAltIcon } from '../icons/sortalt';
+import { SortAmountDownIcon } from '../icons/sortamountdown';
+import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 import { InputText } from '../inputtext/InputText';
 import { RowBase } from '../row/RowBase';
 import { Tooltip } from '../tooltip/Tooltip';
 import { classNames, DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
-import { SortAltIcon } from '../icons/sortalt';
-import { SortAmountDownIcon } from '../icons/sortamountdown';
-import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 
 export const TreeTableHeader = React.memo((props) => {
     const filterTimeout = React.useRef(null);
@@ -261,6 +261,7 @@ export const TreeTableHeader = React.memo((props) => {
             const singleSorted = getColumnProp(column, 'field') === props.sortField;
             const multipleSorted = multiSortMetaData !== null;
             const sorted = getColumnProp(column, 'sortable') && (singleSorted || multipleSorted);
+            const frozen = getColumnProp(column, 'frozen');
             let sortOrder = 0;
 
             if (singleSorted) sortOrder = props.sortOrder;
@@ -273,7 +274,9 @@ export const TreeTableHeader = React.memo((props) => {
             const className = classNames(getColumnProp(column, 'headerClassName') || getColumnProp(column, 'className'), {
                 'p-sortable-column': getColumnProp(column, 'sortable'),
                 'p-highlight': sorted,
-                'p-resizable-column': props.resizableColumns && getColumnProp(column, 'resizeable')
+                'p-frozen-column': frozen,
+                'p-resizable-column': props.resizableColumns && getColumnProp(column, 'resizeable'),
+                'p-reorderable-column': props.reorderableColumns && getColumnProp(column, 'reorderable') && !frozen
             });
 
             const headerTooltip = getColumnProp(column, 'headerTooltip');


### PR DESCRIPTION
### Defect Fixes
Fix #4629: TreeTable do not allow reorder over frozen column
