### PR TITLE
fix: datatable: contextmenu for multiple rows #4342

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -510,20 +510,23 @@ export const TableBody = React.memo(
         };
 
         const onRowRightClick = (event) => {
+            const isMultiSelection = isCheckboxSelectionModeInColumn && ObjectUtils.isEmpty(props.selection);
+            const data = isMultiSelection ? event.data : props.selection;
+
             if (props.onContextMenu || props.onContextMenuSelectionChange) {
-                DomHandler.clearSelection();
+                if (!ObjectUtils.isEmpty(props.selection)) DomHandler.clearSelection();
 
                 if (props.onContextMenuSelectionChange) {
                     props.onContextMenuSelectionChange({
                         originalEvent: event.originalEvent,
-                        value: event.data
+                        value: data
                     });
                 }
 
                 if (props.onContextMenu) {
                     props.onContextMenu({
                         originalEvent: event.originalEvent,
-                        data: event.data
+                        data
                     });
                 }
 


### PR DESCRIPTION
Fix #4342 datatable: contextmenu for multiple rows 