### PR TITLE
Fix #5003: ProgressBar apply classname to determinate

### DIFF
--- a/components/lib/progressbar/ProgressBar.js
+++ b/components/lib/progressbar/ProgressBar.js
@@ -30,7 +30,7 @@ export const ProgressBar = React.memo(
             const label = createLabel();
             const rootProps = mergeProps(
                 {
-                    className: cx('root'),
+                    className: classNames(props.className, cx('root')),
                     style: props.style,
                     role: 'progressbar',
                     'aria-valuemin': '0',


### PR DESCRIPTION
Fix #5003: ProgressBar apply classname to determinate
