### PR TITLE
Fix #5100: MultiSelect add space after comma

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -502,7 +502,7 @@ export const MultiSelect = React.memo(
                     return getSelectedItemsLabel();
                 } else {
                     if (ObjectUtils.isArray(props.value)) {
-                        return props.value.reduce((acc, value, index) => acc + (index !== 0 ? ',' : '') + getLabelByValue(value), '');
+                        return props.value.reduce((acc, value, index) => acc + (index !== 0 ? ', ' : '') + getLabelByValue(value), '');
                     } else {
                         return '';
                     }


### PR DESCRIPTION
Fix #5100: MultiSelect add space after comma

Puts it in line with PrimeNG
