### PR TITLE
fix Primefaces #5012 TreeSelect: With selected value, close icon looks cluttered

### DIFF
--- a/components/lib/treeselect/TreeSelectBase.js
+++ b/components/lib/treeselect/TreeSelectBase.js
@@ -125,9 +125,9 @@ const styles = `
     }
     
     .p-treeselect-clear-icon {
-        position: absolute;
+        position: relative;
         top: 50%;
-        margin-top: -.5rem;
+        margin-top: -0.6rem;
     }
     
     .p-fluid .p-treeselect {


### PR DESCRIPTION
### Defect Fixes
fix Primefaces #5012 TreeSelect: With selected value, close icon looks cluttered

Before fix
![image](https://github.com/primefaces/primereact/assets/123446355/13a6b65f-9588-4836-a081-bad3589400e7)

After fix
![image](https://github.com/primefaces/primereact/assets/123446355/7dfcfe07-7b36-4af1-865d-cade37805d9c)



