### PR TITLE
Fix #4803: Calendar disabledDays only in date display

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1836,7 +1836,7 @@ export const Calendar = React.memo(
                 validDate = !isDateDisabled(day, month, year);
             }
 
-            if (props.disabledDays && currentView !== 'month') {
+            if (props.disabledDays && currentView === 'date') {
                 validDay = !isDayDisabled(day, month, year);
             }
 


### PR DESCRIPTION
Fix #4803: Calendar disabledDays only in date display
