### PR TITLE
Fix #5164: Datatable frozen column and filter row

### DIFF
--- a/components/lib/datatable/DataTableBase.js
+++ b/components/lib/datatable/DataTableBase.js
@@ -405,7 +405,7 @@ const classes = {
         }),
     headerCheckboxIcon: 'p-checkbox-icon',
     headerContent: 'p-column-header-content',
-    headerCell: ({ headerProps: props, frozen, sortMeta, align, _isSortableDisabled, column, getColumnProp }) =>
+    headerCell: ({ headerProps: props, frozen, sortMeta, align, _isSortableDisabled, getColumnProp }) =>
         ObjectUtils.isEmpty(props)
             ? classNames('p-filter-column', { 'p-frozen-column': frozen })
             : classNames({

--- a/components/lib/datatable/TableHeader.js
+++ b/components/lib/datatable/TableHeader.js
@@ -213,7 +213,7 @@ export const TableHeader = React.memo((props) => {
                 const headerCellProps = mergeProps(
                     {
                         style: colStyle,
-                        className: classNames(filterHeaderClassName, className, cx('headerCells', { frozen, column: col })),
+                        className: classNames(filterHeaderClassName, className, cx('headerCell', { frozen, column: col })),
                         key: colKey
                     },
                     getColumnPTOptions(col, 'root'),


### PR DESCRIPTION
Fix #5164: Datatable frozen column and filter row