### PR TITLE
Fix #4948: FileUpload click instead of mousedown

### DIFF
--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -730,7 +730,7 @@ export const FileUpload = React.memo(
                     className: classNames(chooseOptions.className, cx('basicButton', { hasFiles, disabled, focusedState })),
                     style: chooseOptions.style,
                     tabIndex: 0,
-                    onMouseUp: onSimpleUploaderClick,
+                    onClick: onSimpleUploaderClick,
                     onKeyDown: (e) => onKeyDown(e),
                     onFocus,
                     onBlur


### PR DESCRIPTION
Fix #4948: FileUpload click instead of mousedown
