### PR TITLE
fix Primefaces #4954 TreeSelect: With selected value, close icon looks cluttered

### DIFF
--- a/components/lib/treeselect/TreeSelectBase.js
+++ b/components/lib/treeselect/TreeSelectBase.js
@@ -124,9 +124,8 @@ const styles = `
 }
 
 .p-treeselect-clear-icon {
-    position: absolute;
     top: 50%;
-    margin-top: -.5rem;
+    margin-top: 11px;
 }
 
 .p-fluid .p-treeselect {


### PR DESCRIPTION
### Defect Fixes
#4954 TreeSelect: With selected value, close icon looks cluttered

Before fix
https://user-images.githubusercontent.com/123446355/270184681-9793a9c1-2e7a-4c54-8899-8b9d971b99e1.png

After fix 
![image](https://github.com/primefaces/primereact/assets/123446355/252fab11-0556-4e58-ad1b-e5cfec3ef549)
