### PR TITLE
Fix #4704: typescript order for closeOnEscape

### DIFF
--- a/components/lib/image/image.d.ts
+++ b/components/lib/image/image.d.ts
@@ -147,6 +147,11 @@ export interface ImageProps extends Omit<React.DetailedHTMLProps<React.HTMLAttri
      */
     children?: React.ReactNode | undefined;
     /**
+     * Specifies if pressing escape key should hide the preview.
+     * @defaultValue true
+     */
+    closeOnEscape?: boolean | undefined;
+    /**
      * The crossorigin content attribute on media elements is a CORS settings attribute.
      */
     crossOrigin?: 'anonymous' | 'use-credentials' | '' | undefined;
@@ -247,11 +252,6 @@ export interface ImageProps extends Omit<React.DetailedHTMLProps<React.HTMLAttri
      * @defaultValue false
      */
     unstyled?: boolean;
-    /**
-     * Specifies if pressing escape key should hide the preview.
-     * @defaultValue true
-     */
-    closeOnEscape?: boolean | undefined;
 }
 
 /**

--- a/components/lib/overlaypanel/overlaypanel.d.ts
+++ b/components/lib/overlaypanel/overlaypanel.d.ts
@@ -85,6 +85,11 @@ export interface OverlayPanelProps extends Omit<React.DetailedHTMLProps<React.HT
      */
     closeIcon?: IconType<OverlayPanelProps> | undefined;
     /**
+     * Specifies if pressing escape key should hide the preview.
+     * @defaultValue true
+     */
+    closeOnEscape?: boolean | undefined;
+    /**
      * DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located.
      * @defaultValue document.body
      */
@@ -125,11 +130,6 @@ export interface OverlayPanelProps extends Omit<React.DetailedHTMLProps<React.HT
      * @defaultValue false
      */
     unstyled?: boolean;
-    /**
-     * Specifies if pressing escape key should hide the preview.
-     * @defaultValue true
-     */
-    closeOnEscape?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
Fix #4704: typescript order for closeOnEscape
