### PR TITLE
Editor: Fix background color in dark mode themes

### DIFF
--- a/components/lib/editor/EditorBase.js
+++ b/components/lib/editor/EditorBase.js
@@ -675,7 +675,6 @@ const styles = `
     line-height: 22px;
 }
 .ql-snow .ql-picker-options {
-    background-color: #fff;
     display: none;
     min-width: 100%;
     padding: 4px 8px;


### PR DESCRIPTION
Fix #4990 

The `background-color` line was affecting the others colors in all the themes. Removing the property solves the problem.
I applied the same solution in PrimeVue project: https://github.com/primefaces/primevue/pull/4524.

The solution in PrimeNG is different (https://github.com/primefaces/primeng-sass-theme/pull/55). I edited the `primeng-sass-theme` project and I added `!important` in the class. If you consider it's more convenient to do in `primereact-sass-theme`, let me know.

## CURRENTLY
![problem editor](https://github.com/primefaces/primereact/assets/19764334/01dfba68-ccca-4a54-b514-d1bbfa1bcffb)

## AFTER SOLUTION
![fix editor](https://github.com/primefaces/primereact/assets/19764334/0c3044ff-7bc5-4430-aa6d-6bcd4a67f8e1)
