### PR TITLE
Union type to allow SVGElement for icon props

### DIFF
--- a/components/lib/utils/utils.d.ts
+++ b/components/lib/utils/utils.d.ts
@@ -169,7 +169,7 @@ export type IconOptions<ComponentProps, AdditionalProps> = AdditionalProps & {
     /**
      * Icon specific properties.
      */
-    iconProps: React.HTMLProps<HTMLElement>;
+    iconProps: React.HTMLProps<HTMLElement | SVGElement>;
     /**
      * The element representing the icon.
      */
@@ -191,5 +191,5 @@ export type PassThroughType<T, O> =
     | null
     | undefined
     | {
-          [key: string]: any;
-      };
+        [key: string]: any;
+    };


### PR DESCRIPTION
This PR seeks to allow SVGElement as a union type onto the existing `iconProps: React.HTMLProps<HTMLElement>` as follows `iconProps: React.HTMLProps<HTMLElement | SVGElement>;`

This will resolve typescript errors that are raised when using with Custom icons that are SVG based.

- fixes #4850 