### PR TITLE
Fix #5114: Mentioning deletes the first word of the comment

### DIFF
--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -202,7 +202,7 @@ export const Mention = React.memo(
 
             if (currentText.trim() !== selectedText) {
                 const prevText = value.substring(0, triggerState.index);
-                const nextText = value.substring(triggerState.index + currentText.length);
+                const nextText = value.substring(spaceIndex > -1 ? triggerState.index : triggerState.index + currentText.length);
 
                 inputRef.current.value = `${prevText}${selectedText} ${nextText}`;
                 event.target = inputRef.current;


### PR DESCRIPTION
fix #5114 

Mention component deletes the first word when mentioning beginning of the comment in the input. This PR fixes this issue.