### PR TITLE
Fix #4768: Sort and Filter performance gains

### DIFF
--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PrimeReact, { PrimeReactContext, ariaLabel } from '../api/Api';
+import { useHandleStyle } from '../componentbase/ComponentBase';
 import { useMountEffect, usePrevious, useResizeListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { ChevronDownIcon } from '../icons/chevrondown';
 import { ChevronLeftIcon } from '../icons/chevronleft';
@@ -8,7 +9,6 @@ import { ChevronUpIcon } from '../icons/chevronup';
 import { Ripple } from '../ripple/Ripple';
 import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, classNames, mergeProps } from '../utils/Utils';
 import { CarouselBase } from './CarouselBase';
-import { useHandleStyle } from '../componentbase/ComponentBase';
 
 const CarouselItem = React.memo((props) => {
     const { ptm, cx } = props;
@@ -264,12 +264,14 @@ export const Carousel = React.memo(
         `;
 
             if (props.responsiveOptions) {
+                const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
+
                 responsiveOptions.current = [...props.responsiveOptions];
                 responsiveOptions.current.sort((data1, data2) => {
                     const value1 = data1.breakpoint;
                     const value2 = data2.breakpoint;
 
-                    return ObjectUtils.sort(value1, value2, -1, (context && context.locale) || PrimeReact.locale, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
+                    return ObjectUtils.sort(value1, value2, -1, comparator, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
                 });
 
                 for (let i = 0; i < responsiveOptions.current.length; i++) {

--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -138,13 +138,20 @@ export const DataView = React.memo(
 
         const sort = () => {
             if (props.value) {
+                // performance optimization to prevent resolving field data in each loop
+                const lookupMap = new Map();
+                const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
                 const value = [...props.value];
 
-                value.sort((data1, data2) => {
-                    let value1 = ObjectUtils.resolveFieldData(data1, props.sortField);
-                    let value2 = ObjectUtils.resolveFieldData(data2, props.sortField);
+                for (let item of value) {
+                    lookupMap.set(item, ObjectUtils.resolveFieldData(item, props.sortField));
+                }
 
-                    return ObjectUtils.sort(value1, value2, props.sortOrder, (context && context.locale) || PrimeReact.locale, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
+                value.sort((data1, data2) => {
+                    let value1 = lookupMap.get(data1);
+                    let value2 = lookupMap.get(data2);
+
+                    return ObjectUtils.sort(value1, value2, props.sortOrder, comparator, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
                 });
 
                 return value;

--- a/components/lib/galleria/GalleriaThumbnails.js
+++ b/components/lib/galleria/GalleriaThumbnails.js
@@ -238,12 +238,14 @@ export const GalleriaThumbnails = React.memo(
         `;
 
             if (props.responsiveOptions) {
+                const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
+
                 responsiveOptions.current = [...props.responsiveOptions];
                 responsiveOptions.current.sort((data1, data2) => {
                     const value1 = data1.breakpoint;
                     const value2 = data2.breakpoint;
 
-                    return ObjectUtils.sort(value1, value2, -1, (context && context.locale) || PrimeReact.locale, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
+                    return ObjectUtils.sort(value1, value2, -1, comparator, (context && context.nullSortOrder) || PrimeReact.nullSortOrder);
                 });
 
                 for (let i = 0; i < responsiveOptions.current.length; i++) {

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -356,8 +356,8 @@ export default class ObjectUtils {
         return index;
     }
 
-    static sort(value1, value2, order = 1, locale, nullSortOrder = 1) {
-        const result = ObjectUtils.compare(value1, value2, locale, order);
+    static sort(value1, value2, order = 1, comparator, nullSortOrder = 1) {
+        const result = ObjectUtils.compare(value1, value2, comparator, order);
         let finalSortOrder = order;
 
         // nullSortOrder == 1 means Excel like sort nulls at bottom
@@ -368,7 +368,7 @@ export default class ObjectUtils {
         return finalSortOrder * result;
     }
 
-    static compare(value1, value2, locale, order = 1) {
+    static compare(value1, value2, comparator, order = 1) {
         let result = -1;
         const emptyValue1 = ObjectUtils.isEmpty(value1);
         const emptyValue2 = ObjectUtils.isEmpty(value2);
@@ -376,10 +376,15 @@ export default class ObjectUtils {
         if (emptyValue1 && emptyValue2) result = 0;
         else if (emptyValue1) result = order;
         else if (emptyValue2) result = -order;
-        else if (typeof value1 === 'string' && typeof value2 === 'string') result = value1.localeCompare(value2, locale, { numeric: true });
+        else if (typeof value1 === 'string' && typeof value2 === 'string') result = comparator(value1, value2);
         else result = value1 < value2 ? -1 : value1 > value2 ? 1 : 0;
 
         return result;
+    }
+
+    static localeComparator(locale) {
+        //performance gain using Int.Collator. It is not recommended to use localeCompare against large arrays.
+        return new Intl.Collator(locale, { numeric: true }).compare;
     }
 
     static findChildrenByKey(data, key) {


### PR DESCRIPTION
Fix #4768: Sort and Filter performance gains

- Big performance gain using Int.Collator. It is not recommended to use localeCompare against large arrays.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
- Within the `sortSingle` function, performing calls to `resolveFieldData(data1, this.d_sortField)` only once for each item in the dataset, and using a Map for later lookups
- Within the `filter` function, only run filters whose value is not `null`.
