### PR TITLE
Fix #4932: Menu respect ID field

### DIFF
--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -1,18 +1,19 @@
 import * as React from 'react';
 import PrimeReact, { PrimeReactContext } from '../api/Api';
+import { useHandleStyle } from '../componentbase/ComponentBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { useEventListener, useMatchMedia, useMountEffect, useResizeListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { Portal } from '../portal/Portal';
 import { DomHandler, UniqueComponentId, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
 import { ContextMenuBase } from './ContextMenuBase';
 import { ContextMenuSub } from './ContextMenuSub';
-import { useHandleStyle } from '../componentbase/ComponentBase';
 
 export const ContextMenu = React.memo(
     React.forwardRef((inProps, ref) => {
         const context = React.useContext(PrimeReactContext);
         const props = ContextMenuBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [visibleState, setVisibleState] = React.useState(false);
         const [reshowState, setReshowState] = React.useState(false);
         const [resetMenuState, setResetMenuState] = React.useState(false);
@@ -20,6 +21,7 @@ export const ContextMenu = React.memo(
         const { ptm, cx, isUnstyled } = ContextMenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 visible: visibleState,
                 reshow: reshowState,
                 resetMenu: resetMenuState,
@@ -214,8 +216,12 @@ export const ContextMenu = React.memo(
         };
 
         useMountEffect(() => {
+            const uniqueId = UniqueComponentId();
+
+            !idState && setIdState(uniqueId);
+
             if (props.breakpoint) {
-                !attributeSelectorState && setAttributeSelectorState(UniqueComponentId());
+                !attributeSelectorState && setAttributeSelectorState(uniqueId);
             }
         });
 
@@ -286,7 +292,19 @@ export const ContextMenu = React.memo(
             return (
                 <CSSTransition nodeRef={menuRef} {...transitionProps}>
                     <div ref={menuRef} {...rootProps}>
-                        <ContextMenuSub hostName="ContextMenu" menuProps={props} model={props.model} root resetMenu={resetMenuState} onLeafClick={onLeafClick} isMobileMode={isMobileMode} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />
+                        <ContextMenuSub
+                            hostName="ContextMenu"
+                            id={idState}
+                            menuProps={props}
+                            model={props.model}
+                            root
+                            resetMenu={resetMenuState}
+                            onLeafClick={onLeafClick}
+                            isMobileMode={isMobileMode}
+                            submenuIcon={props.submenuIcon}
+                            ptm={ptm}
+                            cx={cx}
+                        />
                     </div>
                 </CSSTransition>
             );

--- a/components/lib/contextmenu/ContextMenuSub.js
+++ b/components/lib/contextmenu/ContextMenuSub.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { useUpdateEffect } from '../hooks/Hooks';
+import { AngleRightIcon } from '../icons/angleright';
 import { Ripple } from '../ripple/Ripple';
 import { DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
-import { AngleRightIcon } from '../icons/angleright';
 
 export const ContextMenuSub = React.memo((props) => {
     const [activeItemState, setActiveItemState] = React.useState(null);
@@ -94,11 +94,13 @@ export const ContextMenuSub = React.memo((props) => {
     });
 
     const createSeparator = (index) => {
+        const key = props.id + '_separator_' + index;
         const separatorProps = mergeProps(
             {
-                role: 'separator',
-                key: 'separator_' + index,
-                className: cx('separator')
+                id: key,
+                key,
+                className: cx('separator'),
+                role: 'separator'
             },
             ptm('separator', { hostName: props.hostName })
         );
@@ -106,10 +108,11 @@ export const ContextMenuSub = React.memo((props) => {
         return <li {...separatorProps}></li>;
     };
 
-    const createSubmenu = (item) => {
+    const createSubmenu = (item, index) => {
         if (item.items) {
             return (
                 <ContextMenuSub
+                    id={props.id + '_' + index}
                     hostName={props.hostName}
                     menuProps={props.menuProps}
                     model={item.items}
@@ -132,7 +135,7 @@ export const ContextMenuSub = React.memo((props) => {
         }
 
         const active = activeItemState === item;
-        const key = item.label + '_' + index;
+        const key = item.id || props.id + '_' + index;
         const iconProps = mergeProps(
             {
                 className: cx('icon')
@@ -155,7 +158,7 @@ export const ContextMenuSub = React.memo((props) => {
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(props.submenuIcon || <AngleRightIcon {...submenuIconProps} />, { ...submenuIconProps }, { props: props.menuProps });
         const label = item.label && <span {...labelProps}>{item.label}</span>;
-        const submenu = createSubmenu(item);
+        const submenu = createSubmenu(item, index);
         const actionProps = mergeProps(
             {
                 href: item.url || '#',
@@ -195,7 +198,8 @@ export const ContextMenuSub = React.memo((props) => {
 
         const menuitemProps = mergeProps(
             {
-                id: item.id,
+                id: key,
+                key,
                 role: 'none',
                 className: cx('menuitem', { item, active }),
                 style: item.style,

--- a/components/lib/dock/Dock.js
+++ b/components/lib/dock/Dock.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
+import { useMountEffect } from '../hooks/Hooks';
 import { Ripple } from '../ripple/Ripple';
-import { classNames, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
+import { classNames, IconUtils, mergeProps, ObjectUtils, UniqueComponentId } from '../utils/Utils';
 import { DockBase } from './DockBase';
 
 export const Dock = React.memo(
@@ -10,9 +11,11 @@ export const Dock = React.memo(
         const [currentIndexState, setCurrentIndexState] = React.useState(-3);
         const context = React.useContext(PrimeReactContext);
         const props = DockBase.getProps(inProps, context);
+        const [idState, setIdState] = React.useState(props.id);
         const { ptm, cx, isUnstyled } = DockBase.setMetaData({
             props,
             state: {
+                id: idState,
                 currentIndex: currentIndexState
             }
         });
@@ -51,6 +54,7 @@ export const Dock = React.memo(
             }
 
             const { disabled, icon: _icon, label, template, url, target } = item;
+            const key = item.id || idState + '_' + index;
             const contentClassName = classNames('p-dock-action', { 'p-disabled': disabled });
             const iconClassName = classNames('p-dock-action-icon', _icon);
             const iconProps = mergeProps(
@@ -94,7 +98,8 @@ export const Dock = React.memo(
 
             const menuitemProps = mergeProps(
                 {
-                    key: index,
+                    id: key,
+                    key,
                     className: cx('menuitem', { currentIndexState, index }),
                     role: 'none',
                     onMouseEnter: () => onItemMouseEnter(index)
@@ -154,6 +159,12 @@ export const Dock = React.memo(
 
             return null;
         };
+
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
 
         React.useImperativeHandle(ref, () => ({
             props,

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -14,6 +14,7 @@ export const MegaMenu = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = MegaMenuBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [activeItemState, setActiveItemState] = React.useState(null);
         const [attributeSelectorState, setAttributeSelectorState] = React.useState(null);
         const [mobileActiveState, setMobileActiveState] = React.useState(false);
@@ -27,6 +28,7 @@ export const MegaMenu = React.memo(
         const { ptm, cx, isUnstyled } = MegaMenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 activeItem: activeItemState,
                 attributeSelector: attributeSelectorState,
                 mobileActive: mobileActiveState
@@ -207,8 +209,12 @@ export const MegaMenu = React.memo(
         }));
 
         useMountEffect(() => {
+            const uniqueId = UniqueComponentId();
+
+            !idState && setIdState(uniqueId);
+
             if (props.breakpoint) {
-                !attributeSelectorState && setAttributeSelectorState(UniqueComponentId());
+                !attributeSelectorState && setAttributeSelectorState(uniqueId);
             }
 
             bindDocumentClickListener();
@@ -232,10 +238,11 @@ export const MegaMenu = React.memo(
         }, [activeItemState]);
 
         const createSeparator = (index) => {
-            const key = 'separator_' + index;
+            const key = idState + '_separator__' + index;
 
             const separatorProps = mergeProps(
                 {
+                    id: key,
                     key,
                     className: cx('separator'),
                     role: 'separator'
@@ -272,7 +279,7 @@ export const MegaMenu = React.memo(
             if (item.separator) {
                 return createSeparator(index);
             } else {
-                const key = item.label + '_' + index;
+                const key = item.id || idState + '_' + index;
                 const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
                 const iconProps = mergeProps(
                     {
@@ -304,8 +311,8 @@ export const MegaMenu = React.memo(
 
                 const submenuItemProps = mergeProps(
                     {
-                        key: key,
-                        id: item.id,
+                        key,
+                        id: key,
                         className: classNames(item.className, cx('submenuItem')),
                         style: item.style,
                         role: 'none'
@@ -338,16 +345,18 @@ export const MegaMenu = React.memo(
             }
         };
 
-        const createSubmenu = (submenu) => {
+        const createSubmenu = (submenu, index) => {
             if (submenu.visible === false) {
                 return null;
             }
 
             const items = submenu.items.map(createSubmenuItem);
 
+            const key = submenu.id || idState + '_sub_' + index;
             const submenuHeaderProps = mergeProps(
                 {
-                    id: submenu.id,
+                    id: key,
+                    key,
                     className: classNames(submenu.className, cx('submenuHeader', { submenu })),
                     style: submenu.style,
                     role: 'presentation',
@@ -357,7 +366,7 @@ export const MegaMenu = React.memo(
             );
 
             return (
-                <React.Fragment key={submenu.label}>
+                <React.Fragment key={key}>
                     <li {...submenuHeaderProps}>{submenu.label}</li>
                     {items}
                 </React.Fragment>
@@ -577,10 +586,11 @@ export const MegaMenu = React.memo(
                 getPTOptions(category, 'headerAction', index)
             );
 
+            const key = category.id || idState + '_cat_' + index;
             const menuItemProps = mergeProps(
                 {
-                    key: category.label + '_' + index,
-                    id: category.id,
+                    key,
+                    id: key,
                     className: classNames(category.className, cx('menuitem', { category, activeItemState })),
                     style: category.style,
                     onMouseEnter: (e) => onCategoryMouseEnter(e, category),

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -1,22 +1,23 @@
 import * as React from 'react';
-import { PrimeReactContext } from '../api/Api';
+import PrimeReact, { PrimeReactContext } from '../api/Api';
+import { useHandleStyle } from '../componentbase/ComponentBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
-import { useOverlayListener, useUnmountEffect } from '../hooks/Hooks';
+import { useMountEffect, useOverlayListener, useUnmountEffect } from '../hooks/Hooks';
 import { OverlayService } from '../overlayservice/OverlayService';
 import { Portal } from '../portal/Portal';
-import { DomHandler, IconUtils, ObjectUtils, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
+import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
 import { MenuBase } from './MenuBase';
-import PrimeReact from '../api/Api';
-import { useHandleStyle } from '../componentbase/ComponentBase';
 
 export const Menu = React.memo(
     React.forwardRef((inProps, ref) => {
         const context = React.useContext(PrimeReactContext);
         const props = MenuBase.getProps(inProps, context);
+        const [idState, setIdState] = React.useState(props.id);
         const [visibleState, setVisibleState] = React.useState(!props.popup);
         const { ptm, cx, sx, isUnstyled } = MenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 visible: visibleState
             }
         });
@@ -140,6 +141,12 @@ export const Menu = React.memo(
             ZIndexUtils.clear(menuRef.current);
         };
 
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
+
         useUnmountEffect(() => {
             ZIndexUtils.clear(menuRef.current);
         });
@@ -154,10 +161,12 @@ export const Menu = React.memo(
         }));
 
         const createSubmenu = (submenu, index) => {
-            const key = submenu.label + '_' + index;
+            const key = idState + '_sub_' + index;
             const items = submenu.items.map(createMenuItem);
             const submenuHeaderProps = mergeProps(
                 {
+                    id: key,
+                    key,
                     role: 'presentation',
                     className: classNames(submenu.className, cx('submenuHeader', { submenu })),
                     style: sx('submenuHeader', { submenu }),
@@ -175,9 +184,10 @@ export const Menu = React.memo(
         };
 
         const createSeparator = (index) => {
-            const key = 'separator_' + index;
+            const key = idState + '_separator_' + index;
             const separatorProps = mergeProps(
                 {
+                    id: key,
                     key,
                     className: cx('separator'),
                     role: 'separator'
@@ -210,7 +220,7 @@ export const Menu = React.memo(
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const tabIndex = item.disabled ? null : 0;
-            const key = item.label + '_' + index;
+            const key = item.id || idState + '_' + index;
             const actionProps = mergeProps(
                 {
                     href: item.url || '#',
@@ -250,6 +260,7 @@ export const Menu = React.memo(
 
             const menuitemProps = mergeProps(
                 {
+                    id: key,
                     key,
                     className: classNames(item.className, cx('menuitem')),
                     style: sx('menuitem', { item }),

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import PrimeReact, { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
-import { useEventListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
+import { useEventListener, useMountEffect, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { BarsIcon } from '../icons/bars';
-import { IconUtils, ObjectUtils, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
+import { IconUtils, ObjectUtils, UniqueComponentId, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
 import { MenubarBase } from './MenubarBase';
 import { MenubarSub } from './MenubarSub';
 
@@ -12,6 +12,7 @@ export const Menubar = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = MenubarBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [mobileActiveState, setMobileActiveState] = React.useState(false);
         const elementRef = React.useRef(null);
         const rootMenuRef = React.useRef(null);
@@ -19,6 +20,7 @@ export const Menubar = React.memo(
         const { ptm, cx, isUnstyled } = MenubarBase.setMetaData({
             props,
             state: {
+                id: idState,
                 mobileActive: mobileActiveState
             }
         });
@@ -47,6 +49,12 @@ export const Menubar = React.memo(
         const isOutsideClicked = (event) => {
             return rootMenuRef.current !== event.target && !rootMenuRef.current.contains(event.target) && menuButtonRef.current !== event.target && !menuButtonRef.current.contains(event.target);
         };
+
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
 
         useUpdateEffect(() => {
             if (mobileActiveState) {
@@ -132,7 +140,7 @@ export const Menubar = React.memo(
         const start = createStartContent();
         const end = createEndContent();
         const menuButton = createMenuButton();
-        const submenu = <MenubarSub hostName="Menubar" ref={rootMenuRef} menuProps={props} model={props.model} root mobileActive={mobileActiveState} onLeafClick={onLeafClick} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />;
+        const submenu = <MenubarSub hostName="Menubar" id={idState} ref={rootMenuRef} menuProps={props} model={props.model} root mobileActive={mobileActiveState} onLeafClick={onLeafClick} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />;
         const rootProps = mergeProps(
             {
                 id: props.id,

--- a/components/lib/menubar/MenubarSub.js
+++ b/components/lib/menubar/MenubarSub.js
@@ -176,9 +176,10 @@ export const MenubarSub = React.memo(
         }, [props.parentActive]);
 
         const createSeparator = (index) => {
-            const key = 'separator_' + index;
+            const key = props.id + '_separator_' + index;
             const separatorProps = mergeProps(
                 {
+                    id: key,
                     key,
                     className: cx('separator'),
                     role: 'separator'
@@ -189,10 +190,11 @@ export const MenubarSub = React.memo(
             return <li {...separatorProps}></li>;
         };
 
-        const createSubmenu = (item) => {
+        const createSubmenu = (item, index) => {
             if (item.items) {
                 return (
                     <MenubarSub
+                        id={props.id + '_' + index}
                         hostName={props.hostName}
                         menuProps={props.menuProps}
                         model={item.items}
@@ -215,7 +217,7 @@ export const MenubarSub = React.memo(
                 return null;
             }
 
-            const key = item.label + '_' + index;
+            const key = item.id || props.id + '_' + index;
             const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(
@@ -246,7 +248,7 @@ export const MenubarSub = React.memo(
                     { ...submenuIconProps },
                     { props: { menuProps: props.menuProps, ...props } }
                 );
-            const submenu = createSubmenu(item);
+            const submenu = createSubmenu(item, index);
             const actionProps = mergeProps(
                 {
                     href: item.url || '#',
@@ -286,9 +288,9 @@ export const MenubarSub = React.memo(
 
             const menuitemProps = mergeProps(
                 {
+                    id: key,
                     key,
                     role: 'none',
-                    id: item.id,
                     className: classNames(item.className, cx('menuitem', { item, activeItemState })),
                     onMouseEnter: (event) => onItemMouseEnter(event, item),
                     'data-p-disabled': item.disabled || false

--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -126,7 +126,7 @@ export const PanelMenu = React.memo(
                 return null;
             }
 
-            const key = item.label + '_' + index;
+            const key = item.id || idState + '_' + index;
             const active = isItemActive(item);
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const headerIconProps = mergeProps(
@@ -240,7 +240,7 @@ export const PanelMenu = React.memo(
                     <CSSTransition nodeRef={menuContentRef} {...transitionProps}>
                         <div id={contentId} ref={menuContentRef} {...toggleableContentProps}>
                             <div {...menuContentProps}>
-                                <PanelMenuSub hostName="PanelMenu" menuProps={props} model={item.items} className="p-panelmenu-root-submenu" multiple={props.multiple} submenuIcon={props.submenuIcon} root ptm={ptm} cx={cx} />
+                                <PanelMenuSub hostName="PanelMenu" id={key} menuProps={props} model={item.items} className="p-panelmenu-root-submenu" multiple={props.multiple} submenuIcon={props.submenuIcon} root ptm={ptm} cx={cx} />
                             </div>
                         </div>
                     </CSSTransition>

--- a/components/lib/panelmenu/PanelMenuSub.js
+++ b/components/lib/panelmenu/PanelMenuSub.js
@@ -88,12 +88,14 @@ export const PanelMenuSub = React.memo((props) => {
     });
 
     const createSeparator = (index) => {
-        const key = 'separator_' + index;
+        const key = props.id + '_sep_' + index;
 
         const separatorProps = mergeProps(
             {
+                id: key,
                 key,
-                className: cx('separator')
+                className: cx('separator'),
+                role: 'separator'
             },
             _ptm('separator')
         );
@@ -101,7 +103,7 @@ export const PanelMenuSub = React.memo((props) => {
         return <li {...separatorProps}></li>;
     };
 
-    const createSubmenu = (item, active) => {
+    const createSubmenu = (item, active, index) => {
         const submenuRef = React.createRef();
 
         const toggleableContentProps = mergeProps(
@@ -125,7 +127,7 @@ export const PanelMenuSub = React.memo((props) => {
             return (
                 <CSSTransition nodeRef={submenuRef} {...transitionProps}>
                     <div ref={submenuRef} {...toggleableContentProps}>
-                        <PanelMenuSub menuProps={props.menuProps} model={item.items} multiple={props.multiple} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />
+                        <PanelMenuSub id={props.id + '_' + index} menuProps={props.menuProps} model={item.items} multiple={props.multiple} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />
                     </div>
                 </CSSTransition>
             );
@@ -139,7 +141,7 @@ export const PanelMenuSub = React.memo((props) => {
             return null;
         }
 
-        const key = item.label + '_' + index;
+        const key = item.id || props.id + '_' + index;
         const active = isItemActive(item);
         const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
         const iconClassName = classNames('p-menuitem-icon', item.icon);
@@ -165,7 +167,7 @@ export const PanelMenuSub = React.memo((props) => {
             getPTOptions(item, 'submenuicon')
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(active ? props.submenuIcon || <ChevronDownIcon {...submenuIconProps} /> : props.submenuIcon || <ChevronRightIcon {...submenuIconProps} />);
-        const submenu = createSubmenu(item, active);
+        const submenu = createSubmenu(item, active, index);
         const actionProps = mergeProps(
             {
                 href: item.url || '#',
@@ -205,7 +207,7 @@ export const PanelMenuSub = React.memo((props) => {
         const menuitemProps = mergeProps(
             {
                 key,
-                id: item.id,
+                id: key,
                 className: cx('menuitem', { item }),
                 style: item.style,
                 role: 'none'

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -2,11 +2,11 @@ import * as React from 'react';
 import PrimeReact, { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
-import { useOverlayListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
+import { useMountEffect, useOverlayListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { ChevronLeftIcon } from '../icons/chevronleft';
 import { OverlayService } from '../overlayservice/OverlayService';
 import { Portal } from '../portal/Portal';
-import { DomHandler, IconUtils, ZIndexUtils, mergeProps } from '../utils/Utils';
+import { DomHandler, IconUtils, UniqueComponentId, ZIndexUtils, mergeProps } from '../utils/Utils';
 import { SlideMenuBase } from './SlideMenuBase';
 import { SlideMenuSub } from './SlideMenuSub';
 
@@ -15,11 +15,13 @@ export const SlideMenu = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = SlideMenuBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [levelState, setLevelState] = React.useState(0);
         const [visibleState, setVisibleState] = React.useState(false);
         const { ptm, cx, sx, isUnstyled } = SlideMenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 visible: visibleState,
                 level: levelState
             }
@@ -98,6 +100,12 @@ export const SlideMenu = React.memo(
             ZIndexUtils.clear(menuRef.current);
             setLevelState(0);
         };
+
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
 
         useUpdateEffect(() => {
             setLevelState(0);
@@ -201,6 +209,7 @@ export const SlideMenu = React.memo(
                         <div {...wrapperProps}>
                             <div {...contentProps}>
                                 <SlideMenuSub
+                                    id={idState}
                                     hostName="SlideMenu"
                                     menuProps={props}
                                     model={props.model}

--- a/components/lib/slidemenu/SlideMenuSub.js
+++ b/components/lib/slidemenu/SlideMenuSub.js
@@ -44,11 +44,14 @@ export const SlideMenuSub = React.memo((props) => {
     };
 
     const createSeparator = (index) => {
-        const key = 'separator_' + index;
+        const key = props.id + '_sep_' + index;
+
         const separatorProps = mergeProps(
             {
+                id: key,
                 key,
-                className: cx('separator')
+                className: cx('separator'),
+                role: 'separator'
             },
             ptm('separator', { hostName: props.hostName })
         );
@@ -62,6 +65,7 @@ export const SlideMenuSub = React.memo((props) => {
         if (item.items && shouldRender) {
             return (
                 <SlideMenuSub
+                    id={props.id + '_' + index}
                     menuProps={props.menuProps}
                     model={item.items}
                     index={props.index + 1}
@@ -81,7 +85,7 @@ export const SlideMenuSub = React.memo((props) => {
     };
 
     const createKey = (item, index) => {
-        return item.label + '_' + index;
+        return item.id || props.id + '_' + index;
     };
 
     const createMenuitem = (item, index) => {
@@ -150,7 +154,7 @@ export const SlideMenuSub = React.memo((props) => {
 
         const menuitemProps = mergeProps(
             {
-                id: item.id,
+                id: key,
                 key,
                 className: cx('menuitem', { active, item }),
                 style: item.style

--- a/components/lib/steps/Steps.js
+++ b/components/lib/steps/Steps.js
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
-import { IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
+import { useMountEffect } from '../hooks/Hooks';
+import { IconUtils, ObjectUtils, UniqueComponentId, classNames, mergeProps } from '../utils/Utils';
 import { StepsBase } from './StepsBase';
 
 export const Steps = React.memo(
@@ -9,10 +10,14 @@ export const Steps = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = StepsBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const elementRef = React.useRef(null);
 
         const { ptm, cx, isUnstyled } = StepsBase.setMetaData({
-            props
+            props,
+            state: {
+                id: idState
+            }
         });
 
         useHandleStyle(StepsBase.css.styles, isUnstyled, { name: 'steps' });
@@ -50,7 +55,7 @@ export const Steps = React.memo(
                 return null;
             }
 
-            const key = item.label + '_' + index;
+            const key = item.id || idState + '_' + index;
             const active = index === props.activeIndex;
             const disabled = item.disabled || (index !== props.activeIndex && props.readOnly);
             const tabIndex = disabled ? -1 : '';
@@ -120,8 +125,8 @@ export const Steps = React.memo(
 
             const menuItemProps = mergeProps(
                 {
-                    key: key,
-                    id: item.id,
+                    key,
+                    id: key,
                     className: cx('menuitem', { active, disabled, item }),
                     style: item.style,
                     role: 'tab',
@@ -150,6 +155,12 @@ export const Steps = React.memo(
 
             return null;
         };
+
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
 
         React.useImperativeHandle(ref, () => ({
             props,

--- a/components/lib/tabmenu/TabMenu.js
+++ b/components/lib/tabmenu/TabMenu.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
+import { useMountEffect } from '../hooks/Hooks';
 import { Ripple } from '../ripple/Ripple';
-import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
+import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, classNames, mergeProps } from '../utils/Utils';
 import { TabMenuBase } from './TabMenuBase';
 
 export const TabMenu = React.memo(
@@ -10,6 +11,7 @@ export const TabMenu = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = TabMenuBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [activeIndexState, setActiveIndexState] = React.useState(props.activeIndex);
         const elementRef = React.useRef(null);
         const inkbarRef = React.useRef(null);
@@ -20,6 +22,7 @@ export const TabMenu = React.memo(
         const { ptm, cx, isUnstyled } = TabMenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 activeIndex: activeIndexState
             }
         });
@@ -77,6 +80,12 @@ export const TabMenu = React.memo(
             }
         };
 
+        useMountEffect(() => {
+            if (!idState) {
+                setIdState(UniqueComponentId());
+            }
+        });
+
         React.useImperativeHandle(ref, () => ({
             props,
             getElement: () => elementRef.current
@@ -92,7 +101,7 @@ export const TabMenu = React.memo(
             }
 
             const { className: _className, style, disabled, icon: _icon, label: _label, template, url, target } = item;
-            const key = _label + '_' + index;
+            const key = item.id || idState + '_' + index;
             const active = isSelected(index);
             const iconClassName = classNames('p-menuitem-icon', _icon);
             const iconProps = mergeProps(
@@ -151,6 +160,7 @@ export const TabMenu = React.memo(
             const menuItemProps = mergeProps(
                 {
                     ref: tabsRef.current[`tab_${index}`],
+                    id: key,
                     key,
                     className: cx('menuitem', { _className, active, disabled }),
                     style: style,

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -14,11 +14,13 @@ export const TieredMenu = React.memo(
         const context = React.useContext(PrimeReactContext);
         const props = TieredMenuBase.getProps(inProps, context);
 
+        const [idState, setIdState] = React.useState(props.id);
         const [visibleState, setVisibleState] = React.useState(!props.popup);
         const [attributeSelectorState, setAttributeSelectorState] = React.useState(null);
         const { ptm, cx, sx, isUnstyled } = TieredMenuBase.setMetaData({
             props,
             state: {
+                id: idState,
                 visible: visibleState,
                 attributeSelector: attributeSelectorState
             }
@@ -147,8 +149,12 @@ export const TieredMenu = React.memo(
         };
 
         useMountEffect(() => {
+            const uniqueId = UniqueComponentId();
+
+            !idState && setIdState(uniqueId);
+
             if (props.breakpoint) {
-                !attributeSelectorState && setAttributeSelectorState(UniqueComponentId());
+                !attributeSelectorState && setAttributeSelectorState(uniqueId);
             }
         });
 
@@ -207,6 +213,7 @@ export const TieredMenu = React.memo(
                 <CSSTransition nodeRef={menuRef} {...transitionProps}>
                     <div {...rootProps}>
                         <TieredMenuSub
+                            id={idState}
                             hostName="TieredMenu"
                             menuProps={props}
                             model={props.model}

--- a/components/lib/tieredmenu/TieredMenuSub.js
+++ b/components/lib/tieredmenu/TieredMenuSub.js
@@ -202,10 +202,11 @@ export const TieredMenuSub = React.memo((props) => {
         return <li {...separatorProps}></li>;
     };
 
-    const createSubmenu = (item) => {
+    const createSubmenu = (item, index) => {
         if (item.items) {
             return (
                 <TieredMenuSub
+                    id={props.id + '_' + index}
                     menuProps={props.menuProps}
                     model={item.items}
                     onLeafClick={onLeafClick}
@@ -231,7 +232,7 @@ export const TieredMenuSub = React.memo((props) => {
         }
 
         const { id, className: _className, style, disabled, icon: _icon, label: _label, items, target, url, template } = item;
-        const key = _label + '_' + index;
+        const key = id || props.id + '_' + index;
         const active = activeItemState === item;
         const linkClassName = classNames('p-menuitem-link', { 'p-disabled': disabled });
         const iconClassName = classNames('p-menuitem-icon', _icon);
@@ -257,7 +258,7 @@ export const TieredMenuSub = React.memo((props) => {
             getPTOptions(item, 'submenuIcon')
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(props.submenuIcon || <AngleRightIcon {...submenuIconProps} />, { ...submenuIconProps }, { props: props.menuProps });
-        const submenu = createSubmenu(item);
+        const submenu = createSubmenu(item, index);
         const actionProps = mergeProps(
             {
                 href: url || '#',
@@ -301,7 +302,7 @@ export const TieredMenuSub = React.memo((props) => {
         const menuitemProps = mergeProps(
             {
                 key,
-                id: item.id,
+                id: key,
                 className: cx('menuitem', { _className, active }),
                 style: style,
                 onMouseEnter: (event) => onItemMouseEnter(event, item),


### PR DESCRIPTION
Fix #4932: Menu respect ID field

Improves on what Primevue does by autogenerating Menu ID's but using the `menu.id` if manually set by user.