### PR TITLE
fix Primefaces primefaces#5044 Menu with popup prop passed doesnot close on Escape keypress

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -32331,6 +32331,14 @@
                             "type": "boolean",
                             "default": "false",
                             "description": "When enabled, it removes component related styles in the core."
+                        },
+                        {
+                            "name": "closeOnEscape",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "true",
+                            "description": "Specifies if pressing escape key should hide the Menu Popup."
                         }
                     ]
                 },

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -7,6 +7,7 @@ import { OverlayService } from '../overlayservice/OverlayService';
 import { Portal } from '../portal/Portal';
 import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, ZIndexUtils, classNames, mergeProps } from '../utils/Utils';
 import { MenuBase } from './MenuBase';
+import { useOnEscapeKey } from '../../lib/hooks/Hooks';
 
 export const Menu = React.memo(
     React.forwardRef((inProps, ref) => {
@@ -25,6 +26,10 @@ export const Menu = React.memo(
         useHandleStyle(MenuBase.css.styles, isUnstyled, { name: 'menu' });
         const menuRef = React.useRef(null);
         const targetRef = React.useRef(null);
+
+        useOnEscapeKey(targetRef, props.popup && props.closeOnEscape, (event) => {
+            hide(event);
+        });
 
         const [bindOverlayListener, unbindOverlayListener] = useOverlayListener({
             target: targetRef,

--- a/components/lib/menu/MenuBase.js
+++ b/components/lib/menu/MenuBase.js
@@ -72,7 +72,8 @@ export const MenuBase = ComponentBase.extend({
         transitionOptions: null,
         onShow: null,
         onHide: null,
-        children: undefined
+        children: undefined,
+        closeOnEscape: true
     },
     css: {
         classes,

--- a/components/lib/menu/menu.d.ts
+++ b/components/lib/menu/menu.d.ts
@@ -154,6 +154,11 @@ export interface MenuProps extends Omit<React.DetailedHTMLProps<React.HTMLAttrib
      * @defaultValue false
      */
     unstyled?: boolean;
+    /**
+     * Specifies if pressing escape key should hide the Menu Popup.
+     * @defaultValue true
+     */
+    closeOnEscape?: boolean | undefined;
 }
 
 /**


### PR DESCRIPTION
### Defect Fixes
Fix primefaces#5044 Menu with popup prop passed doesnot close on Escape keypress

