### PR TITLE
docs: Changed Height Picklist component

### DIFF
--- a/components/doc/picklist/basicdoc.js
+++ b/components/doc/picklist/basicdoc.js
@@ -36,7 +36,7 @@ export function BasicDoc(props) {
     const code = {
         basic: `
 <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} breakpoint="1400px"
-    sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }} />
+    sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }} />
         `,
         javascript: `
 import React, { useState, useEffect } from 'react';
@@ -75,7 +75,7 @@ export default function BasicDemo() {
     return (
         <div className="card">
             <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} breakpoint="1400px"
-                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }} />
+                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }} />
         </div>
     );
 }
@@ -130,7 +130,7 @@ export default function BasicDemo() {
     return (
         <div className="card">
             <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} breakpoint="1400px"
-                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }} />
+                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }} />
         </div>
     );
 }
@@ -162,7 +162,7 @@ export default function BasicDemo() {
                 </p>
             </DocSectionText>
             <div className="card">
-                <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} breakpoint="1400px" sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }} />
+                <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} breakpoint="1400px" sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }} />
             </div>
             <DocSectionCode code={code} service={['ProductService']} />
         </>

--- a/components/doc/picklist/filterdoc.js
+++ b/components/doc/picklist/filterdoc.js
@@ -36,7 +36,7 @@ export function FilterDoc(props) {
     const code = {
         basic: `
 <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} filter filterBy="name" breakpoint="1400px"
-    sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }}
+    sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }}
     sourceFilterPlaceholder="Search by name" targetFilterPlaceholder="Search by name" />
         `,
         javascript: `
@@ -76,7 +76,7 @@ export default function FilterDemo() {
     return (
         <div className="card">
             <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} filter filterBy="name" breakpoint="1400px"
-                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }}
+                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }}
                 sourceFilterPlaceholder="Search by name" targetFilterPlaceholder="Search by name" />
         </div>
     );
@@ -132,7 +132,7 @@ export default function FilterDemo() {
     return (
         <div className="card">
             <PickList source={source} target={target} onChange={onChange} itemTemplate={itemTemplate} filter filterBy="name" breakpoint="1400px"
-                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }}
+                sourceHeader="Available" targetHeader="Selected" sourceStyle={{ height: '24rem' }} targetStyle={{ height: '24rem' }}
                 sourceFilterPlaceholder="Search by name" targetFilterPlaceholder="Search by name" />
         </div>
     );
@@ -172,8 +172,8 @@ export default function FilterDemo() {
                     itemTemplate={itemTemplate}
                     sourceHeader="Available"
                     targetHeader="Selected"
-                    sourceStyle={{ height: '30rem' }}
-                    targetStyle={{ height: '30rem' }}
+                    sourceStyle={{ height: '24rem' }}
+                    targetStyle={{ height: '24rem' }}
                     breakpoint="1400px"
                     filter
                     filterBy="name"

--- a/components/doc/picklist/pt/ptdoc.js
+++ b/components/doc/picklist/pt/ptdoc.js
@@ -43,8 +43,8 @@ export function PTDoc(props) {
     breakpoint="1400px"
     sourceHeader="Available"
     targetHeader="Selected"
-    sourceStyle={{ height: '30rem' }}
-    targetStyle={{ height: '30rem' }}
+    sourceStyle={{ height: '24rem' }}
+    targetStyle={{ height: '24rem' }}
     pt={{
         list: { style: { height: '342px' } },
         moveAllToTargetButton: {
@@ -101,8 +101,8 @@ export default function PTDemo() {
                 breakpoint="1400px"
                 sourceHeader="Available"
                 targetHeader="Selected"
-                sourceStyle={{ height: '30rem' }}
-                targetStyle={{ height: '30rem' }}
+                sourceStyle={{ height: '24rem' }}
+                targetStyle={{ height: '24rem' }}
                 pt={{
                     list: { style: { height: '342px' } },
                     moveAllToTargetButton: {
@@ -175,8 +175,8 @@ export default function PTDemo() {
                 breakpoint="1400px"
                 sourceHeader="Available"
                 targetHeader="Selected"
-                sourceStyle={{ height: '30rem' }}
-                targetStyle={{ height: '30rem' }}
+                sourceStyle={{ height: '24rem' }}
+                targetStyle={{ height: '24rem' }}
                 pt={{
                     list: { style: { height: '342px' } },
                     moveAllToTargetButton: {
@@ -222,8 +222,8 @@ export default function PTDemo() {
                     breakpoint="1400px"
                     sourceHeader="Available"
                     targetHeader="Selected"
-                    sourceStyle={{ height: '30rem' }}
-                    targetStyle={{ height: '30rem' }}
+                    sourceStyle={{ height: '24rem' }}
+                    targetStyle={{ height: '24rem' }}
                     pt={{
                         list: { style: { height: '342px' } },
                         moveAllToTargetButton: {


### PR DESCRIPTION
Fix #4887

Changed the documentation of the Picklist Component.
The current documentation was adding `sourceStyle={{ height: '30rem' }} targetStyle={{ height: '30rem' }}` but was doing nothing because we have a `max-height: 24rem`. For that reason I changed all the files of this component to `24rem`.

![image](https://github.com/primefaces/primereact/assets/19764334/8ec685f9-55ec-4f12-85ac-91168bd77bbd)

![image](https://github.com/primefaces/primereact/assets/19764334/71eff5d0-44e1-4d27-89d1-9c4891c5670d)

Note: My personal opinion is maybe remove `max-height: 24rem` and doing that the user can feel free to add in `sourceStyle` and `targetStyle` the height that they want. If you want this change, I should do it in `primereact-sass-theme`, let me know and I can do it too.
