### PR TITLE
Fix #4938: Dialog remove blockscroll on unmount

### DIFF
--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -341,7 +341,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         const isMaximized = props.maximizable && maximized;
 
         if (props.modal) {
-            const hasBlockScroll = document.primeDialogParams && document.primeDialogParams.some((param) => param.hasBlockScroll);
+            const hasBlockScroll = props.blockScroll || (document.primeDialogParams && document.primeDialogParams.some((param) => param.hasBlockScroll));
 
             if (hasBlockScroll || isMaximized) {
                 DomHandler.removeClass(document.body, 'p-overflow-hidden');


### PR DESCRIPTION
Fix #4938: Dialog remove blockscroll on unmount
