### PR TITLE
Fix #5096 - Component Styles: Remove use of !important now that @layer is used

### DIFF
--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -233,7 +233,7 @@ export const CascadeSelect = React.memo(
     }
 
     .p-cascadeselect-panel[${selector}] .p-cascadeselect-item-active > .p-cascadeselect-sublist {
-        left: 0 !important;
+        left: 0;
         box-shadow: none;
         border-radius: 0;
         padding: 0 0 0 calc(var(--inline-spacing) * 2); /* @todo */

--- a/components/lib/cascadeselect/CascadeSelectBase.js
+++ b/components/lib/cascadeselect/CascadeSelectBase.js
@@ -121,7 +121,7 @@ const styles = `
     }
     
     .p-cascadeselect-item-active {
-        overflow: visible !important;
+        overflow: visible;
     }
     
     .p-cascadeselect-item-active > .p-cascadeselect-sublist {

--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -316,7 +316,7 @@ const commonStyle = `
     }
 
     .p-disabled, .p-disabled * {
-        cursor: default !important;
+        cursor: default;
         pointer-events: none;
         user-select: none;
     }
@@ -442,7 +442,7 @@ const commonStyle = `
         padding: 0;
         position: absolute;
         width: 1px;
-        word-wrap: normal !important;
+        word-wrap: normal;
     }
 
     /* @todo Refactor */

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -78,7 +78,7 @@ export const ContextMenu = React.memo(
     }
 
     .p-contextmenu[${selector}] .p-menuitem-active > .p-submenu-list {
-        left: 0 !important;
+        left: 0;
         box-shadow: none;
         border-radius: 0;
         padding: 0 0 0 calc(var(--inline-spacing) * 2); /* @todo */

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -387,7 +387,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         let selector = `.p-datatable[${attributeSelector.current}] > .p-datatable-wrapper ${isVirtualScrollerDisabled() ? '' : '> .p-virtualscroller'} > .p-datatable-table`;
 
         widths.forEach((width, index) => {
-            let style = `width: ${width}px !important; max-width: ${width}px !important`;
+            let style = `width: ${width}px; max-width: ${width}px`;
 
             innerHTML += `
                 ${selector} > .p-datatable-thead > tr > th:nth-child(${index + 1}),
@@ -599,7 +599,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
 
         widths.forEach((width, index) => {
             let colWidth = index === colIndex ? newColumnWidth : nextColumnWidth && index === colIndex + 1 ? nextColumnWidth : width;
-            let style = `width: ${colWidth}px !important; max-width: ${colWidth}px !important`;
+            let style = `width: ${colWidth}px; max-width: ${colWidth}px`;
 
             innerHTML += `
                 ${selector} > .p-datatable-thead > tr > th:nth-child(${index + 1}),
@@ -805,12 +805,12 @@ export const DataTable = React.forwardRef((inProps, ref) => {
 @media screen and (max-width: ${props.breakpoint}) {
     ${selector} > .p-datatable-thead > tr > th,
     ${selector} > .p-datatable-tfoot > tr > td {
-        display: none !important;
+        display: none;
     }
 
     ${selector} > .p-datatable-tbody > tr > td {
         display: flex;
-        width: 100% !important;
+        width: 100%;
         align-items: center;
         justify-content: space-between;
     }

--- a/components/lib/datatable/DataTableBase.js
+++ b/components/lib/datatable/DataTableBase.js
@@ -116,7 +116,7 @@ const styles = `
 
     .p-datatable .p-column-resizer {
         display: block;
-        position: absolute !important;
+        position: absolute;
         top: 0;
         right: 0;
         margin: 0;
@@ -254,7 +254,7 @@ const styles = `
     }
 
     .p-datatable .p-virtualscroller .p-virtualscroller-loading {
-        transform: none !important;
+        transform: none;
         min-height: 0;
         position: sticky;
         top: 0;

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -397,7 +397,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
             innerHTML += `
                 @media screen and (max-width: ${breakpoint}) {
                     .p-dialog[${attributeSelector.current}] {
-                        width: ${props.breakpoints[breakpoint]} !important;
+                        width: ${props.breakpoints[breakpoint]};
                     }
                 }
             `;

--- a/components/lib/dialog/DialogBase.js
+++ b/components/lib/dialog/DialogBase.js
@@ -193,8 +193,8 @@ const styles = `
         transition: none;
         transform: none;
         margin: 0;
-        width: 100vw;
-        height: 100vh;
+        width: 100vw !important;
+        height: 100vh !important;
         max-height: 100%;
         top: 0px;
         left: 0px;

--- a/components/lib/dialog/DialogBase.js
+++ b/components/lib/dialog/DialogBase.js
@@ -192,12 +192,12 @@ const styles = `
     .p-dialog-maximized {
         transition: none;
         transform: none;
-        margin: 0 !important;
-        width: 100vw !important;
-        height: 100vh !important;
+        margin: 0;
+        width: 100vw;
+        height: 100vh;
         max-height: 100%;
-        top: 0px !important;
-        left: 0px !important;
+        top: 0px;
+        left: 0px;
     }
     
     .p-dialog-maximized .p-dialog-content {

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -452,7 +452,7 @@ export const MegaMenu = React.memo(
 @media screen and (max-width: ${props.breakpoint}) {
     .p-megamenu[${selector}] > .p-megamenu-root-list .p-menuitem-active .p-megamenu-panel {
         position: relative;
-        left: 0 !important;
+        left: 0;
         box-shadow: none;
         border-radius: 0;
         background: inherit;

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -181,7 +181,7 @@ export const OverlayPanel = React.forwardRef((inProps, ref) => {
                 innerHTML += `
                     @media screen and (max-width: ${breakpoint}) {
                         .p-overlaypanel[${attributeSelector.current}] {
-                            width: ${props.breakpoints[breakpoint]} !important;
+                            width: ${props.breakpoints[breakpoint]};
                         }
                     }
                 `;

--- a/components/lib/ripple/RippleBase.js
+++ b/components/lib/ripple/RippleBase.js
@@ -21,7 +21,7 @@ const styles = `
     }
     
     .p-ripple-disabled .p-ink {
-        display: none !important;
+        display: none;
     }
 }
 

--- a/components/lib/scrolltop/ScrollTopBase.js
+++ b/components/lib/scrolltop/ScrollTopBase.js
@@ -30,7 +30,7 @@ const styles = `
     }
     
     .p-scrolltop-helper {
-        display: none !important;
+        display: none;
     }
     
     .p-scrolltop-enter {

--- a/components/lib/sidebar/SidebarBase.js
+++ b/components/lib/sidebar/SidebarBase.js
@@ -94,11 +94,11 @@ const styles = `
     .p-sidebar-full .p-sidebar {
         transition: none;
         transform: none;
-        width: 100vw !important;
-        height: 100vh !important;
+        width: 100vw;
+        height: 100vh;
         max-height: 100%;
-        top: 0px !important;
-        left: 0px !important;
+        top: 0px;
+        left: 0px;
     }
     
     /* Animation */

--- a/components/lib/sidebar/SidebarBase.js
+++ b/components/lib/sidebar/SidebarBase.js
@@ -94,11 +94,11 @@ const styles = `
     .p-sidebar-full .p-sidebar {
         transition: none;
         transform: none;
-        width: 100vw;
-        height: 100vh;
+        width: 100vw !important;
+        height: 100vh !important;
         max-height: 100%;
-        top: 0px;
-        left: 0px;
+        top: 0px !important;
+        left: 0px !important;
     }
     
     /* Animation */

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -94,7 +94,7 @@ export const TieredMenu = React.memo(
     }
 
     .p-tieredmenu[${selector}] .p-menuitem-active > .p-submenu-list {
-        left: 0 !important;
+        left: 0;
         box-shadow: none;
         border-radius: 0;
         padding: 0 0 0 calc(var(--inline-spacing) * 2); /* @todo */

--- a/components/lib/treetable/TreeTableBase.js
+++ b/components/lib/treetable/TreeTableBase.js
@@ -69,7 +69,7 @@ const styles = `
     
     .p-treetable .p-column-resizer {
         display: block;
-        position: absolute !important;
+        position: absolute;
         top: 0;
         right: 0;
         margin: 0;


### PR DESCRIPTION
Fix #5096 - Component Styles: Remove use of !important now that @layer is used

@melloware @mertsincan, I did a side-by-side comparison running the showcase locally and looking at primereact.org and did not see any appreciable differences. As far as I can tell, now that `@layer primereact` is in place, `!important` is no longer needed.