### PR TITLE
Fix #5151: MultiSelect prevent SelectAll click propagation

### DIFF
--- a/components/lib/multiselect/MultiSelectHeader.js
+++ b/components/lib/multiselect/MultiSelectHeader.js
@@ -40,6 +40,7 @@ export const MultiSelectHeader = React.memo((props) => {
         }
 
         event.preventDefault();
+        event.stopPropagation();
     };
 
     const createFilterElement = () => {


### PR DESCRIPTION
Fix #5151: MultiSelect prevent SelectAll click propagation