### PR TITLE
fix #5098 Chips: Tab press with some active input does not create a new chip

### DIFF
--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -111,6 +111,7 @@ export const Chips = React.memo(
 
                     break;
 
+                case 'Tab':
                 case 'Enter':
                     if (inputValue && inputValue.trim().length && (!props.max || props.max > values.length)) {
                         addItem(event, inputValue, true);


### PR DESCRIPTION
### Defect Fixes
fix #5098 Chips: Tab press with some active input does not create a new chip

