### PR TITLE
Fix #5203: ComponentBase context could be undefined

### DIFF
--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -472,7 +472,7 @@ export const ComponentBase = {
         ptOptions: undefined,
         unstyled: false
     },
-    context: undefined,
+    context: {},
     globalCSS: undefined,
     classes: {},
     styles: '',
@@ -635,7 +635,7 @@ const _useDefaultPT = (callback, key, params) => {
     return _usePT(getDefaultPT(), callback, key, params);
 };
 
-export const useHandleStyle = (styles, isUnstyled = () => {}, config) => {
+export const useHandleStyle = (styles = () => {}, config) => {
     const { name, styled = false, hostName = '' } = config;
 
     const globalCSS = _useGlobalPT(getOptionValue, 'global.css', ComponentBase.cParams);


### PR DESCRIPTION
Fix #5203: ComponentBase context could be undefined
Fix #5168