### PR TITLE
Fix #4788: Calendar typescript improvements

### DIFF
--- a/components/doc/calendar/basicdoc.js
+++ b/components/doc/calendar/basicdoc.js
@@ -26,14 +26,15 @@ export default function BasicDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function BasicDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e: CalendarChangeEvent) => setDate(e.value)} />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} />
         </div>
     )
 }

--- a/components/doc/calendar/buttonbardoc.js
+++ b/components/doc/calendar/buttonbardoc.js
@@ -26,14 +26,15 @@ export default function ButtonBarDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function ButtonBarDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} showButtonBar />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} showButtonBar />
         </div>
     )
 }

--- a/components/doc/calendar/datetemplatedoc.js
+++ b/components/doc/calendar/datetemplatedoc.js
@@ -44,10 +44,11 @@ export default function DateTemplateDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function DateTemplateDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     const dateTemplate = (date: Date) => {
         if (date.day > 10 && date.day < 15) {
@@ -61,7 +62,7 @@ export default function DateTemplateDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} dateTemplate={dateTemplate} />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} dateTemplate={dateTemplate} />
         </div>
     )
 }

--- a/components/doc/calendar/floatlabeldoc.js
+++ b/components/doc/calendar/floatlabeldoc.js
@@ -32,15 +32,16 @@ export default function FloatLabelDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function FloatLabelDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
             <span className="p-float-label">
-                <Calendar inputId="birth_date" value={date} onChange={(e: CalendarChangeEvent) => setDate(e.value)} />
+                <Calendar inputId="birth_date" value={date} onChange={(e) => setDate(e.value)} />
                 <label htmlFor="birth_date">Birth Date</label>
             </span>
         </div>

--- a/components/doc/calendar/formatdoc.js
+++ b/components/doc/calendar/formatdoc.js
@@ -26,14 +26,15 @@ export default function FormatDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function FormatDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+     const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} dateFormat="dd/mm/yy" />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} dateFormat="dd/mm/yy" />
         </div>
     )
 }

--- a/components/doc/calendar/icondoc.js
+++ b/components/doc/calendar/icondoc.js
@@ -26,14 +26,15 @@ export default function IconDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function IconDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} showIcon />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} showIcon />
         </div>
     )
 }

--- a/components/doc/calendar/inlinedoc.js
+++ b/components/doc/calendar/inlinedoc.js
@@ -28,14 +28,15 @@ export default function InlineDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function InlineDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} inline showWeek />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} inline showWeek />
         </div>
     )
 }

--- a/components/doc/calendar/localedoc.js
+++ b/components/doc/calendar/localedoc.js
@@ -53,11 +53,12 @@ export default function LocaleDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
 import { addLocale } from 'primereact/api';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function LocaleDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     addLocale('es', {
         firstDayOfWeek: 1,
@@ -73,7 +74,7 @@ export default function LocaleDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e: CalendarChangeEvent) => setDate(e.value)} locale="es" />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} locale="es" />
         </div>
     )
 }

--- a/components/doc/calendar/minmaxdoc.js
+++ b/components/doc/calendar/minmaxdoc.js
@@ -62,7 +62,8 @@ export default function MinMaxDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function MinMaxDemo() {
     let today = new Date();
@@ -73,7 +74,7 @@ export default function MinMaxDemo() {
     let nextMonth = month === 11 ? 0 : month + 1;
     let nextYear = nextMonth === 0 ? year + 1 : year;
 
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     let minDate = new Date();
 
@@ -87,7 +88,7 @@ export default function MinMaxDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e: CalendarChangeEvent) => setDate(e.value)} minDate={minDate} maxDate={maxDate} readOnlyInput />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} minDate={minDate} maxDate={maxDate} readOnlyInput />
         </div>
     )
 }

--- a/components/doc/calendar/monthpickerdoc.js
+++ b/components/doc/calendar/monthpickerdoc.js
@@ -26,14 +26,15 @@ export default function MonthPickerDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function MonthPickerDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} view="month" dateFormat="mm/yy" />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} view="month" dateFormat="mm/yy" />
         </div>
     )
 }

--- a/components/doc/calendar/multipledoc.js
+++ b/components/doc/calendar/multipledoc.js
@@ -26,14 +26,15 @@ export default function MultipleDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function MultipleDemo() {
-    const [dates, setDates] = useState<string | Date | Date[] | null>(null);
+    const [dates, setDates] = useState<Nullable<Date[]>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={dates} onChange={(e : CalendarChangeEvent) => setDates(e.value)} selectionMode="multiple" readOnlyInput />
+            <Calendar value={dates} onChange={(e) => setDates(e.value)} selectionMode="multiple" readOnlyInput />
         </div>
     )
 }

--- a/components/doc/calendar/multiplemonthsdoc.js
+++ b/components/doc/calendar/multiplemonthsdoc.js
@@ -26,14 +26,15 @@ export default function MultipleMonthsDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function MultipleMonthsDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} numberOfMonths={2} />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={2} />
         </div>
     )
 }

--- a/components/doc/calendar/rangedoc.js
+++ b/components/doc/calendar/rangedoc.js
@@ -26,14 +26,15 @@ export default function RangeDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function RangeDemo() {
-    const [dates, setDates] = useState<string | Date | Date[] | null>(null);
+    const [dates, setDates] = useState<Nullable<(Date | null)[]>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={dates} onChange={(e : CalendarChangeEvent) => setDates(e.value)} selectionMode="range" readOnlyInput />
+            <Calendar value={dates} onChange={(e) => setDates(e.value)} selectionMode="range" readOnlyInput />
         </div>
 
     )

--- a/components/doc/calendar/timedoc.js
+++ b/components/doc/calendar/timedoc.js
@@ -49,12 +49,13 @@ export default function TimeDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent} from 'primereact/calendar';
+import { Calendar} from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function TimeDemo() {
-    const [datetime12h, setDateTime12h] = useState<string | Date | Date[] | null>(null);
-    const [datetime24h, setDateTime24h] = useState<string | Date | Date[] | null>(null);
-    const [time, setTime] = useState<string | Date | Date[] | null>(null);
+    const [datetime12h, setDateTime12h] = useState<Nullable<Date>>(null);
+    const [datetime24h, setDateTime24h] = useState<Nullable<Date>>(null);
+    const [time, setTime] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex flex-wrap gap-3 p-fluid">
@@ -62,19 +63,19 @@ export default function TimeDemo() {
                 <label htmlFor="calendar-12h" className="font-bold block mb-2">
                     12h Format
                 </label>
-                <Calendar id="calendar-12h" value={datetime12h} onChange={(e: CalendarChangeEvent) => setDateTime12h(e.value)} showTime hourFormat="12" />
+                <Calendar id="calendar-12h" value={datetime12h} onChange={(e) => setDateTime12h(e.value)} showTime hourFormat="12" />
             </div>
             <div className="flex-auto">
                 <label htmlFor="calendar-24h" className="font-bold block mb-2">
                     24h Format
                 </label>
-                <Calendar id="calendar-24h" value={datetime24h} onChange={(e: CalendarChangeEvent) => setDateTime24h(e.value)} showTime hourFormat="24" />
+                <Calendar id="calendar-24h" value={datetime24h} onChange={(e) => setDateTime24h(e.value)} showTime hourFormat="24" />
             </div>
             <div className="flex-auto">
                 <label htmlFor="calendar-timeonly" className="font-bold block mb-2">
                     Time Only
                 </label>
-                <Calendar id="calendar-timeonly" value={time} onChange={(e: CalendarChangeEvent) => setTime(e.value)} timeOnly />
+                <Calendar id="calendar-timeonly" value={time} onChange={(e) => setTime(e.value)} timeOnly />
             </div>
         </div>
     )

--- a/components/doc/calendar/touchuidoc.js
+++ b/components/doc/calendar/touchuidoc.js
@@ -26,14 +26,15 @@ export default function TouchUIDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function TouchUIDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} touchUI />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} touchUI />
         </div>
     )
 }

--- a/components/doc/calendar/yearpickerdoc.js
+++ b/components/doc/calendar/yearpickerdoc.js
@@ -26,14 +26,15 @@ export default function YearPickerDemo() {
         `,
         typescript: `
 import React, { useState } from "react";
-import { Calendar, CalendarChangeEvent } from 'primereact/calendar';
+import { Calendar } from 'primereact/calendar';
+import { Nullable } from "primereact/ts-helpers";
 
 export default function YearPickerDemo() {
-    const [date, setDate] = useState<string | Date | Date[] | null>(null);
+    const [date, setDate] = useState<Nullable<Date>>(null);
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e : CalendarChangeEvent) => setDate(e.value)} view="year" dateFormat="yy" />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} view="year" dateFormat="yy" />
         </div>
     )
 }

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import PrimeReact, { PrimeReactContext, localeOption, localeOptions } from '../api/Api';
 import { Button } from '../button/Button';
+import { useHandleStyle } from '../componentbase/ComponentBase';
 import { useMountEffect, useOverlayListener, usePrevious, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { CalendarIcon } from '../icons/calendar';
 import { ChevronDownIcon } from '../icons/chevrondown';
@@ -13,7 +14,6 @@ import { Ripple } from '../ripple/Ripple';
 import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, ZIndexUtils, classNames, mask, mergeProps } from '../utils/Utils';
 import { CalendarBase } from './CalendarBase';
 import { CalendarPanel } from './CalendarPanel';
-import { useHandleStyle } from '../componentbase/ComponentBase';
 
 export const Calendar = React.memo(
     React.forwardRef((inProps, ref) => {

--- a/components/lib/calendar/calendar.d.ts
+++ b/components/lib/calendar/calendar.d.ts
@@ -348,6 +348,7 @@ export interface CalendarYearOptions {
     selectable: boolean;
 }
 
+/**
  * Custom month change event.
  * @see {@link CalendarProps.onMonthChange}
  * @event

--- a/components/lib/calendar/calendar.d.ts
+++ b/components/lib/calendar/calendar.d.ts
@@ -8,12 +8,12 @@
  *
  */
 import * as React from 'react';
+import { ButtonPassThroughOptions } from '../button/button';
 import { CSSTransitionProps } from '../csstransition';
+import { InputTextPassThroughOptions } from '../inputtext/inputtext';
 import { TooltipOptions } from '../tooltip/tooltipoptions';
 import { FormEvent, Nullable } from '../ts-helpers';
 import { IconType, PassThroughType } from '../utils';
-import { ButtonPassThroughOptions } from '../button/button';
-import { InputTextPassThroughOptions } from '../inputtext/inputtext';
 
 export declare type CalendarPassThroughType<T> = PassThroughType<T, CalendarPassThroughMethodOptions>;
 
@@ -269,18 +269,10 @@ export interface CalendarState {
      */
     overlayVisible: boolean;
     /**
-     * Current viewDate state as a string.
+     * Current viewDate state.
      */
-    viewDate: any;
+    viewDate: Nullable<Date>;
 }
-
-/**
- * Custom change event.
- * @see {@link CalendarProps.onChange}
- * @extends {FormEvent}
- * @event
- */
-interface CalendarChangeEvent extends FormEvent<Date | Date[] | string> {}
 
 /**
  * Custom month change event.
@@ -438,7 +430,7 @@ interface CalendarYearNavigatorTemplateEvent extends CalendarNavigatorTemplateEv
  * Defines valid properties in Calendar component.
  * @group Properties
  */
-export interface CalendarProps {
+interface CalendarBaseProps {
     /**
      * Unique identifier of the element.
      */
@@ -622,11 +614,6 @@ export interface CalendarProps {
      */
     selectOtherMonths?: boolean | undefined;
     /**
-     * Specifies the selection mode.
-     * @defaultValue single
-     */
-    selectionMode?: 'single' | 'multiple' | 'range' | undefined;
-    /**
      * The cutoff year for determining the century for a date.
      * @defaultValue +10
      */
@@ -734,11 +721,6 @@ export interface CalendarProps {
      */
     transitionOptions?: CSSTransitionProps | undefined;
     /**
-     * Value of the component.
-     * @defaultValue null
-     */
-    value?: Date | Date[] | string | null | undefined;
-    /**
      * Type of view to display.
      * @defaultValue date
      */
@@ -746,7 +728,7 @@ export interface CalendarProps {
     /**
      * Date instance whose month and year are used to display the calendar.
      */
-    viewDate?: Date | null | undefined;
+    viewDate?: Nullable<Date>;
     /**
      * Specifies the visibility of the overlay.
      * @defaultValue false
@@ -806,11 +788,6 @@ export interface CalendarProps {
      * @param {React.FocusEvent<HTMLInputElement>} event - Browser event
      */
     onBlur?(event: React.FocusEvent<HTMLInputElement>): void;
-    /**
-     * Callback to invoke when value changes.
-     * @param {CalendarChangeEvent} event - Custom change event
-     */
-    onChange?(event: CalendarChangeEvent): void;
     /**
      * Callback to invoke when clear button is clicked.
      * @param {React.MouseEvent<HTMLButtonElement>} event - Browser event
@@ -881,6 +858,62 @@ export interface CalendarProps {
     unstyled?: boolean;
 }
 
+interface CalendarPropsSingle extends CalendarBaseProps {
+    /**
+     * Specifies the selection mode either "single", "range", or "multiple";
+     * @defaultValue single
+     */
+    selectionMode?: 'single' | undefined;
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    value?: Nullable<Date>;
+    /**
+     * Callback to invoke when value changes.
+     * @param { FormEvent<Date>} event - Custom change event
+     */
+    onChange?(event: FormEvent<Date>): void;
+}
+
+interface CalendarPropsRange extends CalendarBaseProps {
+    /**
+     * Specifies the selection mode either "single", "range", or "multiple";
+     * @defaultValue single
+     */
+    selectionMode: 'range';
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    value?: Nullable<(Date | null)[]>;
+    /**
+     * Callback to invoke when value changes.
+     * @param { FormEvent<(Date | null)[]>} event - Custom change event
+     */
+    onChange?(event: FormEvent<(Date | null)[]>): void;
+}
+
+interface CalendarPropsMultiple extends CalendarBaseProps {
+    /**
+     * Specifies the selection mode either "single", "range", or "multiple";
+     * @defaultValue single
+     */
+    selectionMode: 'multiple';
+    /**
+     * Value of the component.
+     * @defaultValue null
+     */
+    value?: Nullable<Date[]>;
+    /**
+     * Callback to invoke when value changes.
+     * @param {FormEvent<Date[]>} event - Custom change event
+     */
+    onChange?(event: FormEvent<Date[]>): void;
+}
+
+export type CalendarProps = CalendarPropsSingle | CalendarPropsRange | CalendarPropsMultiple;
+
 /**
  * **PrimeReact - Calendar**
  *
@@ -935,5 +968,5 @@ export declare class Calendar extends React.Component<CalendarProps, any> {
      * @param {React.SyntheticEvent | null} event - Browser event.
      * @param {Date | Date[] | null} value - New date.
      */
-    public updateViewDate(event: React.SyntheticEvent | null, value: Date | Date[] | null | undefined): void;
+    public updateViewDate(event: React.SyntheticEvent | null, value: Nullable<Date | Date[]>): void;
 }


### PR DESCRIPTION
Fix #4788: Calendar typescript improvements

```ts
import React, { useState } from 'react';
import { Calendar} from 'primereact/calendar';
import { Nullable } from 'primereact/ts-helpers';

export default function RangeDemo() {
  const [dates, setDates] = useState<Nullable<(Date | null)[]>>(null);

  return (
    <div className="card flex justify-content-center">
      <Calendar
        value={dates}
        onChange={(e) => setDates(e.value)}
        selectionMode="range"
        readOnlyInput
      />
    </div>
  );
}
```