### PR TITLE
Fix #4654: DataTable. Filtering When Toggling Columns

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1374,7 +1374,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         if (props.onValueChange) {
             props.onValueChange(processedData({ filters }));
         }
-    }, [props.filters]);
+    }, [props.filters, props.children]);
 
     useUpdateEffect(() => {
         if (isStateful()) {


### PR DESCRIPTION
Fix #4654 : DataTable. Filtering When Toggling Columns


https://github.com/primefaces/primereact/assets/38601497/8f2a61a0-1a87-414b-92f4-3805597f2a19


