### PR TITLE
Fix #4662: SVG icons allow click event to pass through

### DIFF
--- a/components/lib/iconbase/IconBase.css
+++ b/components/lib/iconbase/IconBase.css
@@ -7,6 +7,14 @@
     animation: p-icon-spin 2s infinite linear;
 }
 
+svg.p-icon {
+    pointer-events: auto;
+}
+
+svg.p-icon g {
+    pointer-events: none;
+}
+
 @-webkit-keyframes p-icon-spin {
     0% {
         -webkit-transform: rotate(0deg);


### PR DESCRIPTION
Fix #4662: SVG icons allow click event to pass through
