### PR TITLE
Fix #3788: Carousel swipe events

### DIFF
--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -224,7 +224,7 @@ export const Carousel = React.memo(
         };
 
         const changePageOnTouch = (e, diff) => {
-            if (Math.abs(diff) > swipeThreshold) {
+            if (Math.abs(diff) > swipeThreshold.current) {
                 if (diff < 0) {
                     // left
                     navForward(e);


### PR DESCRIPTION
Fixes #3788 
Was being compared to the swipeThreshold ref object instead of its value, causing the condition to always throw false.