### PR TITLE
Fix #5177: Orderlist move top and bottom keep order

### DIFF
--- a/components/lib/orderlist/OrderListControls.js
+++ b/components/lib/orderlist/OrderListControls.js
@@ -47,7 +47,7 @@ export const OrderListControls = React.memo((props) => {
         if (props.selection) {
             let value = [...props.value];
 
-            for (let i = 0; i < props.selection.length; i++) {
+            for (let i = props.selection.length - 1; i >= 0; i--) {
                 const selectedItem = props.selection[i];
                 const selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, value, props.dataKey);
 
@@ -103,7 +103,7 @@ export const OrderListControls = React.memo((props) => {
         if (props.selection) {
             let value = [...props.value];
 
-            for (let i = props.selection.length - 1; i >= 0; i--) {
+            for (let i = 0; i < props.selection.length; i++) {
                 let selectedItem = props.selection[i];
                 let selectedItemIndex = ObjectUtils.findIndexInList(selectedItem, value, props.dataKey);
 


### PR DESCRIPTION
Fix #5177: Orderlist move top and bottom keep order

Fix ported from PrimeVue