### PR TITLE
#4777: Improving Datatable SelectionChanged event

### DIFF
--- a/components/doc/datatable/cellselection/disableddoc.js
+++ b/components/doc/datatable/cellselection/disableddoc.js
@@ -112,8 +112,7 @@ export default function DisabledCellSelectionDemo() {
             </div>
             <DataTable value={products} cellSelection selectionMode="single" selection={selectedCell!} metaKeySelection={metaKey}
                     onSelectionChange={(e) => {
-                        const value = e.value as DataTableCellSelection<Product[]>;
-                        setSelectedCell(value);
+                        if (e.type === 'cell') setSelectedCell(e.value);                        
                     }} 
                     isDataSelectable={isCellSelectable} cellClassName={cellClassName} tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>

--- a/components/doc/datatable/cellselection/eventsdoc.js
+++ b/components/doc/datatable/cellselection/eventsdoc.js
@@ -117,8 +117,7 @@ export default function CellSelectEventsDemo() {
             <Toast ref={toast} />
             <DataTable value={products} cellSelection selectionMode="single" selection={selectedCell!} metaKeySelection={false}
                     onSelectionChange={(e) => {
-                        const value = e.value as DataTableCellSelection<Product[]>;
-                        setSelectedCell(value);
+                        if (e.type === 'cell') setSelectedCell(e.value);
                     }}
                     onCellSelect={onCellSelect} onCellUnselect={onCellUnselect} tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>

--- a/components/doc/datatable/cellselection/multipledoc.js
+++ b/components/doc/datatable/cellselection/multipledoc.js
@@ -99,8 +99,7 @@ export default function MultipleCellsSelectionDemo() {
             </div>
             <DataTable value={products} cellSelection selectionMode="multiple" selection={selectedCells!}
                     onSelectionChange={(e) => {
-                        const value = e.value as DataTableCellSelection<Product[]>;
-                        setSelectedCells(value);
+                        if (e.type === 'cell') setSelectedCells(e.value);
                     }}
                     metaKeySelection={metaKey} dragSelection tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>

--- a/components/doc/datatable/cellselection/singledoc.js
+++ b/components/doc/datatable/cellselection/singledoc.js
@@ -97,8 +97,7 @@ export default function SingleCellSelectionDemo() {
             </div>
             <DataTable value={products} cellSelection selectionMode="single" selection={selectedCell!}
                     onSelectionChange={(e) => {
-                        const value = e.value as DataTableCellSelection<Product[]>;
-                         setSelectedCell(value);
+                       if (e.type === 'cell') setSelectedCell(e.value);
                     }} metaKeySelection={metaKey} tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>
                 <Column field="name" header="Name"></Column>

--- a/components/doc/datatable/rowselection/eventsdoc.js
+++ b/components/doc/datatable/rowselection/eventsdoc.js
@@ -113,8 +113,7 @@ export default function RowSelectEventsDemo() {
             <Toast ref={toast} />
             <DataTable value={products} selectionMode="single" selection={selectedProduct!} 
                         onSelectionChange={(e) => {
-                            const value = e.value as Product;
-                            setSelectedProduct(value);
+                            if (e.type === 'single') setSelectedCell(e.value);
                         }}  dataKey="id" onRowSelect={onRowSelect} onRowUnselect={onRowUnselect} metaKeySelection={false} tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>
                 <Column field="name" header="Name"></Column>

--- a/components/doc/datatable/rowselection/multipledoc.js
+++ b/components/doc/datatable/rowselection/multipledoc.js
@@ -97,9 +97,7 @@ export default function MultipleRowsSelectionDemo() {
             </div>
             <DataTable value={products} selectionMode="multiple" selection={selectedProducts} 
                     onSelectionChange={(e) => {
-                        if (Array.isArray(e.value)) {
-                            setSelectedProducts(e.value);
-                        }
+                        if (e.type === 'multiple') setSelectedProducts(e.value);
                     }}
                     dataKey="id" metaKeySelection={metaKey} dragSelection tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>

--- a/components/doc/datatable/rowselection/radiobuttondoc.js
+++ b/components/doc/datatable/rowselection/radiobuttondoc.js
@@ -97,8 +97,9 @@ export default function RadioButtonRowSelectionDemo() {
             </div>
             <DataTable value={products} selectionMode={rowClick ? undefined : 'radiobutton'} selection={selectedProduct!}
                 onSelectionChange={(e) => {
-                     const value = e.value as Product;
-                     setSelectedProduct(value);
+                    if (e.type === 'single' || e.type === 'radio') {
+                        setSelectedProduct(e.value);
+                    }
                 }} dataKey="id" tableStyle={{ minWidth: '50rem' }}>
                 <Column selectionMode="single" headerStyle={{ width: '3rem' }}></Column>
                 <Column field="code" header="Code"></Column>

--- a/components/doc/datatable/rowselection/singledoc.js
+++ b/components/doc/datatable/rowselection/singledoc.js
@@ -96,8 +96,7 @@ export default function SingleRowSelectionDemo() {
             </div>
             <DataTable value={products} selectionMode="single" selection={selectedProduct!} 
                 onSelectionChange={(e) => {
-                     const value = e.value as Product;
-                     setSelectedProduct(value);
+                    if (e.type === 'single') { setSelectedProduct(e.value); }
                 }} dataKey="id" metaKeySelection={metaKey} tableStyle={{ minWidth: '50rem' }}>
                 <Column field="code" header="Code"></Column>
                 <Column field="name" header="Name"></Column>

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -359,7 +359,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
 
             if (restoredState.selection && props.onSelectionChange) {
                 props.onSelectionChange({
-                    value: restoredState.selection
+                    value: restoredState.selection,
+                    type: props.selectionMode || 'cell'
                 });
             }
 

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -476,7 +476,7 @@ export const TableBody = React.memo(
 
             if (allowRowSelection()) {
                 if (allowRangeSelection(event)) {
-                    onRangeSelection(event, 'row');
+                    onRangeSelection(event, 'multiple');
                 } else {
                     const toggleable = isRadioSelectionModeInColumn || isCheckboxSelectionModeInColumn || allowMetaKeySelection(event);
 
@@ -485,9 +485,9 @@ export const TableBody = React.memo(
                     anchorRowFirst.current = props.first;
 
                     if (isSingleSelection()) {
-                        onSingleSelection({ ...event, toggleable, type: 'row' });
+                        onSingleSelection({ ...event, toggleable, type: 'single' });
                     } else {
-                        onMultipleSelection({ ...event, toggleable, type: 'row' });
+                        onMultipleSelection({ ...event, toggleable, type: 'multiple' });
                     }
                 }
 
@@ -566,7 +566,7 @@ export const TableBody = React.memo(
             const isSameRow = event.index === anchorRowIndex.current;
 
             if (allowRowDrag(event) && !isSameRow) {
-                onRangeSelection(event, 'row');
+                onRangeSelection(event, 'multiple');
             }
         };
 

--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -295,11 +295,35 @@ interface DataTableContextMenuSelectionChangeEvent<TValue extends DataTableValue
 }
 
 /**
- * Custom selection change event.
+ * Custom multiple selection change event.
  * @see {@link DataTableProps.onSelectionChange}
  * @event
  */
-interface DataTableSelectionChangeEvent<TValue extends DataTableValueArray> {
+interface DataTableSelectionMultipleChangeEvent<TValue extends DataTableValueArray> {
+    /**
+     * Browser event.
+     */
+    originalEvent: React.SyntheticEvent;
+    /**
+     * Selection objects.
+     */
+    value: TValue;
+    /**
+     * Type of the selection.
+     */
+    type?: 'multiple' | 'all' | 'checkbox' | undefined;
+    /**
+     * Extra options.
+     */
+    [key: string]: any;
+}
+
+/**
+ * Custom single selection change event.
+ * @see {@link DataTableProps.onSelectionChange}
+ * @event
+ */
+interface DataTableSelectionSingleChangeEvent<TValue extends DataTableValueArray> {
     /**
      * Browser event.
      */
@@ -307,16 +331,42 @@ interface DataTableSelectionChangeEvent<TValue extends DataTableValueArray> {
     /**
      * Selection object.
      */
-    value: DataTableSelection<TValue>;
+    value: TValue[number];
     /**
      * Type of the selection.
      */
-    type?: string;
+    type?: 'single' | 'radio';
     /**
      * Extra options.
      */
     [key: string]: any;
 }
+
+/**
+ * Custom cell selection change event.
+ * @see {@link DataTableProps.onSelectionChange}
+ * @event
+ */
+interface DataTableSelectionCellChangeEvent<TValue extends DataTableValueArray> {
+    /**
+     * Browser event.
+     */
+    originalEvent: React.SyntheticEvent;
+    /**
+     * Selection objects.
+     */
+    value: DataTableCellSelection<TValue>;
+    /**
+     * Type of the selection.
+     */
+    type?: 'cell';
+    /**
+     * Extra options.
+     */
+    [key: string]: any;
+}
+
+type DataTableSelectionChangeEvent<TValue extends DataTableValueArray> = DataTableSelectionSingleChangeEvent<TValue> | DataTableSelectionMultipleChangeEvent<TValue> | DataTableSelectionCellChangeEvent<TValue>;
 
 /**
  * Custom select all change event.


### PR DESCRIPTION
Fix #4777: Improving Datatable SelectionChanged event

@ulasturann @mertsincan this is what I have so far using Discriminated Unions https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions

This seems to be the TypeScript recommended way and now if you have this...

```ts
    const [selectedProduct, setSelectedProduct] = useState<Product>({});
    const [selectedProducts, setSelectedProducts] = useState<Product[]>([]);
    const [selectedCells, setSelectedCells] = useState<DataTableCellSelection<Product[]>>();
```

In the selection event by checking the type it now knows the correct single, multiple, or cell type event,

```xml
<DataTable
                    value={products}
                    selectionMode="single"
                    selection={selectedProduct}
                    onSelectionChange={(e) => {
                        switch (e.type) {
                            case 'single':
                            case 'radio':
                                setSelectedProduct(e.value);
                                break;
                            case 'cell':
                                setSelectedCells(e.value);
                                break;
                            case 'multiple':
                            case 'checkbox':
                            case 'all':
                                setSelectedProducts(e.value);
                                break;
                        }
                    }}
                    dataKey="id"
                    metaKeySelection={metaKey}
                    tableStyle={{ minWidth: '50rem' }}
                >
```

Its not exactly what the user wants but this is a much better TypeScript way of having multiple possible outcomes.
