### PR TITLE
Fix scrollpanel scrollbar on zoom out

### DIFF
--- a/components/lib/scrollpanel/ScrollPanelBase.js
+++ b/components/lib/scrollpanel/ScrollPanelBase.js
@@ -32,7 +32,7 @@ export const ScrollPanelBase = ComponentBase.extend({
             width: calc(100% + 18px);
             padding: 0 18px 18px 0;
             position: relative;
-            overflow: scroll;
+            overflow: hidden;
             box-sizing: border-box;
         }
         


### PR DESCRIPTION
Fix #4660

Added `overflow: hidden;` in `.p-scrollpanel-content` to fix the problem.

## PROBLEM when you are zooming out or your zoom is small appears another scrollbar

![imagen](https://github.com/primefaces/primereact/assets/19764334/d3a30c9c-785c-4b56-8b26-688e7e747e8c)

![problem scrollpanel](https://github.com/primefaces/primereact/assets/19764334/c1770417-705c-4f78-90e1-9394df737451)

## SOLVED
![fixed scrollpanel](https://github.com/primefaces/primereact/assets/19764334/3f31e79f-4281-40c4-a3a3-63f3cee60b36)

