### PR TITLE
MultiSelect label now uses props.values instead of props.options

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -375,7 +375,7 @@ export const MultiSelect = React.memo(
                         }
                     }
                 } else {
-                    option = findOptionByValue(val, props.options);
+                    option = findOptionByValue(val, props.value);
                 }
             }
 


### PR DESCRIPTION
### Defect Fixes
Fix #4944 

Here is the [issue](https://github.com/primefaces/primereact/issues/4944) I submitted  as well as the relevant [discussion](https://github.com/orgs/primefaces/discussions/88)  #4944 

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
