### PR TITLE
Fix #4854: Datatable showRowReorder render NULL instead of false

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -627,7 +627,7 @@ export const BodyCell = React.memo((props) => {
             );
             const rowReorderIcon = getColumnProp('rowReorderIcon') || <BarsIcon {...rowReorderIconProps} />;
 
-            content = showReorder && IconUtils.getJSXIcon(rowReorderIcon, { ...rowReorderIconProps }, { props });
+            content = showReorder ? IconUtils.getJSXIcon(rowReorderIcon, { ...rowReorderIconProps }, { props }) : null;
         } else if (expander) {
             const rowTogglerIconProps = mergeProps(
                 {


### PR DESCRIPTION
Fix #4854: Datatable showRowReorder render NULL instead of false
