### PR TITLE
Fix #5054: ContextMenu typescript examples fixed

### DIFF
--- a/components/doc/contextmenu/basicdoc.js
+++ b/components/doc/contextmenu/basicdoc.js
@@ -40,8 +40,8 @@ import { ContextMenu } from 'primereact/contextmenu';
 import { MenuItem } from 'primereact/menuitem';
 
 export default function BasicDemo() {
-    const cm = useRef(null);
-    const items: MenuItem = [
+    const cm = useRef<ContextMenu>(null);
+    const items: MenuItem[] = [
         { label: 'View', icon: 'pi pi-fw pi-search' },
         { label: 'Delete', icon: 'pi pi-fw pi-trash' }
     ];
@@ -49,7 +49,7 @@ export default function BasicDemo() {
     return (
         <div className="card flex md:justify-content-center">
             <ContextMenu model={items} ref={cm} breakpoint="767px" />
-            <img src="https://primefaces.org/cdn/primereact/images/nature/nature3.jpg" alt="Logo" className="max-w-full" onContextMenu={(e) => cm.current.show(e)} />
+            <img src="https://primefaces.org/cdn/primereact/images/nature/nature3.jpg" alt="Logo" className="max-w-full" onContextMenu={(e) => cm.current?.show(e)} />
         </div>
     )
 }

--- a/components/doc/contextmenu/pt/ptdoc.js
+++ b/components/doc/contextmenu/pt/ptdoc.js
@@ -298,8 +298,8 @@ import { ContextMenu } from 'primereact/contextmenu';
 import { MenuItem } from 'primereact/menuitem';
 
 export default function PTDemo() {
-    const cm = useRef(null);
-    const items: MenuItem = [
+    const cm = useRef<ContextMenu>(null);
+    const items: MenuItem[] = [
         {
             label: 'File',
             icon: 'pi pi-fw pi-file',
@@ -436,7 +436,7 @@ export default function PTDemo() {
                     action: ({ props, state, context }) => ({ className: context.active ? 'bg-primary-200' : undefined })
                 }}
             />
-            <img src="https://primefaces.org/cdn/primereact/images/nature/nature3.jpg" alt="Logo" className="max-w-full" onContextMenu={(e) => cm.current.show(e)} />
+            <img src="https://primefaces.org/cdn/primereact/images/nature/nature3.jpg" alt="Logo" className="max-w-full" onContextMenu={(e) => cm.current?.show(e)} />
         </div>
     )
 }


### PR DESCRIPTION
Fix #5054: ContextMenu typescript examples fixed
