### PR TITLE
Fix #4893: Accordion controlled docs missing useState

### DIFF
--- a/components/doc/accordion/controlleddoc.js
+++ b/components/doc/accordion/controlleddoc.js
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Accordion, AccordionTab } from '../../lib/accordion/Accordion';
 import { Button } from '../../lib/button/Button';
-import { DocSectionText } from '../common/docsectiontext';
 import { DocSectionCode } from '../common/docsectioncode';
+import { DocSectionText } from '../common/docsectiontext';
 
 export function ControlledDoc(props) {
     const [activeIndex, setActiveIndex] = useState(null);
@@ -62,6 +62,8 @@ import { Accordion, AccordionTab } from 'primereact/accordion';
 import { Button } from 'primereact/button';
 
 export default function ControlledDoc() {
+    const [activeIndex, setActiveIndex] = useState(null);
+
     const onClick = (itemIndex) => {
         let _activeIndex = activeIndex ? [...activeIndex] : [];
 
@@ -123,7 +125,9 @@ import { Accordion, AccordionTab } from 'primereact/accordion';
 import { Button } from 'primereact/button';
 
 export default function ControlledDoc() {
-    const onClick = (itemIndex) => {
+    const [activeIndex, setActiveIndex] = useState<number[] | null>(null);
+
+    const onClick = (itemIndex: number) => {
         let _activeIndex = activeIndex ? [...activeIndex] : [];
 
         if (_activeIndex.length === 0) {


### PR DESCRIPTION
Fix #4893: Accordion controlled docs missing useState
