### PR TITLE
Fix #4669: DataTable restore width fix

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -382,7 +382,6 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             if (props.columnResizeMode === 'expand' && tableWidthState.current) {
                 tableRef.current.style.width = tableWidthState.current;
                 tableRef.current.style.minWidth = tableWidthState.current;
-                elementRef.current.style.width = tableWidthState.current;
             }
 
             if (ObjectUtils.isNotEmpty(widths)) {


### PR DESCRIPTION
### Defect Fixes
Fix <ins>**[#4608](https://github.com/primefaces/primereact/issues/4669)**</ins> The problem arose due to the fact that after restoring the width, a inline style was added to the root element and after that the scroll was lost.

![image](https://github.com/primefaces/primereact/assets/13043517/e90a57d2-e940-4629-9fbe-d1ecb9ed8e38)


