### PR TITLE
Added custom event for data table row pointer events #5051

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -16800,6 +16800,32 @@
                             "description": "Callback to invoke when a row is navigated away from with mouse."
                         },
                         {
+                            "name": "onRowPointerDown",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "optional": false,
+                                    "type": "DataTableRowPointerEvent",
+                                    "description": "Custom click event."
+                                }
+                            ],
+                            "returnType": "void",
+                            "description": "Callback to invoke when a row pointerDown event occurs."
+                        },
+                        {
+                            "name": "onRowPointerUp",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "optional": false,
+                                    "type": "DataTableRowPointerEvent",
+                                    "description": "Custom click event."
+                                }
+                            ],
+                            "returnType": "void",
+                            "description": "Callback to invoke when a row pointerUp event occurs."
+                        },
+                        {
                             "name": "onRowReorder",
                             "parameters": [
                                 {
@@ -17396,6 +17422,33 @@
                         }
                     ],
                     "extendedBy": "DataTableRowEditEvent,DataTableRowEditCompleteEvent"
+                },
+                "DataTableRowPointerEvent": {
+                    "description": "Custom row pointer event.",
+                    "relatedProp": "onRowPointerDown",
+                    "props": [
+                        {
+                            "name": "data",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "DataTableValue",
+                            "description": "Original rows data."
+                        },
+                        {
+                            "name": "originalEvent",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "PointerEvent<HTMLElement>",
+                            "description": "Browser event."
+                        },
+                        {
+                            "name": "index",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "number",
+                            "description": "Clicked row data index"
+                        }
+                    ]
                 },
                 "DataTableRowClickEvent": {
                     "description": "Custom row click event.",
@@ -19551,6 +19604,32 @@
                             ],
                             "returnType": "void",
                             "description": "Callback to invoke when a row is double clicked."
+                        },
+                        {
+                            "name": "onRowPointerDown",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "optional": false,
+                                    "type": "DataTableRowPointerEvent",
+                                    "description": "Custom click event."
+                                }
+                            ],
+                            "returnType": "void",
+                            "description": "Callback to invoke when a row pointerDown event occurs."
+                        },
+                        {
+                            "name": "onRowPointerUp",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "optional": false,
+                                    "type": "DataTableRowPointerEvent",
+                                    "description": "Custom click event."
+                                }
+                            ],
+                            "returnType": "void",
+                            "description": "Callback to invoke when a row pointerUp event occurs."
                         },
                         {
                             "name": "onRowEditCancel",

--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -119,6 +119,14 @@ export const BodyRow = React.memo((props) => {
         props.onRowDoubleClick({ originalEvent: event, data: props.rowData, index: props.rowIndex });
     };
 
+    const onPointerDown = (event) => {
+        props.onRowPointerDown({ originalEvent: event, data: props.rowData, index: props.rowIndex });
+    };
+
+    const onPointerUp = (event) => {
+        props.onRowPointerDown({ originalEvent: event, data: props.rowData, index: props.rowIndex });
+    };
+
     const onRightClick = (event) => {
         props.onRowRightClick({ originalEvent: event, data: props.rowData, index: props.rowIndex });
     };
@@ -391,6 +399,8 @@ export const BodyRow = React.memo((props) => {
             onMouseLeave: (e) => onMouseLeave(e),
             onClick: (e) => onClick(e),
             onDoubleClick: (e) => onDoubleClick(e),
+            onPointerDown: (e) => onPointerDown(e),
+            onPointerUp: (e) => onPointerUp(e),
             onContextMenu: (e) => onRightClick(e),
             onTouchEnd: (e) => onTouchEnd(e),
             onKeyDown: (e) => onKeyDown(e),

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1625,6 +1625,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 onRowClick={props.onRowClick}
                 onRowCollapse={props.onRowCollapse}
                 onRowDoubleClick={props.onRowDoubleClick}
+                onRowPointerDown={props.onRowPointerDown}
+                onRowPointerUp={props.onRowPointerUp}
                 onRowEditCancel={props.onRowEditCancel}
                 onRowEditChange={props.onRowEditChange}
                 onRowEditComplete={props.onRowEditComplete}
@@ -1686,6 +1688,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 tabIndex={props.tabIndex}
                 onRowClick={props.onRowClick}
                 onRowDoubleClick={props.onRowDoubleClick}
+                onRowPointerDown={props.onRowPointerDown}
+                onRowPointerUp={props.onRowPointerUp}
                 onRowMouseEnter={props.onRowMouseEnter}
                 onRowMouseLeave={props.onRowMouseLeave}
                 onCellClick={props.onCellClick}

--- a/components/lib/datatable/DataTableBase.js
+++ b/components/lib/datatable/DataTableBase.js
@@ -7,96 +7,96 @@ const styles = `
     .p-datatable {
         position: relative;
     }
-    
+
     .p-datatable > .p-datatable-wrapper {
         overflow: auto;
     }
-    
+
     .p-datatable-table {
         border-spacing: 0px;
         width: 100%;
     }
-    
+
     .p-datatable .p-sortable-disabled {
         cursor: auto;
     }
-    
+
     .p-datatable .p-sortable-column {
         cursor: pointer;
         user-select: none;
     }
-    
+
     .p-datatable .p-sortable-column .p-column-title,
     .p-datatable .p-sortable-column .p-sortable-column-icon,
     .p-datatable .p-sortable-column .p-sortable-column-badge {
         vertical-align: middle;
     }
-    
+
     .p-datatable .p-sortable-column .p-sortable-column-badge {
         display: inline-flex;
         align-items: center;
         justify-content: center;
     }
-    
+
     .p-datatable-selectable .p-selectable-row,
     .p-datatable-selectable-cell .p-selectable-cell {
         cursor: pointer;
     }
-    
+
     .p-datatable-drag-selection-helper {
         position: absolute;
         z-index: 99999999;
     }
-    
+
     /* Scrollable */
     .p-datatable-scrollable > .p-datatable-wrapper {
         position: relative;
     }
-    
+
     .p-datatable-scrollable-table > .p-datatable-thead {
         position: sticky;
         top: 0;
         z-index: 1;
     }
-    
+
     .p-datatable-scrollable-table > .p-datatable-frozen-tbody {
         position: sticky;
         z-index: 1;
     }
-    
+
     .p-datatable-scrollable-table > .p-datatable-tfoot {
         position: sticky;
         bottom: 0;
         z-index: 1;
     }
-    
+
     .p-datatable-scrollable .p-frozen-column {
         position: sticky;
         background: inherit;
     }
-    
+
     .p-datatable-scrollable th.p-frozen-column {
         z-index: 1;
     }
-    
+
     .p-datatable-flex-scrollable {
         display: flex;
         flex-direction: column;
         height: 100%;
     }
-    
+
     .p-datatable-flex-scrollable > .p-datatable-wrapper {
         display: flex;
         flex-direction: column;
         flex: 1;
         height: 100%;
     }
-    
+
     .p-datatable-scrollable-table > .p-datatable-tbody > .p-rowgroup-header {
         position: sticky;
         z-index: 1;
     }
-    
+
     /* Resizable */
     .p-datatable-resizable-table > .p-datatable-thead > tr > th,
     .p-datatable-resizable-table > .p-datatable-tfoot > tr > td,
@@ -104,16 +104,16 @@ const styles = `
         overflow: hidden;
         white-space: nowrap;
     }
-    
+
     .p-datatable-resizable-table > .p-datatable-thead > tr > th.p-resizable-column:not(.p-frozen-column) {
         background-clip: padding-box;
         position: relative;
     }
-    
+
     .p-datatable-resizable-table-fit > .p-datatable-thead > tr > th.p-resizable-column:last-child .p-column-resizer {
         display: none;
     }
-    
+
     .p-datatable .p-column-resizer {
         display: block;
         position: absolute !important;
@@ -126,19 +126,19 @@ const styles = `
         cursor: col-resize;
         border: 1px solid transparent;
     }
-    
+
     .p-datatable .p-column-header-content {
         display: flex;
         align-items: center;
     }
-    
+
     .p-datatable .p-column-resizer-helper {
         width: 1px;
         position: absolute;
         z-index: 10;
         display: none;
     }
-    
+
     .p-datatable .p-row-editor-init,
     .p-datatable .p-row-editor-save,
     .p-datatable .p-row-editor-cancel {
@@ -148,7 +148,7 @@ const styles = `
         overflow: hidden;
         position: relative;
     }
-    
+
     /* Expand */
     .p-datatable .p-row-toggler {
         display: inline-flex;
@@ -157,19 +157,19 @@ const styles = `
         overflow: hidden;
         position: relative;
     }
-    
+
     /* Reorder */
     .p-datatable-reorder-indicator-up,
     .p-datatable-reorder-indicator-down {
         position: absolute;
         display: none;
     }
-    
+
     .p-reorderable-column,
     .p-datatable-reorderablerow-handle {
         cursor: move;
     }
-    
+
     /* Loader */
     .p-datatable .p-datatable-loading-overlay {
         position: absolute;
@@ -178,24 +178,24 @@ const styles = `
         justify-content: center;
         z-index: 2;
     }
-    
+
     /* Filter */
     .p-column-filter-row {
         display: flex;
         align-items: center;
         width: 100%;
     }
-    
+
     .p-column-filter-menu {
         display: inline-flex;
         margin-left: auto;
     }
-    
+
     .p-column-filter-row .p-column-filter-element {
         flex: 1 1 auto;
         width: 1%;
     }
-    
+
     .p-column-filter-menu-button,
     .p-column-filter-clear-button {
         display: inline-flex;
@@ -206,53 +206,53 @@ const styles = `
         overflow: hidden;
         position: relative;
     }
-    
+
     .p-column-filter-overlay {
         position: absolute;
         top: 0;
         left: 0;
     }
-    
+
     .p-column-filter-row-items {
         margin: 0;
         padding: 0;
         list-style: none;
     }
-    
+
     .p-column-filter-row-item {
         cursor: pointer;
     }
-    
+
     .p-column-filter-add-button,
     .p-column-filter-remove-button {
         justify-content: center;
     }
-    
+
     .p-column-filter-add-button .p-button-label,
     .p-column-filter-remove-button .p-button-label {
         flex-grow: 0;
     }
-    
+
     .p-column-filter-buttonbar {
         display: flex;
         align-items: center;
         justify-content: space-between;
     }
-    
+
     .p-column-filter-buttonbar .p-button:not(.p-button-icon-only) {
         width: auto;
     }
-    
+
     /* Responsive */
     .p-datatable .p-datatable-tbody > tr > td > .p-column-title {
         display: none;
     }
-    
+
     /* VirtualScroller */
     .p-datatable-virtualscroller-spacer {
         display: flex;
     }
-    
+
     .p-datatable .p-virtualscroller .p-virtualscroller-loading {
         transform: none !important;
         min-height: 0;
@@ -260,7 +260,7 @@ const styles = `
         top: 0;
         left: 0;
     }
-    
+
     /* Alignment */
     .p-datatable .p-datatable-thead > tr > th.p-align-left > .p-column-header-content,
     .p-datatable .p-datatable-tbody > tr > td.p-align-left,
@@ -268,14 +268,14 @@ const styles = `
         text-align: left;
         justify-content: flex-start;
     }
-    
+
     .p-datatable .p-datatable-thead > tr > th.p-align-right > .p-column-header-content,
     .p-datatable .p-datatable-tbody > tr > td.p-align-right,
     .p-datatable .p-datatable-tfoot > tr > td.p-align-right {
         text-align: right;
         justify-content: flex-end;
     }
-    
+
     .p-datatable .p-datatable-thead > tr > th.p-align-center > .p-column-header-content,
     .p-datatable .p-datatable-tbody > tr > td.p-align-center,
     .p-datatable .p-datatable-tfoot > tr > td.p-align-center {
@@ -502,6 +502,8 @@ export const DataTableBase = ComponentBase.extend({
         onRowClick: null,
         onRowCollapse: null,
         onRowDoubleClick: null,
+        onRowPointerDown: null,
+        onRowPointerUp: null,
         onRowEditCancel: null,
         onRowEditChange: null,
         onRowEditComplete: null,

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -514,6 +514,30 @@ export const TableBody = React.memo(
             }
         };
 
+        const onRowPointerDown = (e) => {
+            const { originalEvent: event } = e;
+
+            if (DomHandler.isClickable(event.target)) {
+                return;
+            }
+
+            if (props.onRowPointerDown) {
+                props.onRowPointerDown(e);
+            }
+        };
+
+        const onRowPointerUp = (e) => {
+            const { originalEvent: event } = e;
+
+            if (DomHandler.isClickable(event.target)) {
+                return;
+            }
+
+            if (props.onRowPointerUp) {
+                props.onRowPointerUp(e);
+            }
+        };
+
         const onRowRightClick = (event) => {
             if (props.onContextMenu || props.onContextMenuSelectionChange) {
                 const hasSelection = ObjectUtils.isNotEmpty(props.selection);
@@ -965,6 +989,8 @@ export const TableBody = React.memo(
                         onRadioChange={onRadioChange}
                         onRowClick={onRowClick}
                         onRowDoubleClick={onRowDoubleClick}
+                        onRowPointerDown={onRowPointerDown}
+                        onRowPointerUp={onRowPointerUp}
                         onRowDragEnd={onRowDragEnd}
                         onRowDragLeave={onRowDragLeave}
                         onRowDragOver={onRowDragOver}

--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -434,6 +434,23 @@ interface DataTableRowMouseEvent extends Omit<DataTableRowEvent, 'originalEvent'
 }
 
 /**
+ * Custom row pointer event.
+ * @see {@link DataTableProps.onRowPointerDown}, {@link DataTableProps.onRowPointerUp}
+ * @extends DataTableRowMouseEvent
+ * @event
+ */
+interface DataTableRowPointerEvent extends Omit<DataTableRowEvent, 'originalEvent'> {
+    /**
+     * Browser event.
+     */
+    originalEvent: React.PointerEvent<HTMLElement>;
+    /**
+     * Clicked row data index
+     */
+    index: number;
+}
+
+/**
  * Custom row click event.
  * @see {@link DataTableProps.onRowClick}, {@link DataTableProps.onRowDoubleClick}
  * @extends DataTableRowMouseEvent
@@ -1498,6 +1515,16 @@ interface DataTableBaseProps<TValue extends DataTableValueArray> extends Omit<Re
      * @param {DataTableRowClickEvent} event - Custom click event.
      */
     onRowDoubleClick?(event: DataTableRowClickEvent): void;
+    /**
+     * Callback to invoke when a row pointerDown event occurs.
+     * @param {DataTableRowPointerEvent} event - Custom click event.
+     */
+    onRowPointerDown?(event: DataTableRowPointerEvent): void;
+    /**
+     * Callback to invoke when a row pointerUp event occurs.
+     * @param {DataTableRowPointerEvent} event - Custom click event.
+     */
+    onRowPointerUp?(event: DataTableRowPointerEvent): void;
     /**
      * Callback to invoke when the cancel icon is clicked on row editing mode.
      * @param {DataTableRowEditEvent} event - Custom row edit event.


### PR DESCRIPTION
In order for users to be able to simulate row clicks as html links the center mouse button needs to be able to be listed for along with the row that was clicked

resolves #5051

