### PR TITLE
Added tailwind-merge support

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -781,6 +781,13 @@
                             "description": "When enabled, it removes all of components styles in the core."
                         },
                         {
+                            "name": "useTailwind",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "description": "When enabled, all className merges will use twMerge"
+                        },
+                        {
                             "name": "setAppendTo",
                             "optional": true,
                             "readonly": false,
@@ -38490,6 +38497,12 @@
                             "optional": true,
                             "readonly": false,
                             "type": "boolean"
+                        },
+                        {
+                            "name": "useTailwind",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean"
                         }
                     ],
                     "callbacks": []
@@ -52786,8 +52799,12 @@
                     "name": "mergeProps",
                     "parameters": [
                         {
-                            "name": "args",
+                            "name": "props",
                             "type": "object[]"
+                        },
+                        {
+                            "name": "options",
+                            "type": "object"
                         }
                     ],
                     "returnType": "object | undefined"

--- a/components/doc/passthrough/usepassthroughdoc.js
+++ b/components/doc/passthrough/usepassthroughdoc.js
@@ -22,7 +22,8 @@ export default function UsePassThroughDemo() {
         },
         {
             mergeSections: true,
-            mergeProps: false
+            mergeProps: false,
+            useTailwind: false
         }
     );
 
@@ -43,7 +44,7 @@ const CustomTailwind = usePassThrough(
             header: 'my_panel_header'
         }
     },
-    { mergeSections: true, mergeProps: false }
+    { mergeSections: true, mergeProps: false, useTailwind: false }
 );
 
 // Output: 
@@ -59,7 +60,7 @@ const CustomTailwind = usePassThrough(
             header: 'my_panel_header'
         }
     },
-    { mergeSections: true, mergeProps: true }
+    { mergeSections: true, mergeProps: true, useTailwind: false }
 );
 
 // Output: 
@@ -76,7 +77,7 @@ const CustomTailwind = usePassThrough(
             header: 'my_panel_header'
         }
     },
-    { mergeSections: false, mergeProps: true }
+    { mergeSections: false, mergeProps: true, useTailwind: false }
 );
 
 // Output: 
@@ -93,7 +94,7 @@ const CustomTailwind = usePassThrough(
             header: 'my_panel_header'
         }
     },
-    { mergeSections: false, mergeProps: false }
+    { mergeSections: false, mergeProps: false, useTailwind: false }
 );
 
 // Output: 
@@ -113,6 +114,12 @@ const CustomTailwind = usePassThrough(
                 <p>
                     The <i>mergeSections</i> defines whether the sections from the main configuration gets added and the <i>mergeProps</i> controls whether to override or merge the defined props. Defaults are <i>true</i> for <i>mergeSections</i> and
                     <i>false</i> for <i>mergeProps</i>.
+                </p>
+                <p>
+                    The <i>useTailwind</i> option should be set to <i>true</i> if using Tailwind to prevent className conflicts between the default Tailwind theme and your custom theme. If <i>useTailwind</i> is set to <i>true</i> <i>mergeProps</i>{' '}
+                    will be overridden to <i>true</i>.
+                    <br />
+                    See <a href="https://www.npmjs.com/package/tailwind-merge">tailwind-merge</a> for more information.
                 </p>
             </DocSectionText>
             <DocSectionCode code={code2} hideToggleCode import hideCodeSandbox hideStackBlitz />

--- a/components/doc/tailwind/unstyledmode/setupdoc.js
+++ b/components/doc/tailwind/unstyledmode/setupdoc.js
@@ -39,6 +39,20 @@ return(
         basic: `
 import { PrimeReactProvider } from "primereact/api";
 
+...
+return(
+    <PrimeReactProvider value={{ unstyled: true, pt: {}, useTailwind: true }}>
+        <App />
+    </PrimeReactProvider>
+)
+ 
+`
+    };
+
+    const code4 = {
+        basic: `
+import { PrimeReactProvider } from "primereact/api";
+
 export default function MyApp({ Component, pageProps }) {
     
     //My Design System with Tailwind
@@ -125,11 +139,19 @@ export default function MyApp({ Component, pageProps }) {
                 <p className="flex align-items-start gap-2">
                     <Badge value="3"></Badge>
                     <span>
+                        <b>Optional:</b> enable <i>useTailwind</i> to resolve className conflicts via <a href="https://www.npmjs.com/package/tailwind-merge">tailwind-merge</a>. This will prevent classNames specified in the global pass through from
+                        overriding those specified via pass through in your application.
+                    </span>
+                </p>
+                <DocSectionCode code={code3} hideToggleCode import hideCodeSandbox hideStackBlitz />
+                <p className="flex align-items-start gap-2">
+                    <Badge value="4"></Badge>
+                    <span>
                         At the final step, component styles are provided via a pass through configuration that utilizes Tailwind CSS. The default preset of each component is available at the Tailwind part under theming section of each component so
                         you'll able to copy paste instead of starting from scratch. Example below styles, inputtext and panel components;
                     </span>
                 </p>
-                <DocSectionCode code={code3} hideToggleCode import hideCodeSandbox hideStackBlitz />
+                <DocSectionCode code={code4} hideToggleCode import hideCodeSandbox hideStackBlitz />
                 <p>Voilà 💙, you now have 90+ awesome React UI components styled with Tailwind that will work in harmony with the rest of your application. Time to customize it to bring in your own style with Tailwind.</p>
             </DocSectionText>
         </>

--- a/components/lib/accordion/Accordion.js
+++ b/components/lib/accordion/Accordion.js
@@ -48,7 +48,7 @@ export const Accordion = React.forwardRef((inProps, ref) => {
             }
         };
 
-        return mergeProps(ptm(`accordiontab.${key}`, { accordiontab: tabMetaData }), ptm(`accordiontab.${key}`, tabMetaData), ptmo(tab.props, key, tabMetaData));
+        return mergeProps([ptm(`accordiontab.${key}`, { accordiontab: tabMetaData }), ptm(`accordiontab.${key}`, tabMetaData), ptmo(tab.props, key, tabMetaData)], { useTailwind: context.useTailwind });
     };
 
     const getTabProp = (tab, name) => AccordionTabBase.getCProp(tab, name);
@@ -108,44 +108,56 @@ export const Accordion = React.forwardRef((inProps, ref) => {
         const ariaControls = idState + '_content_' + index;
         const tabIndex = getTabProp(tab, 'disabled') ? -1 : getTabProp(tab, 'tabIndex');
         const headerTitleProps = mergeProps(
-            {
-                className: cx('tab.headertitle')
-            },
-            getTabPT(tab, 'headertitle', index)
+            [
+                {
+                    className: cx('tab.headertitle')
+                },
+                getTabPT(tab, 'headertitle', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
         const header = getTabProp(tab, 'headerTemplate') ? ObjectUtils.getJSXElement(getTabProp(tab, 'headerTemplate'), AccordionTabBase.getCProps(tab)) : <span {...headerTitleProps}>{getTabProp(tab, 'header')}</span>;
         const headerIconProps = mergeProps(
-            {
-                className: cx('tab.headericon')
-            },
-            getTabPT(tab, 'headericon', index)
+            [
+                {
+                    className: cx('tab.headericon')
+                },
+                getTabPT(tab, 'headericon', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = selected ? props.collapseIcon || <ChevronDownIcon {...headerIconProps} /> : props.expandIcon || <ChevronRightIcon {...headerIconProps} />;
         const toggleIcon = IconUtils.getJSXIcon(icon, { ...headerIconProps }, { props, selected });
         const label = selected ? ariaLabel('collapseLabel') : ariaLabel('expandLabel');
         const headerProps = mergeProps(
-            {
-                className: classNames(getTabProp(tab, 'headerClassName'), getTabProp(tab, 'className'), cx('tab.header', { selected, getTabProp, tab })),
-                style,
-                'data-p-highlight': selected,
-                'data-p-disabled': getTabProp(tab, 'disabled')
-            },
-            getTabPT(tab, 'header', index)
+            [
+                {
+                    className: classNames(getTabProp(tab, 'headerClassName'), getTabProp(tab, 'className'), cx('tab.header', { selected, getTabProp, tab })),
+                    style,
+                    'data-p-highlight': selected,
+                    'data-p-disabled': getTabProp(tab, 'disabled')
+                },
+                getTabPT(tab, 'header', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const headerActionProps = mergeProps(
-            {
-                id: headerId,
-                href: '#' + ariaControls,
-                className: cx('tab.headeraction'),
-                role: 'tab',
-                tabIndex,
-                onClick: (e) => onTabHeaderClick(e, tab, index),
-                'aria-label': label,
-                'aria-controls': ariaControls,
-                'aria-expanded': selected
-            },
-            getTabPT(tab, 'headeraction', index)
+            [
+                {
+                    id: headerId,
+                    href: '#' + ariaControls,
+                    className: cx('tab.headeraction'),
+                    role: 'tab',
+                    tabIndex,
+                    onClick: (e) => onTabHeaderClick(e, tab, index),
+                    'aria-label': label,
+                    'aria-controls': ariaControls,
+                    'aria-expanded': selected
+                },
+                getTabPT(tab, 'headeraction', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -164,33 +176,42 @@ export const Accordion = React.forwardRef((inProps, ref) => {
         const ariaLabelledby = idState + '_header_' + index;
         const contentRef = React.createRef();
         const toggleableContentProps = mergeProps(
-            {
-                id: contentId,
-                ref: contentRef,
-                className: classNames(getTabProp(tab, 'contentClassName'), getTabProp(tab, 'className'), cx('tab.toggleablecontent')),
-                style,
-                role: 'region',
-                'aria-labelledby': ariaLabelledby
-            },
-            getTabPT(tab, 'toggleablecontent', index)
+            [
+                {
+                    id: contentId,
+                    ref: contentRef,
+                    className: classNames(getTabProp(tab, 'contentClassName'), getTabProp(tab, 'className'), cx('tab.toggleablecontent')),
+                    style,
+                    role: 'region',
+                    'aria-labelledby': ariaLabelledby
+                },
+                getTabPT(tab, 'toggleablecontent', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const contentProps = mergeProps(
-            {
-                className: cx('tab.content')
-            },
-            getTabPT(tab, 'content', index)
+            [
+                {
+                    className: cx('tab.content')
+                },
+                getTabPT(tab, 'content', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('tab.transition'),
-                timeout: { enter: 1000, exit: 450 },
-                in: selected,
-                unmountOnExit: true,
-                options: props.transitionOptions
-            },
-            getTabPT(tab, 'transition', index)
+            [
+                {
+                    classNames: cx('tab.transition'),
+                    timeout: { enter: 1000, exit: 450 },
+                    in: selected,
+                    unmountOnExit: true,
+                    options: props.transitionOptions
+                },
+                getTabPT(tab, 'transition', index)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -210,12 +231,15 @@ export const Accordion = React.forwardRef((inProps, ref) => {
             const tabContent = createTabContent(tab, selected, index);
 
             const rootProps = mergeProps(
-                {
-                    key,
-                    className: cx('tab.root', { selected })
-                },
-                AccordionTabBase.getCOtherProps(tab),
-                getTabPT(tab, 'root', index)
+                [
+                    {
+                        key,
+                        className: cx('tab.root', { selected })
+                    },
+                    AccordionTabBase.getCOtherProps(tab),
+                    getTabPT(tab, 'root', index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -235,12 +259,15 @@ export const Accordion = React.forwardRef((inProps, ref) => {
 
     const tabs = createTabs();
     const rootProps = mergeProps(
-        {
-            className: classNames(props.className, cx('root')),
-            style: props.style
-        },
-        AccordionBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                className: classNames(props.className, cx('root')),
+                style: props.style
+            },
+            AccordionBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/api/PrimeReactContext.js
+++ b/components/lib/api/PrimeReactContext.js
@@ -32,6 +32,7 @@ export const PrimeReactProvider = (props) => {
     );
     const [pt, setPt] = useState(propsValue.pt || undefined);
     const [unstyled, setUnstyled] = useState(propsValue.unstyled || false);
+    const [useTailwind, setUseTailwind] = useState(propsValue.useTailwind || false);
     const [filterMatchModeOptions, setFilterMatchModeOptions] = useState(
         propsValue.filterMatchModeOptions || {
             text: [FilterMatchMode.STARTS_WITH, FilterMatchMode.CONTAINS, FilterMatchMode.NOT_CONTAINS, FilterMatchMode.ENDS_WITH, FilterMatchMode.EQUALS, FilterMatchMode.NOT_EQUALS],
@@ -87,7 +88,9 @@ export const PrimeReactProvider = (props) => {
         filterMatchModeOptions,
         setFilterMatchModeOptions,
         unstyled,
-        setUnstyled
+        setUnstyled,
+        useTailwind,
+        setUseTailwind
     };
 
     return <PrimeReactContext.Provider value={value}>{props.children}</PrimeReactContext.Provider>;

--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -218,6 +218,11 @@ export interface APIOptions {
      */
     unstyled?: boolean;
     /**
+     * When enabled, all className merges will use twMerge
+     * @defaultValue false
+     */
+    useTailwind?: boolean;
+    /**
      * This method is used to change the theme dynamically.
      * @param {string} theme - The name of the theme to be applied.
      * @param {string} newTheme - The name of the new theme to be applied.

--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -574,25 +574,34 @@ export const AutoComplete = React.memo(
                 return props.value.map((val, index) => {
                     const key = index + 'multi-item';
                     const removeTokenIconProps = mergeProps(
-                        {
-                            className: cx('removeTokenIcon'),
-                            onClick: (e) => removeItem(e, index)
-                        },
-                        ptm('removeTokenIcon')
+                        [
+                            {
+                                className: cx('removeTokenIcon'),
+                                onClick: (e) => removeItem(e, index)
+                            },
+                            ptm('removeTokenIcon')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const icon = props.removeTokenIcon || <TimesCircleIcon {...removeTokenIconProps} />;
                     const removeTokenIcon = !props.disabled && IconUtils.getJSXIcon(icon, { ...removeTokenIconProps }, { props });
                     const tokenProps = mergeProps(
-                        {
-                            className: cx('token')
-                        },
-                        ptm('token')
+                        [
+                            {
+                                className: cx('token')
+                            },
+                            ptm('token')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const tokenLabelProps = mergeProps(
-                        {
-                            className: cx('tokenLabel')
-                        },
-                        ptm('tokenLabel')
+                        [
+                            {
+                                className: cx('tokenLabel')
+                            },
+                            ptm('tokenLabel')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     return (
@@ -610,40 +619,46 @@ export const AutoComplete = React.memo(
         const createMultiInput = (allowMoreValues) => {
             const ariaControls = overlayVisibleState ? idState + '_list' : null;
             const inputTokenProps = mergeProps(
-                {
-                    className: cx('inputToken')
-                },
-                ptm('inputToken')
+                [
+                    {
+                        className: cx('inputToken')
+                    },
+                    ptm('inputToken')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const inputProps = mergeProps(
-                {
-                    id: props.inputId,
-                    ref: inputRef,
-                    'aria-autocomplete': 'list',
-                    'aria-controls': ariaControls,
-                    'aria-expanded': overlayVisibleState,
-                    'aria-haspopup': 'listbox',
-                    autoComplete: 'off',
-                    className: props.inputClassName,
-                    disabled: props.disabled,
-                    maxLength: props.maxLength,
-                    name: props.name,
-                    onBlur: onMultiInputBlur,
-                    onChange: allowMoreValues ? onInputChange : undefined,
-                    onFocus: onMultiInputFocus,
-                    onKeyDown: allowMoreValues ? onInputKeyDown : undefined,
-                    onKeyPress: props.onKeyPress,
-                    onKeyUp: props.onKeyUp,
-                    placeholder: allowMoreValues ? props.placeholder : undefined,
-                    readOnly: props.readOnly || !allowMoreValues,
-                    required: props.required,
-                    role: 'combobox',
-                    style: props.inputStyle,
-                    tabIndex: props.tabIndex,
-                    type: props.type,
-                    ...ariaProps
-                },
-                ptm('input')
+                [
+                    {
+                        id: props.inputId,
+                        ref: inputRef,
+                        'aria-autocomplete': 'list',
+                        'aria-controls': ariaControls,
+                        'aria-expanded': overlayVisibleState,
+                        'aria-haspopup': 'listbox',
+                        autoComplete: 'off',
+                        className: props.inputClassName,
+                        disabled: props.disabled,
+                        maxLength: props.maxLength,
+                        name: props.name,
+                        onBlur: onMultiInputBlur,
+                        onChange: allowMoreValues ? onInputChange : undefined,
+                        onFocus: onMultiInputFocus,
+                        onKeyDown: allowMoreValues ? onInputKeyDown : undefined,
+                        onKeyPress: props.onKeyPress,
+                        onKeyUp: props.onKeyUp,
+                        placeholder: allowMoreValues ? props.placeholder : undefined,
+                        readOnly: props.readOnly || !allowMoreValues,
+                        required: props.required,
+                        role: 'combobox',
+                        style: props.inputStyle,
+                        tabIndex: props.tabIndex,
+                        type: props.type,
+                        ...ariaProps
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -658,17 +673,20 @@ export const AutoComplete = React.memo(
             const tokens = createChips();
             const input = createMultiInput(allowMoreValues);
             const containerProps = mergeProps(
-                {
-                    ref: multiContainerRef,
-                    className: cx('container'),
-                    onClick: allowMoreValues ? onMultiContainerClick : undefined,
-                    onContextMenu: props.onContextMenu,
-                    onMouseDown: props.onMouseDown,
-                    onDoubleClick: props.onDblClick,
-                    'data-p-focus': focusedState,
-                    'data-p-disabled': props.disabled
-                },
-                ptm('container')
+                [
+                    {
+                        ref: multiContainerRef,
+                        className: cx('container'),
+                        onClick: allowMoreValues ? onMultiContainerClick : undefined,
+                        onContextMenu: props.onContextMenu,
+                        onMouseDown: props.onMouseDown,
+                        onDoubleClick: props.onDblClick,
+                        'data-p-focus': focusedState,
+                        'data-p-disabled': props.disabled
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -703,10 +721,13 @@ export const AutoComplete = React.memo(
         const createLoader = () => {
             if (searchingState) {
                 const loadingIconProps = mergeProps(
-                    {
-                        className: cx('loadingIcon')
-                    },
-                    ptm('loadingIcon')
+                    [
+                        {
+                            className: cx('loadingIcon')
+                        },
+                        ptm('loadingIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
                 const loaderIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
@@ -729,14 +750,17 @@ export const AutoComplete = React.memo(
         const input = createInput();
         const dropdown = createDropdown();
         const rootProps = mergeProps(
-            {
-                id: idState,
-                ref: elementRef,
-                style: props.style,
-                className: classNames(props.className, cx('root', { focusedState }))
-            },
-            otherProps,
-            ptm('root')
+            [
+                {
+                    id: idState,
+                    ref: elementRef,
+                    style: props.style,
+                    className: classNames(props.className, cx('root', { focusedState }))
+                },
+                otherProps,
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/autocomplete/AutoCompletePanel.js
+++ b/components/lib/autocomplete/AutoCompletePanel.js
@@ -34,10 +34,13 @@ export const AutoCompletePanel = React.memo(
             if (props.panelFooterTemplate) {
                 const content = ObjectUtils.getJSXElement(props.panelFooterTemplate, props, props.onOverlayHide);
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    _ptm('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        _ptm('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{content}</div>;
@@ -54,17 +57,20 @@ export const AutoCompletePanel = React.memo(
                 const selected = props.selectedItem === item;
                 const content = props.itemTemplate ? ObjectUtils.getJSXElement(props.itemTemplate, item, j) : props.field ? ObjectUtils.resolveFieldData(item, props.field) : item;
                 const itemProps = mergeProps(
-                    {
-                        role: 'option',
-                        className: cx('item', { optionGroupLabel: props.optionGroupLabel, suggestion: item }),
-                        style,
-                        onClick: (e) => props.onItemClick(e, item),
-                        'aria-selected': selected,
-                        'data-group': i,
-                        'data-index': j,
-                        'data-p-disabled': item.disabled
-                    },
-                    getPTOptions(item, 'item')
+                    [
+                        {
+                            role: 'option',
+                            className: cx('item', { optionGroupLabel: props.optionGroupLabel, suggestion: item }),
+                            style,
+                            onClick: (e) => props.onItemClick(e, item),
+                            'aria-selected': selected,
+                            'data-group': i,
+                            'data-index': j,
+                            'data-p-disabled': item.disabled
+                        },
+                        getPTOptions(item, 'item')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -84,12 +90,15 @@ export const AutoCompletePanel = React.memo(
                 const childrenContent = createGroupChildren(suggestion, index, style);
                 const key = index + '_' + getOptionGroupRenderKey(suggestion);
                 const itemGroupProps = mergeProps(
-                    {
-                        className: cx('itemGroup'),
-                        style,
-                        'data-p-highlight': false
-                    },
-                    _ptm('itemGroup')
+                    [
+                        {
+                            className: cx('itemGroup'),
+                            style,
+                            'data-p-highlight': false
+                        },
+                        _ptm('itemGroup')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -101,16 +110,19 @@ export const AutoCompletePanel = React.memo(
             } else {
                 const content = props.itemTemplate ? ObjectUtils.getJSXElement(props.itemTemplate, suggestion, index) : props.field ? ObjectUtils.resolveFieldData(suggestion, props.field) : suggestion;
                 const itemProps = mergeProps(
-                    {
-                        index,
-                        role: 'option',
-                        className: cx('item', { suggestion }),
-                        style,
-                        onClick: (e) => props.onItemClick(e, suggestion),
-                        'aria-selected': props.selectedItem === suggestion,
-                        'data-p-disabled': suggestion.disabled
-                    },
-                    getPTOptions(suggestion, 'item')
+                    [
+                        {
+                            index,
+                            role: 'option',
+                            className: cx('item', { suggestion }),
+                            style,
+                            onClick: (e) => props.onItemClick(e, suggestion),
+                            'aria-selected': props.selectedItem === suggestion,
+                            'data-p-disabled': suggestion.disabled
+                        },
+                        getPTOptions(suggestion, 'item')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -130,17 +142,23 @@ export const AutoCompletePanel = React.memo(
             if (props.showEmptyMessage && ObjectUtils.isEmpty(props.suggestions)) {
                 const emptyMessage = props.emptyMessage || localeOption('emptyMessage');
                 const emptyMessageProps = mergeProps(
-                    {
-                        className: cx('emptyMessage')
-                    },
-                    _ptm('emptyMesage')
+                    [
+                        {
+                            className: cx('emptyMessage')
+                        },
+                        _ptm('emptyMesage')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const listProps = mergeProps(
-                    {
-                        className: cx('list')
-                    },
-                    _ptm('list')
+                    [
+                        {
+                            className: cx('list')
+                        },
+                        _ptm('list')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -160,14 +178,17 @@ export const AutoCompletePanel = React.memo(
                         itemTemplate: (item, options) => item && createItem(item, options.index, options),
                         contentTemplate: (options) => {
                             const listProps = mergeProps(
-                                {
-                                    id: props.listId,
-                                    ref: options.contentRef,
-                                    style: options.style,
-                                    className: cx('list', { virtualScrollerProps, options }),
-                                    role: 'listbox'
-                                },
-                                _ptm('list')
+                                [
+                                    {
+                                        id: props.listId,
+                                        ref: options.contentRef,
+                                        style: options.style,
+                                        className: cx('list', { virtualScrollerProps, options }),
+                                        role: 'listbox'
+                                    },
+                                    _ptm('list')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return <ul {...listProps}>{options.children}</ul>;
@@ -179,20 +200,26 @@ export const AutoCompletePanel = React.memo(
             } else {
                 const items = createItems();
                 const listProps = mergeProps(
-                    {
-                        id: props.listId,
-                        className: cx('list'),
-                        role: 'listbox'
-                    },
-                    _ptm('list')
+                    [
+                        {
+                            id: props.listId,
+                            className: cx('list'),
+                            role: 'listbox'
+                        },
+                        _ptm('list')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const listWrapperProps = mergeProps(
-                    {
-                        className: cx('listWrapper'),
-                        style: { maxHeight: props.scrollHeight || 'auto' }
-                    },
-                    _ptm('listWrapper')
+                    [
+                        {
+                            className: cx('listWrapper'),
+                            style: { maxHeight: props.scrollHeight || 'auto' }
+                        },
+                        _ptm('listWrapper')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -208,28 +235,34 @@ export const AutoCompletePanel = React.memo(
             const content = createContent();
             const footer = createFooter();
             const panelProps = mergeProps(
-                {
-                    className: classNames(props.panelClassName, cx('panel', { context })),
-                    style,
-                    onClick: (e) => props.onClick(e)
-                },
-                _ptm('panel')
+                [
+                    {
+                        className: classNames(props.panelClassName, cx('panel', { context })),
+                        style,
+                        onClick: (e) => props.onClick(e)
+                    },
+                    _ptm('panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: props.in,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: props.onEnter,
-                    onEntering: props.onEntering,
-                    onEntered: props.onEntered,
-                    onExit: props.onExit,
-                    onExited: props.onExited
-                },
-                _ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: props.in,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: props.onEnter,
+                        onEntering: props.onEntering,
+                        onEntered: props.onEntered,
+                        onExit: props.onExit,
+                        onExited: props.onExited
+                    },
+                    _ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/avatar/Avatar.js
+++ b/components/lib/avatar/Avatar.js
@@ -25,29 +25,38 @@ export const Avatar = React.forwardRef((inProps, ref) => {
     const createContent = () => {
         if (ObjectUtils.isNotEmpty(props.image) && !imageFailed) {
             const imageProps = mergeProps(
-                {
-                    src: props.image,
-                    onError: onImageError
-                },
-                ptm('image')
+                [
+                    {
+                        src: props.image,
+                        onError: onImageError
+                    },
+                    ptm('image')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <img alt={props.imageAlt} {...imageProps}></img>;
         } else if (props.label) {
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...labelProps}>{props.label}</span>;
         } else if (props.icon) {
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return IconUtils.getJSXIcon(props.icon, { ...iconProps }, { props });
@@ -83,13 +92,16 @@ export const Avatar = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef,
-            style: props.style,
-            className: classNames(props.className, cx('root', { imageFailed }))
-        },
-        AvatarBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef,
+                style: props.style,
+                className: classNames(props.className, cx('root', { imageFailed }))
+            },
+            AvatarBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();

--- a/components/lib/avatargroup/AvatarGroup.js
+++ b/components/lib/avatargroup/AvatarGroup.js
@@ -22,13 +22,16 @@ export const AvatarGroup = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef,
-            style: props.style,
-            className: classNames(props.className, cx('root'))
-        },
-        AvatarGroupBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef,
+                style: props.style,
+                className: classNames(props.className, cx('root'))
+            },
+            AvatarGroupBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <div {...rootProps}>{props.children}</div>;

--- a/components/lib/badge/Badge.js
+++ b/components/lib/badge/Badge.js
@@ -24,13 +24,16 @@ export const Badge = React.memo(
         }));
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                style: props.style,
-                className: classNames(props.className, cx('root'))
-            },
-            BadgeBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    style: props.style,
+                    className: classNames(props.className, cx('root'))
+                },
+                BadgeBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <span {...rootProps}>{props.value}</span>;

--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -85,18 +85,21 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
         if (visibleState) {
             const appendTo = props.fullScreen ? document.body : 'self';
             const maskProps = mergeProps(
-                {
-                    className: classNames(props.className, cx('mask')),
-                    style: {
-                        ...props.style,
-                        position: props.fullScreen ? 'fixed' : 'absolute',
-                        top: '0',
-                        left: '0',
-                        width: '100%',
-                        height: '100%'
-                    }
-                },
-                ptm('mask')
+                [
+                    {
+                        className: classNames(props.className, cx('mask')),
+                        style: {
+                            ...props.style,
+                            position: props.fullScreen ? 'fixed' : 'absolute',
+                            top: '0',
+                            left: '0',
+                            width: '100%',
+                            height: '100%'
+                        }
+                    },
+                    ptm('mask')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : null;
             const mask = (
@@ -114,14 +117,17 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
     const mask = createMask();
 
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            ref: elementRef,
-            style: props.containerStyle,
-            className: cx('root')
-        },
-        BlockUIBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: props.id,
+                ref: elementRef,
+                style: props.containerStyle,
+                className: cx('root')
+            },
+            BlockUIBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -50,28 +50,37 @@ export const BreadCrumb = React.memo(
 
                 const { icon: _icon, target, url, disabled, style, className: _className, template, label: _label } = home;
                 const iconProps = mergeProps(
-                    {
-                        className: cx('icon')
-                    },
-                    ptm('icon')
+                    [
+                        {
+                            className: cx('icon')
+                        },
+                        ptm('icon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = IconUtils.getJSXIcon(_icon, { ...iconProps }, { props });
                 const actionProps = mergeProps(
-                    {
-                        href: url || '#',
-                        className: cx('action'),
-                        'aria-disabled': disabled,
-                        target,
-                        onClick: (event) => itemClick(event, home)
-                    },
-                    ptm('action')
+                    [
+                        {
+                            href: url || '#',
+                            className: cx('action'),
+                            'aria-disabled': disabled,
+                            target,
+                            onClick: (event) => itemClick(event, home)
+                        },
+                        ptm('action')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const labelProps = mergeProps(
-                    {
-                        className: cx('label')
-                    },
-                    ptm('label')
+                    [
+                        {
+                            className: cx('label')
+                        },
+                        ptm('label')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const label = _label && <span {...labelProps}>{_label}</span>;
                 let content = (
@@ -95,13 +104,16 @@ export const BreadCrumb = React.memo(
 
                 const key = idState + '_home';
                 const menuitemProps = mergeProps(
-                    {
-                        id: key,
-                        key,
-                        className: cx('home', { _className, disabled }),
-                        style
-                    },
-                    ptm('home')
+                    [
+                        {
+                            id: key,
+                            key,
+                            className: cx('home', { _className, disabled }),
+                            style
+                        },
+                        ptm('home')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <li {...menuitemProps}>{content}</li>;
@@ -113,21 +125,27 @@ export const BreadCrumb = React.memo(
         const createSeparator = (index) => {
             const key = idState + '_sep_' + index;
             const separatorIconProps = mergeProps(
-                {
-                    className: cx('separatorIcon')
-                },
-                ptm('separatorIcon')
+                [
+                    {
+                        className: cx('separatorIcon')
+                    },
+                    ptm('separatorIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.separatorIcon || <ChevronRightIcon {...separatorIconProps} />;
             const separatorIcon = IconUtils.getJSXIcon(icon, { ...separatorIconProps }, { props });
             const separatorProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('separator'),
-                    role: 'separator'
-                },
-                ptm('separator')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('separator'),
+                        role: 'separator'
+                    },
+                    ptm('separator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...separatorProps}>{separatorIcon}</li>;
@@ -139,21 +157,27 @@ export const BreadCrumb = React.memo(
             }
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const actionProps = mergeProps(
-                {
-                    href: item.url || '#',
-                    className: cx('action'),
-                    target: item.target,
-                    onClick: (event) => itemClick(event, item),
-                    'aria-disabled': item.disabled
-                },
-                ptm('action')
+                [
+                    {
+                        href: item.url || '#',
+                        className: cx('action'),
+                        target: item.target,
+                        onClick: (event) => itemClick(event, item),
+                        'aria-disabled': item.disabled
+                    },
+                    ptm('action')
+                ],
+                { useTailwind: context.useTailwind }
             );
             let content = <a {...actionProps}>{label}</a>;
 
@@ -171,13 +195,16 @@ export const BreadCrumb = React.memo(
 
             const key = item.id || idState + '_' + index;
             const menuitemProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('menuitem', { item }),
-                    style: item.style
-                },
-                ptm('menuitem')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('menuitem', { item }),
+                        style: item.style
+                    },
+                    ptm('menuitem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuitemProps}>{content}</li>;
@@ -223,21 +250,27 @@ export const BreadCrumb = React.memo(
         const items = createMenuitems();
         const separator = createSeparator('home');
         const menuProps = mergeProps(
-            {
-                className: cx('menu')
-            },
-            ptm('menu')
+            [
+                {
+                    className: cx('menu')
+                },
+                ptm('menu')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: cx('root'),
-                style: props.style,
-                'aria-label': 'Breadcrumb'
-            },
-            BreadCrumbBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: cx('root'),
+                    style: props.style,
+                    'aria-label': 'Breadcrumb'
+                },
+                BreadCrumbBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -42,10 +42,13 @@ export const Button = React.memo(
             });
 
             const iconsProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             className = classNames(className, {
@@ -53,10 +56,13 @@ export const Button = React.memo(
             });
 
             const loadingIconProps = mergeProps(
-                {
-                    className: cx('loadingIcon', { className })
-                },
-                ptm('loadingIcon')
+                [
+                    {
+                        className: cx('loadingIcon', { className })
+                    },
+                    ptm('loadingIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.loading ? props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin /> : props.icon;
@@ -66,10 +72,13 @@ export const Button = React.memo(
 
         const createLabel = () => {
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.label) {
@@ -82,13 +91,16 @@ export const Button = React.memo(
         const createBadge = () => {
             if (props.badge) {
                 const badgeProps = mergeProps(
-                    {
-                        className: classNames(props.badgeClassName),
-                        value: props.badge,
-                        unstyled: props.unstyled,
-                        __parentMetadata: { parent: metaData }
-                    },
-                    ptm('badge')
+                    [
+                        {
+                            className: classNames(props.badgeClassName),
+                            value: props.badge,
+                            unstyled: props.unstyled,
+                            __parentMetadata: { parent: metaData }
+                        },
+                        ptm('badge')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <Badge {...badgeProps}>{props.badge}</Badge>;
@@ -111,14 +123,17 @@ export const Button = React.memo(
         const defaultAriaLabel = props.label ? props.label + (props.badge ? ' ' + props.badge : '') : props['aria-label'];
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                'aria-label': defaultAriaLabel,
-                className: classNames(props.className, cx('root', { size, disabled })),
-                disabled: disabled
-            },
-            ButtonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    'aria-label': defaultAriaLabel,
+                    className: classNames(props.className, cx('root', { size, disabled })),
+                    disabled: disabled
+                },
+                ButtonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2655,20 +2655,26 @@ export const Calendar = React.memo(
         const createBackwardNavigator = (isVisible) => {
             const navigatorProps = isVisible ? { onClick: onPrevButtonClick, onKeyDown: (e) => onContainerButtonKeydown(e) } : { style: { visibility: 'hidden' } };
             const previousIconProps = mergeProps(
-                {
-                    className: cx('previousIcon')
-                },
-                ptm('previousIcon')
+                [
+                    {
+                        className: cx('previousIcon')
+                    },
+                    ptm('previousIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.prevIcon || <ChevronLeftIcon {...previousIconProps} />;
             const backwardNavigatorIcon = IconUtils.getJSXIcon(icon, { ...previousIconProps }, { props });
             const previousButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('previousButton'),
-                    ...navigatorProps
-                },
-                ptm('previousButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('previousButton'),
+                        ...navigatorProps
+                    },
+                    ptm('previousButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -2682,20 +2688,26 @@ export const Calendar = React.memo(
         const createForwardNavigator = (isVisible) => {
             const navigatorProps = isVisible ? { onClick: onNextButtonClick, onKeyDown: (e) => onContainerButtonKeydown(e) } : { style: { visibility: 'hidden' } };
             const nextIconProps = mergeProps(
-                {
-                    className: cx('nextIcon')
-                },
-                ptm('nextIcon')
+                [
+                    {
+                        className: cx('nextIcon')
+                    },
+                    ptm('nextIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.nextIcon || <ChevronRightIcon {...nextIconProps} />;
             const forwardNavigatorIcon = IconUtils.getJSXIcon(icon, { ...nextIconProps }, { props });
             const nextButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('nextButton'),
-                    ...navigatorProps
-                },
-                ptm('nextButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('nextButton'),
+                        ...navigatorProps
+                    },
+                    ptm('nextButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -2717,21 +2729,27 @@ export const Calendar = React.memo(
                     .filter((option) => !!option);
                 const displayedMonthNames = displayedMonthOptions.map((option) => option.label);
                 const selectProps = mergeProps(
-                    {
-                        className: cx('select'),
-                        onChange: (e) => onMonthDropdownChange(e, e.target.value),
-                        value: viewMonth
-                    },
-                    ptm('select')
+                    [
+                        {
+                            className: cx('select'),
+                            onChange: (e) => onMonthDropdownChange(e, e.target.value),
+                            value: viewMonth
+                        },
+                        ptm('select')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const content = (
                     <select {...selectProps}>
                         {displayedMonthOptions.map((option) => {
                             const optionProps = mergeProps(
-                                {
-                                    value: option.value
-                                },
-                                ptm('option')
+                                [
+                                    {
+                                        value: option.value
+                                    },
+                                    ptm('option')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return (
@@ -2761,12 +2779,15 @@ export const Calendar = React.memo(
             }
 
             const monthTitleProps = mergeProps(
-                {
-                    className: cx('monthTitle'),
-                    onClick: switchToMonthView,
-                    disabled: switchViewButtonDisabled()
-                },
-                ptm('monthTitle')
+                [
+                    {
+                        className: cx('monthTitle'),
+                        onClick: switchToMonthView,
+                        disabled: switchViewButtonDisabled()
+                    },
+                    ptm('monthTitle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return currentView === 'date' && <button {...monthTitleProps}>{monthNames[month]}</button>;
@@ -2787,22 +2808,28 @@ export const Calendar = React.memo(
                 const viewYear = viewDate.getFullYear();
                 const displayedYearNames = yearOptions.filter((year) => !(props.minDate && props.minDate.getFullYear() > year) && !(props.maxDate && props.maxDate.getFullYear() < year));
                 const selectProps = mergeProps(
-                    {
-                        className: cx('select'),
-                        onChange: (e) => onYearDropdownChange(e, e.target.value),
-                        value: viewYear
-                    },
-                    ptm('select')
+                    [
+                        {
+                            className: cx('select'),
+                            onChange: (e) => onYearDropdownChange(e, e.target.value),
+                            value: viewYear
+                        },
+                        ptm('select')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const content = (
                     <select {...selectProps}>
                         {displayedYearNames.map((year) => {
                             const optionProps = mergeProps(
-                                {
-                                    value: year
-                                },
-                                ptm('option')
+                                [
+                                    {
+                                        value: year
+                                    },
+                                    ptm('option')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return (
@@ -2834,12 +2861,15 @@ export const Calendar = React.memo(
 
             const displayYear = props.numberOfMonths > 1 ? metaYear : currentYear;
             const yearTitleProps = mergeProps(
-                {
-                    className: cx('yearTitle'),
-                    onClick: (e) => switchToYearView(e),
-                    disabled: switchViewButtonDisabled()
-                },
-                ptm('yearTitle')
+                [
+                    {
+                        className: cx('yearTitle'),
+                        onClick: (e) => switchToYearView(e),
+                        disabled: switchViewButtonDisabled()
+                    },
+                    ptm('yearTitle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return currentView !== 'year' && <button {...yearTitleProps}>{displayYear}</button>;
@@ -2848,14 +2878,17 @@ export const Calendar = React.memo(
         const createTitleDecadeElement = () => {
             const years = yearPickerValues();
             const decadeTitleProps = mergeProps(
-                {
-                    className: cx('decadeTitle')
-                },
-                ptm('decadeTitle')
+                [
+                    {
+                        className: cx('decadeTitle')
+                    },
+                    ptm('decadeTitle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (currentView === 'year') {
-                const decadeTitleTextProps = mergeProps(ptm('decadeTitleText'));
+                const decadeTitleTextProps = mergeProps([ptm('decadeTitleText')], { useTailwind: context.useTailwind });
 
                 return <span {...decadeTitleProps}>{props.decadeTemplate ? props.decadeTemplate(years) : <span {...decadeTitleTextProps}>{`${yearPickerValues()[0]} - ${yearPickerValues()[yearPickerValues().length - 1]}`}</span>}</span>;
             }
@@ -2868,10 +2901,13 @@ export const Calendar = React.memo(
             const year = createTitleYearElement(monthMetaData.year);
             const decade = createTitleDecadeElement();
             const titleProps = mergeProps(
-                {
-                    className: cx('title')
-                },
-                ptm('title')
+                [
+                    {
+                        className: cx('title')
+                    },
+                    ptm('title')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const showMonthAfterYear = localeOption('showMonthAfterYear', props.locale);
 
@@ -2885,12 +2921,15 @@ export const Calendar = React.memo(
         };
 
         const createDayNames = (weekDays) => {
-            const weekDayProps = mergeProps(ptm('weekDay'));
+            const weekDayProps = mergeProps([ptm('weekDay')], { useTailwind: context.useTailwind });
             const tableHeaderCellProps = mergeProps(
-                {
-                    scope: 'col'
-                },
-                ptm('tableHeaderCell')
+                [
+                    {
+                        scope: 'col'
+                    },
+                    ptm('tableHeaderCell')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const dayNames = weekDays.map((weekDay, index) => (
                 <th {...tableHeaderCellProps} key={`${weekDay}-${index}`}>
@@ -2900,19 +2939,22 @@ export const Calendar = React.memo(
 
             if (props.showWeek) {
                 const weekHeaderProps = mergeProps(
-                    {
-                        scope: 'col',
-                        className: cx('weekHeader'),
-                        'data-p-disabled': props.showWeek
-                    },
-                    ptm('weekHeader', {
-                        context: {
-                            disabled: props.showWeek
-                        }
-                    })
+                    [
+                        {
+                            scope: 'col',
+                            className: cx('weekHeader'),
+                            'data-p-disabled': props.showWeek
+                        },
+                        ptm('weekHeader', {
+                            context: {
+                                disabled: props.showWeek
+                            }
+                        })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
-                const weekLabel = mergeProps(ptm('weekLabel'));
+                const weekLabel = mergeProps([ptm('weekLabel')], { useTailwind: context.useTailwind });
 
                 const weekHeader = (
                     <th {...weekHeaderProps} key="wn">
@@ -2930,19 +2972,22 @@ export const Calendar = React.memo(
             const content = props.dateTemplate ? props.dateTemplate(date) : date.day;
 
             const dayLabelProps = mergeProps(
-                {
-                    className: cx('dayLabel', { className }),
-                    onClick: (e) => onDateSelect(e, date),
-                    onKeyDown: (e) => onDateCellKeydown(e, date, groupIndex),
-                    'data-p-highlight': isSelected(date),
-                    'data-p-disabled': !date.selectable
-                },
-                ptm('dayLabel', {
-                    context: {
-                        selected: isSelected(date),
-                        disabled: !date.selectable
-                    }
-                })
+                [
+                    {
+                        className: cx('dayLabel', { className }),
+                        onClick: (e) => onDateSelect(e, date),
+                        onKeyDown: (e) => onDateCellKeydown(e, date, groupIndex),
+                        'data-p-highlight': isSelected(date),
+                        'data-p-disabled': !date.selectable
+                    },
+                    ptm('dayLabel', {
+                        context: {
+                            selected: isSelected(date),
+                            disabled: !date.selectable
+                        }
+                    })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -2959,18 +3004,21 @@ export const Calendar = React.memo(
                 const dateClassName = classNames({ 'p-highlight': selected, 'p-disabled': !date.selectable });
                 const content = date.otherMonth && !props.showOtherMonths ? null : createDateCellContent(date, dateClassName, groupIndex);
                 const dayProps = mergeProps(
-                    {
-                        className: cx('day', { date }),
-                        'data-p-today': date.today,
-                        'data-p-other-month': date.otherMonth
-                    },
-                    ptm('day', {
-                        context: {
-                            date,
-                            today: date.today,
-                            otherMonth: date.otherMonth
-                        }
-                    })
+                    [
+                        {
+                            className: cx('day', { date }),
+                            'data-p-today': date.today,
+                            'data-p-other-month': date.otherMonth
+                        },
+                        ptm('day', {
+                            context: {
+                                date,
+                                today: date.today,
+                                otherMonth: date.otherMonth
+                            }
+                        })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -2982,22 +3030,28 @@ export const Calendar = React.memo(
 
             if (props.showWeek) {
                 const weekNumberProps = mergeProps(
-                    {
-                        className: cx('weekNumber')
-                    },
-                    ptm('weekNumber')
+                    [
+                        {
+                            className: cx('weekNumber')
+                        },
+                        ptm('weekNumber')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const weekLabelContainerProps = mergeProps(
-                    {
-                        className: cx('weekLabelContainer'),
-                        'data-p-disabled': props.showWeek
-                    },
-                    ptm('weekLabelContainer', {
-                        context: {
-                            disabled: props.showWeek
-                        }
-                    })
+                    [
+                        {
+                            className: cx('weekLabelContainer'),
+                            'data-p-disabled': props.showWeek
+                        },
+                        ptm('weekLabelContainer', {
+                            context: {
+                                disabled: props.showWeek
+                            }
+                        })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const weekNumberCell = (
@@ -3013,7 +3067,7 @@ export const Calendar = React.memo(
         };
 
         const createDates = (monthMetaData, groupIndex) => {
-            const tableBodyRowProps = mergeProps(ptm('tableBodyRowProps'));
+            const tableBodyRowProps = mergeProps([ptm('tableBodyRowProps')], { useTailwind: context.useTailwind });
 
             return monthMetaData.dates.map((weekDates, index) => (
                 <tr {...tableBodyRowProps} key={index}>
@@ -3026,21 +3080,27 @@ export const Calendar = React.memo(
             const dayNames = createDayNames(weekDays);
             const dates = createDates(monthMetaData, groupIndex);
             const containerProps = mergeProps(
-                {
-                    className: cx('container'),
-                    key: UniqueComponentId('calendar_container_')
-                },
-                ptm('container')
+                [
+                    {
+                        className: cx('container'),
+                        key: UniqueComponentId('calendar_container_')
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const tableProps = mergeProps(
-                {
-                    className: cx('table')
-                },
-                ptm('table')
+                [
+                    {
+                        className: cx('table')
+                    },
+                    ptm('table')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const tableHeaderProps = mergeProps(ptm('tableHeader'));
-            const tableHeaderRowProps = mergeProps(ptm('tableHeaderRow'));
-            const tableBodyProps = mergeProps(ptm('tableBody'));
+            const tableHeaderProps = mergeProps([ptm('tableHeader')], { useTailwind: context.useTailwind });
+            const tableHeaderRowProps = mergeProps([ptm('tableHeaderRow')], { useTailwind: context.useTailwind });
+            const tableBodyProps = mergeProps([ptm('tableBody')], { useTailwind: context.useTailwind });
 
             return (
                 currentView === 'date' && (
@@ -3066,18 +3126,24 @@ export const Calendar = React.memo(
             const header = props.headerTemplate ? props.headerTemplate() : null;
             const monthKey = monthMetaData.month + '-' + monthMetaData.year;
             const groupProps = mergeProps(
-                {
-                    className: cx('group')
-                },
-                ptm('group')
+                [
+                    {
+                        className: cx('group')
+                    },
+                    ptm('group')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerProps = mergeProps(
-                {
-                    className: cx('header'),
-                    key: index
-                },
-                ptm('header')
+                [
+                    {
+                        className: cx('header'),
+                        key: index
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -3097,10 +3163,13 @@ export const Calendar = React.memo(
             const groups = monthsMetaData.map(createMonth);
 
             const groupContainerProps = mergeProps(
-                {
-                    className: cx('groupContainer')
-                },
-                ptm('groupContainer')
+                [
+                    {
+                        className: cx('groupContainer')
+                    },
+                    ptm('groupContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...groupContainerProps}>{groups}</div>;
@@ -3142,31 +3211,43 @@ export const Calendar = React.memo(
             const yearElement = createTitleYearElement(getViewDate().getFullYear());
             const decade = createTitleDecadeElement();
             const groupContainerProps = mergeProps(
-                {
-                    className: cx('groupContainer')
-                },
-                ptm('groupContainer')
+                [
+                    {
+                        className: cx('groupContainer')
+                    },
+                    ptm('groupContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const groupProps = mergeProps(
-                {
-                    className: cx('group')
-                },
-                ptm('group')
+                [
+                    {
+                        className: cx('group')
+                    },
+                    ptm('group')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerProps = mergeProps(
-                {
-                    className: cx('header')
-                },
-                ptm('header')
+                [
+                    {
+                        className: cx('header')
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const titleProps = mergeProps(
-                {
-                    className: cx('title')
-                },
-                ptm('title')
+                [
+                    {
+                        className: cx('title')
+                    },
+                    ptm('title')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -3199,8 +3280,8 @@ export const Calendar = React.memo(
             return null;
         };
 
-        const incrementIconProps = mergeProps(ptm('incrementIcon'));
-        const decrementIconProps = mergeProps(ptm('decrementIcon'));
+        const incrementIconProps = mergeProps([ptm('incrementIcon')], { useTailwind: context.useTailwind });
+        const decrementIconProps = mergeProps([ptm('decrementIcon')], { useTailwind: context.useTailwind });
         const incrementIcon = IconUtils.getJSXIcon(props.incrementIcon || <ChevronUpIcon {...incrementIconProps} />, { ...incrementIconProps }, { props });
         const decrementIcon = IconUtils.getJSXIcon(props.decrementIcon || <ChevronDownIcon {...decrementIconProps} />, { ...decrementIconProps }, { props });
 
@@ -3217,37 +3298,46 @@ export const Calendar = React.memo(
                 else if (hour > 11 && hour !== 12) hour = hour - 12;
             }
 
-            const hourProps = mergeProps(ptm('hour'));
+            const hourProps = mergeProps([ptm('hour')], { useTailwind: context.useTailwind });
             const hourDisplay = hour < 10 ? '0' + hour : hour;
             const hourPickerProps = mergeProps(
-                {
-                    className: cx('hourPicker')
-                },
-                ptm('hourPicker')
+                [
+                    {
+                        className: cx('hourPicker')
+                    },
+                    ptm('hourPicker')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const incrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('incrementButton'),
-                    onMouseDown: (e) => onTimePickerElementMouseDown(e, 0, 1),
-                    onMouseUp: onTimePickerElementMouseUp,
-                    onMouseLeave: onTimePickerElementMouseLeave,
-                    onKeyDown: (e) => onContainerButtonKeydown(e)
-                },
-                ptm('incrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('incrementButton'),
+                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 0, 1),
+                        onMouseUp: onTimePickerElementMouseUp,
+                        onMouseLeave: onTimePickerElementMouseLeave,
+                        onKeyDown: (e) => onContainerButtonKeydown(e)
+                    },
+                    ptm('incrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const decrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('decrementButton'),
-                    onMouseDown: (e) => onTimePickerElementMouseDown(e, 0, -1),
-                    onMouseUp: onTimePickerElementMouseUp,
-                    onMouseLeave: onTimePickerElementMouseLeave,
-                    onKeyDown: (e) => onContainerButtonKeydown(e)
-                },
-                ptm('decrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('decrementButton'),
+                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 0, -1),
+                        onMouseUp: onTimePickerElementMouseUp,
+                        onMouseLeave: onTimePickerElementMouseLeave,
+                        onKeyDown: (e) => onContainerButtonKeydown(e)
+                    },
+                    ptm('decrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -3270,37 +3360,46 @@ export const Calendar = React.memo(
             let minute = doStepMinute(currentTime.getMinutes());
 
             minute = minute > 59 ? minute - 60 : minute;
-            const minuteProps = mergeProps(ptm('minute'));
+            const minuteProps = mergeProps([ptm('minute')], { useTailwind: context.useTailwind });
             const minuteDisplay = minute < 10 ? '0' + minute : minute;
             const minutePickerProps = mergeProps(
-                {
-                    className: cx('minutePicker')
-                },
-                ptm('minutePicker')
+                [
+                    {
+                        className: cx('minutePicker')
+                    },
+                    ptm('minutePicker')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const incrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('incrementButton'),
-                    onMouseDown: (e) => onTimePickerElementMouseDown(e, 1, 1),
-                    onMouseUp: onTimePickerElementMouseUp,
-                    onMouseLeave: onTimePickerElementMouseLeave,
-                    onKeyDown: (e) => onContainerButtonKeydown(e)
-                },
-                ptm('incrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('incrementButton'),
+                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 1, 1),
+                        onMouseUp: onTimePickerElementMouseUp,
+                        onMouseLeave: onTimePickerElementMouseLeave,
+                        onKeyDown: (e) => onContainerButtonKeydown(e)
+                    },
+                    ptm('incrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const decrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('decrementButton'),
-                    onMouseDown: (e) => onTimePickerElementMouseDown(e, 1, -1),
-                    onMouseUp: onTimePickerElementMouseUp,
-                    onMouseLeave: onTimePickerElementMouseLeave,
-                    onKeyDown: (e) => onContainerButtonKeydown(e)
-                },
-                ptm('decrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('decrementButton'),
+                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 1, -1),
+                        onMouseUp: onTimePickerElementMouseUp,
+                        onMouseLeave: onTimePickerElementMouseLeave,
+                        onKeyDown: (e) => onContainerButtonKeydown(e)
+                    },
+                    ptm('decrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -3321,38 +3420,47 @@ export const Calendar = React.memo(
         const createSecondPicker = () => {
             if (props.showSeconds) {
                 const currentTime = getCurrentDateTime();
-                const secondProps = mergeProps(ptm('second'));
+                const secondProps = mergeProps([ptm('second')], { useTailwind: context.useTailwind });
                 const second = currentTime.getSeconds();
                 const secondDisplay = second < 10 ? '0' + second : second;
                 const secondPickerProps = mergeProps(
-                    {
-                        className: cx('secondPicker')
-                    },
-                    ptm('secondPicker')
+                    [
+                        {
+                            className: cx('secondPicker')
+                        },
+                        ptm('secondPicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const incrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('incrementButton'),
-                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 2, 1),
-                        onMouseUp: onTimePickerElementMouseUp,
-                        onMouseLeave: onTimePickerElementMouseLeave,
-                        onKeyDown: (e) => onContainerButtonKeydown(e)
-                    },
-                    ptm('incrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('incrementButton'),
+                            onMouseDown: (e) => onTimePickerElementMouseDown(e, 2, 1),
+                            onMouseUp: onTimePickerElementMouseUp,
+                            onMouseLeave: onTimePickerElementMouseLeave,
+                            onKeyDown: (e) => onContainerButtonKeydown(e)
+                        },
+                        ptm('incrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const decrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('decrementButton'),
-                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 2, -1),
-                        onMouseUp: onTimePickerElementMouseUp,
-                        onMouseLeave: onTimePickerElementMouseLeave,
-                        onKeyDown: (e) => onContainerButtonKeydown(e)
-                    },
-                    ptm('decrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('decrementButton'),
+                            onMouseDown: (e) => onTimePickerElementMouseDown(e, 2, -1),
+                            onMouseUp: onTimePickerElementMouseUp,
+                            onMouseLeave: onTimePickerElementMouseLeave,
+                            onKeyDown: (e) => onContainerButtonKeydown(e)
+                        },
+                        ptm('decrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -3376,38 +3484,47 @@ export const Calendar = React.memo(
         const createMiliSecondPicker = () => {
             if (props.showMillisec) {
                 const currentTime = getCurrentDateTime();
-                const millisecondProps = mergeProps(ptm('millisecond'));
+                const millisecondProps = mergeProps([ptm('millisecond')], { useTailwind: context.useTailwind });
                 const millisecond = currentTime.getMilliseconds();
                 const millisecondDisplay = millisecond < 100 ? (millisecond < 10 ? '00' : '0') + millisecond : millisecond;
                 const millisecondPickerProps = mergeProps(
-                    {
-                        className: cx('millisecondPicker')
-                    },
-                    ptm('millisecondPicker')
+                    [
+                        {
+                            className: cx('millisecondPicker')
+                        },
+                        ptm('millisecondPicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const incrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('incrementButton'),
-                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 3, 1),
-                        onMouseUp: onTimePickerElementMouseUp,
-                        onMouseLeave: onTimePickerElementMouseLeave,
-                        onKeyDown: (e) => onContainerButtonKeydown(e)
-                    },
-                    ptm('incrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('incrementButton'),
+                            onMouseDown: (e) => onTimePickerElementMouseDown(e, 3, 1),
+                            onMouseUp: onTimePickerElementMouseUp,
+                            onMouseLeave: onTimePickerElementMouseLeave,
+                            onKeyDown: (e) => onContainerButtonKeydown(e)
+                        },
+                        ptm('incrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const decrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('decrementButton'),
-                        onMouseDown: (e) => onTimePickerElementMouseDown(e, 3, -1),
-                        onMouseUp: onTimePickerElementMouseUp,
-                        onMouseLeave: onTimePickerElementMouseLeave,
-                        onKeyDown: (e) => onContainerButtonKeydown(e)
-                    },
-                    ptm('decrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('decrementButton'),
+                            onMouseDown: (e) => onTimePickerElementMouseDown(e, 3, -1),
+                            onMouseUp: onTimePickerElementMouseUp,
+                            onMouseLeave: onTimePickerElementMouseLeave,
+                            onKeyDown: (e) => onContainerButtonKeydown(e)
+                        },
+                        ptm('decrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -3433,30 +3550,39 @@ export const Calendar = React.memo(
                 const currentTime = getCurrentDateTime();
                 const hour = currentTime.getHours();
                 const display = hour > 11 ? 'PM' : 'AM';
-                const ampmProps = mergeProps(ptm('ampm'));
+                const ampmProps = mergeProps([ptm('ampm')], { useTailwind: context.useTailwind });
                 const ampmPickerProps = mergeProps(
-                    {
-                        className: cx('ampmPicker')
-                    },
-                    ptm('ampmPicker')
+                    [
+                        {
+                            className: cx('ampmPicker')
+                        },
+                        ptm('ampmPicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const incrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('incrementButton'),
-                        onClick: (e) => toggleAmPm(e)
-                    },
-                    ptm('incrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('incrementButton'),
+                            onClick: (e) => toggleAmPm(e)
+                        },
+                        ptm('incrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const decrementButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('decrementButton'),
-                        onClick: (e) => toggleAmPm(e)
-                    },
-                    ptm('decrementButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('decrementButton'),
+                            onClick: (e) => toggleAmPm(e)
+                        },
+                        ptm('decrementButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -3479,13 +3605,16 @@ export const Calendar = React.memo(
 
         const createSeparator = (separator) => {
             const separatorContainerProps = mergeProps(
-                {
-                    className: cx('separatorContainer')
-                },
-                ptm('separatorContainer')
+                [
+                    {
+                        className: cx('separatorContainer')
+                    },
+                    ptm('separatorContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
-            const separatorProps = mergeProps(ptm('separator'));
+            const separatorProps = mergeProps([ptm('separator')], { useTailwind: context.useTailwind });
 
             return (
                 <div {...separatorContainerProps}>
@@ -3497,10 +3626,13 @@ export const Calendar = React.memo(
         const createTimePicker = () => {
             if ((props.showTime || props.timeOnly) && currentView === 'date') {
                 const timePickerProps = mergeProps(
-                    {
-                        className: cx('timePicker')
-                    },
-                    ptm('timePicker')
+                    [
+                        {
+                            className: cx('timePicker')
+                        },
+                        ptm('timePicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -3587,10 +3719,13 @@ export const Calendar = React.memo(
             if (props.showButtonBar) {
                 const { today, clear } = localeOptions(props.locale);
                 const buttonbarProps = mergeProps(
-                    {
-                        className: cx('buttonbar')
-                    },
-                    ptm('buttonbar')
+                    [
+                        {
+                            className: cx('buttonbar')
+                        },
+                        ptm('buttonbar')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -3608,10 +3743,13 @@ export const Calendar = React.memo(
             if (props.footerTemplate) {
                 const content = props.footerTemplate();
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    ptm('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        ptm('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{content}</div>;
@@ -3623,31 +3761,37 @@ export const Calendar = React.memo(
         const createMonthPicker = () => {
             if (currentView === 'month') {
                 const monthPickerProps = mergeProps(
-                    {
-                        className: cx('monthPicker')
-                    },
-                    ptm('monthPicker')
+                    [
+                        {
+                            className: cx('monthPicker')
+                        },
+                        ptm('monthPicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
                     <div {...monthPickerProps}>
                         {monthPickerValues().map((m, i) => {
                             const monthProps = mergeProps(
-                                {
-                                    className: cx('month', { isMonthSelected, isSelectable, i, currentYear }),
-                                    onClick: (event) => onMonthSelect(event, i),
-                                    onKeyDown: (event) => onMonthCellKeydown(event, i),
-                                    'data-p-disabled': !m.selectable,
-                                    'data-p-highlight': isMonthSelected(i)
-                                },
-                                ptm('month', {
-                                    context: {
-                                        month: m,
-                                        monthIndex: i,
-                                        selected: isMonthSelected(i),
-                                        disabled: !m.selectable
-                                    }
-                                })
+                                [
+                                    {
+                                        className: cx('month', { isMonthSelected, isSelectable, i, currentYear }),
+                                        onClick: (event) => onMonthSelect(event, i),
+                                        onKeyDown: (event) => onMonthCellKeydown(event, i),
+                                        'data-p-disabled': !m.selectable,
+                                        'data-p-highlight': isMonthSelected(i)
+                                    },
+                                    ptm('month', {
+                                        context: {
+                                            month: m,
+                                            monthIndex: i,
+                                            selected: isMonthSelected(i),
+                                            disabled: !m.selectable
+                                        }
+                                    })
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return (
@@ -3666,30 +3810,36 @@ export const Calendar = React.memo(
         const createYearPicker = () => {
             if (currentView === 'year') {
                 const yearPickerProps = mergeProps(
-                    {
-                        className: cx('yearPicker')
-                    },
-                    ptm('yearPicker')
+                    [
+                        {
+                            className: cx('yearPicker')
+                        },
+                        ptm('yearPicker')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
                     <div {...yearPickerProps}>
                         {yearPickerValues().map((y, i) => {
                             const yearProps = mergeProps(
-                                {
-                                    className: cx('year', { isYearSelected, isSelectable, y }),
-                                    onClick: (event) => onYearSelect(event, y),
-                                    'data-p-highlight': isYearSelected(y),
-                                    'data-p-disabled': !isSelectable(0, -1, y)
-                                },
-                                ptm('year', {
-                                    context: {
-                                        year: y,
-                                        yearIndex: i,
-                                        selected: isYearSelected(i),
-                                        disabled: !y.selectable
-                                    }
-                                })
+                                [
+                                    {
+                                        className: cx('year', { isYearSelected, isSelectable, y }),
+                                        onClick: (event) => onYearSelect(event, y),
+                                        'data-p-highlight': isYearSelected(y),
+                                        'data-p-disabled': !isSelectable(0, -1, y)
+                                    },
+                                    ptm('year', {
+                                        context: {
+                                            year: y,
+                                            yearIndex: i,
+                                            selected: isYearSelected(i),
+                                            disabled: !y.selectable
+                                        }
+                                    })
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return (
@@ -3724,13 +3874,16 @@ export const Calendar = React.memo(
         const yearPicker = createYearPicker();
         const isFilled = DomHandler.hasClass(inputRef.current, 'p-filled') && inputRef.current.value !== '';
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: classNames(props.className, cx('root', { focusedState, isFilled })),
-                style: props.style
-            },
-            CalendarBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: classNames(props.className, cx('root', { focusedState, isFilled })),
+                    style: props.style
+                },
+                CalendarBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/calendar/CalendarPanel.js
+++ b/components/lib/calendar/CalendarPanel.js
@@ -2,34 +2,42 @@ import * as React from 'react';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { Portal } from '../portal/Portal';
 import { mergeProps } from '../utils/Utils';
+import { PrimeReactContext } from '../api/Api';
 
 export const CalendarPanel = React.forwardRef((props, ref) => {
     const cx = props.cx;
+    const context = React.useContext(PrimeReactContext);
 
     const createElement = () => {
         const panelProps = mergeProps(
-            {
-                className: cx('panel', { panelClassName: props.className }),
-                style: props.style,
-                onClick: props.onClick,
-                onMouseUp: props.onMouseUp
-            },
-            props.ptm('panel', { hostName: props.hostName })
+            [
+                {
+                    className: cx('panel', { panelClassName: props.className }),
+                    style: props.style,
+                    onClick: props.onClick,
+                    onMouseUp: props.onMouseUp
+                },
+                props.ptm('panel', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: props.in,
-                timeout: { enter: 120, exit: 100 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: props.onEnter,
-                onEntered: props.onEntered,
-                onExit: props.onExit,
-                onExited: props.onExited
-            },
-            props.ptm('transition', { hostName: props.hostName })
+            [
+                {
+                    classNames: cx('transition'),
+                    in: props.in,
+                    timeout: { enter: 120, exit: 100 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: props.onEnter,
+                    onEntered: props.onEntered,
+                    onExit: props.onExit,
+                    onExited: props.onExited
+                },
+                props.ptm('transition', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/card/Card.js
+++ b/components/lib/card/Card.js
@@ -18,10 +18,13 @@ export const Card = React.forwardRef((inProps, ref) => {
 
     const createHeader = () => {
         const headerProps = mergeProps(
-            {
-                className: cx('header')
-            },
-            ptm('header')
+            [
+                {
+                    className: cx('header')
+                },
+                ptm('header')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.header) {
@@ -33,46 +36,61 @@ export const Card = React.forwardRef((inProps, ref) => {
 
     const createBody = () => {
         const titleProps = mergeProps(
-            {
-                className: cx('title')
-            },
-            ptm('title')
+            [
+                {
+                    className: cx('title')
+                },
+                ptm('title')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const title = props.title && <div {...titleProps}>{ObjectUtils.getJSXElement(props.title, props)}</div>;
 
         const subTitleProps = mergeProps(
-            {
-                className: cx('subTitle')
-            },
-            ptm('subTitle')
+            [
+                {
+                    className: cx('subTitle')
+                },
+                ptm('subTitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const subTitle = props.subTitle && <div {...subTitleProps}>{ObjectUtils.getJSXElement(props.subTitle, props)}</div>;
 
         const contentProps = mergeProps(
-            {
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const children = props.children && <div {...contentProps}>{props.children}</div>;
 
         const footerProps = mergeProps(
-            {
-                className: cx('footer')
-            },
-            ptm('footer')
+            [
+                {
+                    className: cx('footer')
+                },
+                ptm('footer')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const footer = props.footer && <div {...footerProps}>{ObjectUtils.getJSXElement(props.footer, props)}</div>;
 
         const bodyProps = mergeProps(
-            {
-                className: cx('body')
-            },
-            ptm('body')
+            [
+                {
+                    className: cx('body')
+                },
+                ptm('body')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -90,14 +108,17 @@ export const Card = React.forwardRef((inProps, ref) => {
     }, [elementRef, ref]);
 
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            ref: elementRef,
-            style: props.style,
-            className: cx('root')
-        },
-        CardBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: props.id,
+                ref: elementRef,
+                style: props.style,
+                className: cx('root')
+            },
+            CardBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const header = createHeader();

--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -12,16 +12,20 @@ import { CarouselBase } from './CarouselBase';
 
 const CarouselItem = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
     const key = props.className && props.className === 'p-carousel-item-cloned' ? 'itemCloned' : 'item';
     const content = props.template(props.item);
     const itemClonedProps = mergeProps(
-        {
-            className: cx(key, { itemProps: props }),
-            'data-p-carousel-item-active': props.active,
-            'data-p-carousel-item-start': props.start,
-            'data-p-carousel-item-end': props.end
-        },
-        ptm(key)
+        [
+            {
+                className: cx(key, { itemProps: props }),
+                'data-p-carousel-item-active': props.active,
+                'data-p-carousel-item-start': props.start,
+                'data-p-carousel-item-end': props.end
+            },
+            ptm(key)
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <div {...itemClonedProps}>{content}</div>;
@@ -462,10 +466,13 @@ export const Carousel = React.memo(
         const createHeader = () => {
             if (props.header) {
                 const headerProps = mergeProps(
-                    {
-                        className: cx('header')
-                    },
-                    ptm('header')
+                    [
+                        {
+                            className: cx('header')
+                        },
+                        ptm('header')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...headerProps}>{props.header}</div>;
@@ -477,10 +484,13 @@ export const Carousel = React.memo(
         const createFooter = () => {
             if (props.footer) {
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    ptm('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        ptm('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{props.footer}</div>;
@@ -495,29 +505,38 @@ export const Carousel = React.memo(
             const backwardNavigator = createBackwardNavigator();
             const forwardNavigator = createForwardNavigator();
             const itemsContentProps = mergeProps(
-                {
-                    className: cx('itemsContent'),
-                    style: sx('itemsContent', { height }),
-                    onTouchStart: (e) => onTouchStart(e),
-                    onTouchMove: (e) => onTouchMove(e),
-                    onTouchEnd: (e) => onTouchEnd(e)
-                },
-                ptm('itemsContent')
+                [
+                    {
+                        className: cx('itemsContent'),
+                        style: sx('itemsContent', { height }),
+                        onTouchStart: (e) => onTouchStart(e),
+                        onTouchMove: (e) => onTouchMove(e),
+                        onTouchEnd: (e) => onTouchEnd(e)
+                    },
+                    ptm('itemsContent')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const containerProps = mergeProps(
-                {
-                    className: classNames(props.containerClassName, cx('container'))
-                },
-                ptm('container')
+                [
+                    {
+                        className: classNames(props.containerClassName, cx('container'))
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const itemsContainerProps = mergeProps(
-                {
-                    className: cx('itemsContainer'),
-                    onTransitionEnd: onTransitionEnd
-                },
-                ptm('itemsContainer')
+                [
+                    {
+                        className: cx('itemsContainer'),
+                        onTransitionEnd: onTransitionEnd
+                    },
+                    ptm('itemsContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -537,22 +556,28 @@ export const Carousel = React.memo(
             if (props.showNavigators) {
                 const isDisabled = (!circular || (props.value && props.value.length < numVisibleState)) && currentPage === 0;
                 const previousButtonIconProps = mergeProps(
-                    {
-                        className: cx('previousButtonIcon')
-                    },
-                    ptm('previousButtonIcon')
+                    [
+                        {
+                            className: cx('previousButtonIcon')
+                        },
+                        ptm('previousButtonIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = isVertical ? props.prevIcon || <ChevronUpIcon {...previousButtonIconProps} /> : props.prevIcon || <ChevronLeftIcon {...previousButtonIconProps} />;
                 const backwardNavigatorIcon = IconUtils.getJSXIcon(icon, { ...previousButtonIconProps }, { props });
                 const previousButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('previousButton', { isDisabled }),
-                        onClick: (e) => navBackward(e),
-                        disabled: isDisabled,
-                        'aria-label': ariaLabel('previousPageLabel')
-                    },
-                    ptm('previousButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('previousButton', { isDisabled }),
+                            onClick: (e) => navBackward(e),
+                            disabled: isDisabled,
+                            'aria-label': ariaLabel('previousPageLabel')
+                        },
+                        ptm('previousButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -570,22 +595,28 @@ export const Carousel = React.memo(
             if (props.showNavigators) {
                 const isDisabled = (!circular || (props.value && props.value.length < numVisibleState)) && (currentPage === totalIndicators - 1 || totalIndicators === 0);
                 const nextButtonIconProps = mergeProps(
-                    {
-                        className: cx('nextButtonIcon')
-                    },
-                    ptm('nextButtonIcon')
+                    [
+                        {
+                            className: cx('nextButtonIcon')
+                        },
+                        ptm('nextButtonIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = isVertical ? props.nextIcon || <ChevronDownIcon {...nextButtonIconProps} /> : props.nextIcon || <ChevronRightIcon {...nextButtonIconProps} />;
                 const forwardNavigatorIcon = IconUtils.getJSXIcon(icon, { ...nextButtonIconProps }, { props });
                 const nextButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('nextButton', { isDisabled }),
-                        onClick: (e) => navForward(e),
-                        disabled: isDisabled,
-                        'aria-label': ariaLabel('nextPageLabel')
-                    },
-                    ptm('nextButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('nextButton', { isDisabled }),
+                            onClick: (e) => navForward(e),
+                            disabled: isDisabled,
+                            'aria-label': ariaLabel('nextPageLabel')
+                        },
+                        ptm('nextButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -612,21 +643,27 @@ export const Carousel = React.memo(
 
             const key = 'carousel-indicator-' + index;
             const indicatorProps = mergeProps(
-                {
-                    key,
-                    className: cx('indicator', { isActive }),
-                    'data-p-highlight': isActive
-                },
-                getPTOptions('indicator')
+                [
+                    {
+                        key,
+                        className: cx('indicator', { isActive }),
+                        'data-p-highlight': isActive
+                    },
+                    getPTOptions('indicator')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const indicatorButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('indicatorButton'),
-                    onClick: (e) => onDotClick(e, index),
-                    'aria-label': `${ariaLabel('pageLabel')} ${index + 1}`
-                },
-                getPTOptions('indicatorButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('indicatorButton'),
+                        onClick: (e) => onDotClick(e, index),
+                        'aria-label': `${ariaLabel('pageLabel')} ${index + 1}`
+                    },
+                    getPTOptions('indicatorButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -647,10 +684,13 @@ export const Carousel = React.memo(
                 }
 
                 const indicatorsProps = mergeProps(
-                    {
-                        className: classNames(props.indicatorsContentClassName, cx('indicators'))
-                    },
-                    ptm('indicators')
+                    [
+                        {
+                            className: classNames(props.indicatorsContentClassName, cx('indicators'))
+                        },
+                        ptm('indicators')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <ul {...indicatorsProps}>{indicators}</ul>;
@@ -664,21 +704,27 @@ export const Carousel = React.memo(
         const header = createHeader();
         const footer = createFooter();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root', { isVertical })),
-                style: props.style
-            },
-            CarouselBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root', { isVertical })),
+                    style: props.style
+                },
+                CarouselBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const contentProps = mergeProps(
-            {
-                className: classNames(props.contentClassName, cx('content'))
-            },
-            ptm('content')
+            [
+                {
+                    className: classNames(props.contentClassName, cx('content'))
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -287,29 +287,35 @@ export const CascadeSelect = React.memo(
         const createKeyboardHelper = () => {
             const value = props.value ? getOptionLabel(props.value) : undefined;
             const hiddenSelectedMessageProps = mergeProps(
-                {
-                    className: 'p-hidden-accessible'
-                },
-                ptm('hiddenSelectedMessage')
+                [
+                    {
+                        className: 'p-hidden-accessible'
+                    },
+                    ptm('hiddenSelectedMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const inputProps = mergeProps(
-                {
-                    ref: inputRef,
-                    type: 'text',
-                    id: props.inputId,
-                    name: props.name,
-                    defaultValue: value,
-                    readOnly: true,
-                    disabled: props.disabled,
-                    onFocus: onInputFocus,
-                    onBlur: onInputBlur,
-                    onKeyDown: (e) => onInputKeyDown(e),
-                    tabIndex: props.tabIndex,
-                    'aria-haspopup': 'listbox',
-                    ...ariaProps
-                },
-                ptm('input')
+                [
+                    {
+                        ref: inputRef,
+                        type: 'text',
+                        id: props.inputId,
+                        name: props.name,
+                        defaultValue: value,
+                        readOnly: true,
+                        disabled: props.disabled,
+                        onFocus: onInputFocus,
+                        onBlur: onInputBlur,
+                        onKeyDown: (e) => onInputKeyDown(e),
+                        tabIndex: props.tabIndex,
+                        'aria-haspopup': 'listbox',
+                        ...ariaProps
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -323,11 +329,14 @@ export const CascadeSelect = React.memo(
             const label = props.value ? getOptionLabel(props.value) : props.placeholder || 'p-emptylabel';
 
             const labelProps = mergeProps(
-                {
-                    ref: labelRef,
-                    className: cx('label', { label })
-                },
-                ptm('label')
+                [
+                    {
+                        ref: labelRef,
+                        className: cx('label', { label })
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...labelProps}>{label}</span>;
@@ -335,56 +344,71 @@ export const CascadeSelect = React.memo(
 
         const createDropdownIcon = () => {
             const dropdownIconProps = mergeProps(
-                {
-                    className: cx('dropdownIcon')
-                },
-                ptm('dropdownIcon')
+                [
+                    {
+                        className: cx('dropdownIcon')
+                    },
+                    ptm('dropdownIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.dropdownIcon || <ChevronDownIcon {...dropdownIconProps} />;
             const dropdownIcon = IconUtils.getJSXIcon(icon, { ...dropdownIconProps }, { props });
             const dropdownButtonProps = mergeProps(
-                {
-                    className: cx('dropdownButton'),
-                    role: 'button',
-                    'aria-haspopup': 'listbox',
-                    'aria-expanded': overlayVisibleState
-                },
-                ptm('dropdownButton')
+                [
+                    {
+                        className: cx('dropdownButton'),
+                        role: 'button',
+                        'aria-haspopup': 'listbox',
+                        'aria-expanded': overlayVisibleState
+                    },
+                    ptm('dropdownButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...dropdownButtonProps}>{dropdownIcon}</div>;
         };
 
         const wrapperProps = mergeProps(
-            {
-                className: cx('wrapper')
-            },
-            ptm('wrapper')
+            [
+                {
+                    className: cx('wrapper')
+                },
+                ptm('wrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const panelProps = mergeProps(
-            {
-                ref: overlayRef,
-                className: cx('panel'),
-                onClick: (e) => onPanelClick(e)
-            },
-            ptm('panel')
+            [
+                {
+                    ref: overlayRef,
+                    className: cx('panel'),
+                    onClick: (e) => onPanelClick(e)
+                },
+                ptm('panel')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const createOverlay = () => {
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: overlayVisibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: onOverlayEnter,
-                    onEntered: onOverlayEntered,
-                    onExit: onOverlayExit,
-                    onExited: onOverlayExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: overlayVisibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: onOverlayEnter,
+                        onEntered: onOverlayEntered,
+                        onExit: onOverlayExit,
+                        onExited: onOverlayExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const overlay = (
@@ -423,15 +447,18 @@ export const CascadeSelect = React.memo(
             const dropdownIcon = createDropdownIcon();
             const overlay = createOverlay();
             const rootProps = mergeProps(
-                {
-                    id: props.id,
-                    ref: elementRef,
-                    className: cx('root', { focusedState, overlayVisibleState }),
-                    style: props.style,
-                    onClick: (e) => onClick(e)
-                },
-                otherProps,
-                ptm('root')
+                [
+                    {
+                        id: props.id,
+                        ref: elementRef,
+                        className: cx('root', { focusedState, overlayVisibleState }),
+                        style: props.style,
+                        onClick: (e) => onClick(e)
+                    },
+                    otherProps,
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -211,40 +211,52 @@ export const CascadeSelectSub = React.memo((props) => {
     const createOption = (option, index) => {
         const submenu = createSubmenu(option);
         const textProps = mergeProps(
-            {
-                className: cx('text')
-            },
-            getPTOptions('text')
+            [
+                {
+                    className: cx('text')
+                },
+                getPTOptions('text')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const content = props.template ? ObjectUtils.getJSXElement(props.template, getOptionValue(option)) : <span {...textProps}>{getOptionLabelToRender(option)}</span>;
         const optionGroupIconProps = mergeProps(
-            {
-                className: cx('optionGroupIcon')
-            },
-            getPTOptions('optionGroupIcon')
+            [
+                {
+                    className: cx('optionGroupIcon')
+                },
+                getPTOptions('optionGroupIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.optionGroupIcon || <AngleRightIcon {...optionGroupIconProps} />;
         const optionGroup = isOptionGroup(option) && IconUtils.getJSXIcon(icon, { ...optionGroupIconProps }, { props });
         const key = getOptionLabelToRender(option) + '_' + index;
         const contentProps = mergeProps(
-            {
-                className: cx('content'),
-                onClick: (event) => onOptionClick(event, option),
-                tabIndex: 0,
-                onKeyDown: (event) => onKeyDown(event, option)
-            },
-            getPTOptions('content')
+            [
+                {
+                    className: cx('content'),
+                    onClick: (event) => onOptionClick(event, option),
+                    tabIndex: 0,
+                    onKeyDown: (event) => onKeyDown(event, option)
+                },
+                getPTOptions('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const itemProps = mergeProps(
-            {
-                className: classNames(option.className, cx('item', { option, isOptionGroup, activeOptionState })),
-                style: option.style,
-                role: 'none',
-                'data-p-item-group': isOptionGroup(option),
-                'data-p-highlight': activeOptionState === option
-            },
-            getPTOptions('item')
+            [
+                {
+                    className: classNames(option.className, cx('item', { option, isOptionGroup, activeOptionState })),
+                    style: option.style,
+                    role: 'none',
+                    'data-p-item-group': isOptionGroup(option),
+                    'data-p-highlight': activeOptionState === option
+                },
+                getPTOptions('item')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -265,13 +277,16 @@ export const CascadeSelectSub = React.memo((props) => {
 
     const submenu = createMenu();
     const listProps = mergeProps(
-        {
-            ref: elementRef,
-            className: cx(props.level === 0 ? 'list' : 'sublist', { context }),
-            role: 'listbox',
-            'aria-orientation': 'horizontal'
-        },
-        props.level === 0 ? getPTOptions('list') : getPTOptions('sublist')
+        [
+            {
+                ref: elementRef,
+                className: cx(props.level === 0 ? 'list' : 'sublist', { context }),
+                role: 'listbox',
+                'aria-orientation': 'horizontal'
+            },
+            props.level === 0 ? getPTOptions('list') : getPTOptions('sublist')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <ul {...listProps}>{submenu}</ul>;

--- a/components/lib/chart/Chart.js
+++ b/components/lib/chart/Chart.js
@@ -92,24 +92,30 @@ const PrimeReactChart = React.memo(
         const title = props.options && props.options.plugins && props.options.plugins.title && props.options.plugins.title.text;
         const ariaLabel = props.ariaLabel || title;
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: sx('root'),
-                className: cx('root')
-            },
-            ChartBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: sx('root'),
+                    className: cx('root')
+                },
+                ChartBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const canvasProps = mergeProps(
-            {
-                ref: canvasRef,
-                width: props.width,
-                height: props.height,
-                role: 'img',
-                'aria-label': ariaLabel
-            },
-            ptm('canvas')
+            [
+                {
+                    ref: canvasRef,
+                    width: props.width,
+                    height: props.height,
+                    role: 'img',
+                    'aria-label': ariaLabel
+                },
+                ptm('canvas')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -119,59 +119,74 @@ export const Checkbox = React.memo(
         const otherProps = CheckboxBase.getOtherProps(props);
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const iconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            ptm('icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                ptm('icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = checked ? props.icon || <CheckIcon {...iconProps} /> : null;
         const checkboxIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props, checked });
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: classNames(props.className, cx('root', { checked, focusedState })),
-                style: props.style,
-                onClick: (e) => onClick(e),
-                onContextMenu: props.onContextMenu,
-                onMouseDown: props.onMouseDown
-            },
-            otherProps,
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: classNames(props.className, cx('root', { checked, focusedState })),
+                    style: props.style,
+                    onClick: (e) => onClick(e),
+                    onContextMenu: props.onContextMenu,
+                    onMouseDown: props.onMouseDown
+                },
+                otherProps,
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputWrapperProps = mergeProps(
-            {
-                className: 'p-hidden-accessible'
-            },
-            ptm('hiddenInputWrapper')
+            [
+                {
+                    className: 'p-hidden-accessible'
+                },
+                ptm('hiddenInputWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputProps = mergeProps(
-            {
-                id: props.inputId,
-                type: 'checkbox',
-                name: props.name,
-                tabIndex: props.tabIndex,
-                defaultChecked: checked,
-                onFocus: (e) => onFocus(e),
-                onBlur: (e) => onBlur(e),
-                onKeyDown: (e) => onKeyDown(e),
-                disabled: props.disabled,
-                readOnly: props.readOnly,
-                required: props.required,
-                ...ariaProps
-            },
-            ptm('hiddenInput')
+            [
+                {
+                    id: props.inputId,
+                    type: 'checkbox',
+                    name: props.name,
+                    tabIndex: props.tabIndex,
+                    defaultChecked: checked,
+                    onFocus: (e) => onFocus(e),
+                    onBlur: (e) => onBlur(e),
+                    onKeyDown: (e) => onKeyDown(e),
+                    disabled: props.disabled,
+                    readOnly: props.readOnly,
+                    required: props.required,
+                    ...ariaProps
+                },
+                ptm('hiddenInput')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const inputProps = mergeProps(
-            {
-                className: cx('input', { checked, focusedState }),
-                'data-p-highlight': checked,
-                'data-p-disabled': props.disabled,
-                'data-p-focus': focusedState
-            },
-            ptm('input')
+            [
+                {
+                    className: cx('input', { checked, focusedState }),
+                    'data-p-highlight': checked,
+                    'data-p-disabled': props.disabled,
+                    'data-p-focus': focusedState
+                },
+                ptm('input')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/chip/Chip.js
+++ b/components/lib/chip/Chip.js
@@ -36,36 +36,45 @@ export const Chip = React.memo(
             let content = [];
 
             const removeIconProps = mergeProps(
-                {
-                    key: 'removeIcon',
-                    tabIndex: 0,
-                    className: cx('removeIcon'),
-                    onClick: close,
-                    onKeyDown
-                },
-                ptm('removeIcon')
+                [
+                    {
+                        key: 'removeIcon',
+                        tabIndex: 0,
+                        className: cx('removeIcon'),
+                        onClick: close,
+                        onKeyDown
+                    },
+                    ptm('removeIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.removeIcon || <TimesCircleIcon {...removeIconProps} />;
 
             if (props.image) {
                 const imageProps = mergeProps(
-                    {
-                        key: 'image',
-                        src: props.image,
-                        onError: props.onImageError
-                    },
-                    ptm('image')
+                    [
+                        {
+                            key: 'image',
+                            src: props.image,
+                            onError: props.onImageError
+                        },
+                        ptm('image')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 content.push(<img alt={props.imageAlt} {...imageProps}></img>);
             } else if (props.icon) {
                 const chipIconProps = mergeProps(
-                    {
-                        key: 'icon',
-                        className: cx('icon')
-                    },
-                    ptm('icon')
+                    [
+                        {
+                            key: 'icon',
+                            className: cx('icon')
+                        },
+                        ptm('icon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 content.push(IconUtils.getJSXIcon(props.icon, { ...chipIconProps }, { props }));
@@ -73,11 +82,14 @@ export const Chip = React.memo(
 
             if (props.label) {
                 const labelProps = mergeProps(
-                    {
-                        key: 'label',
-                        className: cx('label')
-                    },
-                    ptm('label')
+                    [
+                        {
+                            key: 'label',
+                            className: cx('label')
+                        },
+                        ptm('label')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 content.push(<span {...labelProps}>{props.label}</span>);
@@ -94,13 +106,16 @@ export const Chip = React.memo(
             const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : createContent();
 
             const rootProps = mergeProps(
-                {
-                    ref: elementRef,
-                    style: props.style,
-                    className: classNames(props.className, cx('root'))
-                },
-                ChipBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: elementRef,
+                        style: props.style,
+                        className: classNames(props.className, cx('root'))
+                    },
+                    ChipBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...rootProps}>{content}</div>;

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -228,11 +228,14 @@ export const Chips = React.memo(
 
         const createRemoveIcon = (value, index) => {
             const iconProps = mergeProps(
-                {
-                    className: cx('removeTokenIcon'),
-                    onClick: (event) => removeItem(event, index)
-                },
-                ptm('removeTokenIcon')
+                [
+                    {
+                        className: cx('removeTokenIcon'),
+                        onClick: (event) => removeItem(event, index)
+                    },
+                    ptm('removeTokenIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.removeIcon || <TimesCircleIcon {...iconProps} />;
             const removeIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
@@ -247,20 +250,26 @@ export const Chips = React.memo(
         const createItem = (value, index) => {
             const content = props.itemTemplate ? props.itemTemplate(value) : value;
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = <span {...labelProps}>{content}</span>;
             const icon = createRemoveIcon(value, index);
             const tokenProps = mergeProps(
-                {
-                    key: index,
-                    className: cx('token'),
-                    'data-p-highlight': true
-                },
-                ptm('token')
+                [
+                    {
+                        key: index,
+                        className: cx('token'),
+                        'data-p-highlight': true
+                    },
+                    ptm('token')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -273,28 +282,34 @@ export const Chips = React.memo(
 
         const createInput = () => {
             const inputTokenProps = mergeProps(
-                {
-                    className: cx('inputToken')
-                },
-                ptm('inputToken')
+                [
+                    {
+                        className: cx('inputToken')
+                    },
+                    ptm('inputToken')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const inputProps = mergeProps(
-                {
-                    id: props.inputId,
-                    ref: inputRef,
-                    placeholder: props.placeholder,
-                    type: 'text',
-                    name: props.name,
-                    disabled: props.disabled || isMaxedOut(),
-                    onKeyDown: (e) => onKeyDown(e),
-                    onPaste: (e) => onPaste(e),
-                    onFocus: (e) => onFocus(e),
-                    onBlur: (e) => onBlur(e),
-                    readOnly: props.readOnly,
-                    ...ariaProps
-                },
-                ptm('input')
+                [
+                    {
+                        id: props.inputId,
+                        ref: inputRef,
+                        placeholder: props.placeholder,
+                        type: 'text',
+                        name: props.name,
+                        disabled: props.disabled || isMaxedOut(),
+                        onKeyDown: (e) => onKeyDown(e),
+                        onPaste: (e) => onPaste(e),
+                        onFocus: (e) => onFocus(e),
+                        onBlur: (e) => onBlur(e),
+                        readOnly: props.readOnly,
+                        ...ariaProps
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -312,14 +327,17 @@ export const Chips = React.memo(
             const items = createItems();
             const input = createInput();
             const containerProps = mergeProps(
-                {
-                    ref: listRef,
-                    className: cx('container', { focusedState }),
-                    onClick: (e) => onWrapperClick(e),
-                    'data-p-disabled': props.disabled,
-                    'data-p-focus': focusedState
-                },
-                ptm('container')
+                [
+                    {
+                        ref: listRef,
+                        className: cx('container', { focusedState }),
+                        onClick: (e) => onWrapperClick(e),
+                        'data-p-disabled': props.disabled,
+                        'data-p-focus': focusedState
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -335,13 +353,16 @@ export const Chips = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const list = createList();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root', { isFilled, focusedState })),
-                style: props.style
-            },
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root', { isFilled, focusedState })),
+                    style: props.style
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -533,30 +533,39 @@ export const ColorPicker = React.memo(
 
         const createColorSelector = () => {
             const selectorProps = mergeProps(
-                {
-                    ref: colorSelectorRef,
-                    className: cx('selector'),
-                    onMouseDown: (e) => onColorMousedown(e),
-                    onTouchStart: (e) => onColorDragStart(e),
-                    onTouchMove: (e) => onDrag(e),
-                    onTouchEnd: onDragEnd
-                },
-                ptm('selector')
+                [
+                    {
+                        ref: colorSelectorRef,
+                        className: cx('selector'),
+                        onMouseDown: (e) => onColorMousedown(e),
+                        onTouchStart: (e) => onColorDragStart(e),
+                        onTouchMove: (e) => onDrag(e),
+                        onTouchEnd: onDragEnd
+                    },
+                    ptm('selector')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const colorProps = mergeProps(
-                {
-                    className: cx('color')
-                },
-                ptm('color')
+                [
+                    {
+                        className: cx('color')
+                    },
+                    ptm('color')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const colorHandlerProps = mergeProps(
-                {
-                    ref: colorHandleRef,
-                    className: cx('colorHandle')
-                },
-                ptm('colorHandle')
+                [
+                    {
+                        ref: colorHandleRef,
+                        className: cx('colorHandle')
+                    },
+                    ptm('colorHandle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -570,21 +579,27 @@ export const ColorPicker = React.memo(
 
         const createHue = () => {
             const hueProps = mergeProps(
-                {
-                    className: cx('hue'),
-                    onMouseDown: (e) => onHueMousedown(e),
-                    onTouchStart: (e) => onHueDragStart(e),
-                    onTouchMove: (e) => onDrag(e),
-                    onTouchEnd: onDragEnd
-                },
-                ptm('hue')
+                [
+                    {
+                        className: cx('hue'),
+                        onMouseDown: (e) => onHueMousedown(e),
+                        onTouchStart: (e) => onHueDragStart(e),
+                        onTouchMove: (e) => onDrag(e),
+                        onTouchEnd: onDragEnd
+                    },
+                    ptm('hue')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const hueHandlerProps = mergeProps(
-                {
-                    className: cx('hueHandle')
-                },
-                ptm('hueHandle')
+                [
+                    {
+                        className: cx('hueHandle')
+                    },
+                    ptm('hueHandle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -598,10 +613,13 @@ export const ColorPicker = React.memo(
             const colorSelector = createColorSelector();
             const hue = createHue();
             const contentProps = mergeProps(
-                {
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -616,20 +634,23 @@ export const ColorPicker = React.memo(
             if (!props.inline) {
                 const inputProps = ColorPickerBase.getOtherProps(props);
                 const _inputProps = mergeProps(
-                    {
-                        ref: inputRef,
-                        type: 'text',
-                        readOnly: true,
-                        className: cx('input'),
-                        style: props.inputStyle,
-                        id: props.inputId,
-                        tabIndex: props.tabIndex,
-                        disabled: props.disabled,
-                        onClick: onInputClick,
-                        onKeyDown: onInputKeydown,
-                        ...inputProps
-                    },
-                    ptm('input')
+                    [
+                        {
+                            ref: inputRef,
+                            type: 'text',
+                            readOnly: true,
+                            className: cx('input'),
+                            style: props.inputStyle,
+                            id: props.inputId,
+                            tabIndex: props.tabIndex,
+                            disabled: props.disabled,
+                            onClick: onInputClick,
+                            onKeyDown: onInputKeydown,
+                            ...inputProps
+                        },
+                        ptm('input')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <input {..._inputProps} />;
@@ -642,14 +663,17 @@ export const ColorPicker = React.memo(
         const content = createContent();
         const input = createInput();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: props.style,
-                className: cx('root')
-            },
-            ColorPickerBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: props.style,
+                    className: cx('root')
+                },
+                ColorPickerBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/colorpicker/ColorPickerPanel.js
+++ b/components/lib/colorpicker/ColorPickerPanel.js
@@ -10,27 +10,33 @@ export const ColorPickerPanel = React.forwardRef((props, ref) => {
 
     const createElement = () => {
         const panelProps = mergeProps(
-            {
-                className: cx('panel', { panelProps: props, context }),
-                style: props.panelStyle,
-                onClick: props.onClick
-            },
-            ptm('panel', { hostName: props.hostName })
+            [
+                {
+                    className: cx('panel', { panelProps: props, context }),
+                    style: props.panelStyle,
+                    onClick: props.onClick
+                },
+                ptm('panel', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: props.in,
-                timeout: { enter: 120, exit: 100 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: props.onEnter,
-                onEntered: props.onEntered,
-                onExit: props.onExit,
-                onExited: props.onExited
-            },
-            ptm('transition', { hostName: props.hostName })
+            [
+                {
+                    classNames: cx('transition'),
+                    in: props.in,
+                    timeout: { enter: 120, exit: 100 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: props.onEnter,
+                    onEntered: props.onEntered,
+                    onExit: props.onExit,
+                    onExited: props.onExited
+                },
+                ptm('transition', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -532,7 +532,7 @@ export const ComponentBase = {
 
             return mergeSections || (!mergeSections && self)
                 ? useMergeProps
-                    ? mergeProps(globalPT, self, Object.keys(datasetProps).length ? datasetProps : {})
+                    ? mergeProps([globalPT, self, Object.keys(datasetProps).length ? datasetProps : {}], { useTailwind: ComponentBase.context.useTailwind })
                     : { ...globalPT, ...self, ...(Object.keys(datasetProps).length ? datasetProps : {}) }
                 : { ...self, ...(Object.keys(datasetProps).length ? datasetProps : {}) };
         };
@@ -555,7 +555,7 @@ export const ComponentBase = {
                     const self = getOptionValue(css && css.inlineStyles, key, { props, state, ...params });
                     const base = getOptionValue(inlineStyles, key, { props, state, ...params });
 
-                    return mergeProps(base, self);
+                    return mergeProps([base, self], { useTailwind: ComponentBase.context.useTailwind });
                 }
 
                 return undefined;
@@ -613,7 +613,7 @@ const _usePT = (pt, callback, key, params) => {
         else if (ObjectUtils.isString(value)) return value;
         else if (ObjectUtils.isString(originalValue)) return originalValue;
 
-        return mergeSections || (!mergeSections && value) ? (useMergeProps ? mergeProps(originalValue, value) : { ...originalValue, ...value }) : value;
+        return mergeSections || (!mergeSections && value) ? (useMergeProps ? mergeProps([originalValue, value], { useTailwind: ComponentBase.context.useTailwind }) : { ...originalValue, ...value }) : value;
     }
 
     return fn(pt);

--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -148,17 +148,20 @@ export const ConfirmDialog = React.memo(
             };
 
             const acceptButtonProps = mergeProps(
-                {
-                    label: acceptLabel,
-                    icon: getPropValue('acceptIcon'),
-                    className: classNames(getPropValue('acceptClassName'), cx('acceptButton')),
-                    onClick: accept,
-                    unstyled: props.unstyled,
-                    __parentMetadata: {
-                        parent: metaData
-                    }
-                },
-                ptm('acceptButton')
+                [
+                    {
+                        label: acceptLabel,
+                        icon: getPropValue('acceptIcon'),
+                        className: classNames(getPropValue('acceptClassName'), cx('acceptButton')),
+                        onClick: accept,
+                        unstyled: props.unstyled,
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    },
+                    ptm('acceptButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const content = (
@@ -191,37 +194,46 @@ export const ConfirmDialog = React.memo(
             const message = ObjectUtils.getJSXElement(getPropValue('message'), currentProps);
 
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = IconUtils.getJSXIcon(getPropValue('icon'), { ...iconProps }, { props: currentProps });
             const footer = createFooter();
 
             const messageProps = mergeProps(
-                {
-                    className: cx('message')
-                },
-                ptm('message')
+                [
+                    {
+                        className: cx('message')
+                    },
+                    ptm('message')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const rootProps = mergeProps(
-                {
-                    visible: visibleState,
-                    className: classNames(getPropValue('className'), cx('root')),
-                    footer,
-                    onHide: hide,
-                    breakpoints: getPropValue('breakpoints'),
-                    pt: currentProps.pt,
-                    unstyled: props.unstyled,
-                    appendTo: getPropValue('appendTo'),
-                    __parentMetadata: {
-                        parent: metaData
-                    }
-                },
-                ConfirmDialogBase.getOtherProps(currentProps)
+                [
+                    {
+                        visible: visibleState,
+                        className: classNames(getPropValue('className'), cx('root')),
+                        footer,
+                        onHide: hide,
+                        breakpoints: getPropValue('breakpoints'),
+                        pt: currentProps.pt,
+                        unstyled: props.unstyled,
+                        appendTo: getPropValue('appendTo'),
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    },
+                    ConfirmDialogBase.getOtherProps(currentProps)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -233,25 +233,34 @@ export const ConfirmPopup = React.memo(
             const message = ObjectUtils.getJSXElement(getPropValue('message'), currentProps);
 
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = IconUtils.getJSXIcon(getPropValue('icon'), { ...iconProps }, { props: currentProps });
             const messageProps = mergeProps(
-                {
-                    className: cx('message')
-                },
-                ptm('message')
+                [
+                    {
+                        className: cx('message')
+                    },
+                    ptm('message')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const contentProps = mergeProps(
-                {
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -273,36 +282,49 @@ export const ConfirmPopup = React.memo(
             );
 
             const footerProps = mergeProps(
-                {
-                    className: cx('footer')
-                },
-                ptm('footer')
+                [
+                    {
+                        className: cx('footer')
+                    },
+                    ptm('footer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
-            const rejectButtonProps = mergeProps({
-                label: rejectLabel,
-                icon: getPropValue('rejectIcon'),
-                className: cx('rejectButton', { getPropValue }),
-                onClick: reject,
-                pt: ptm('rejectButton'),
-                unstyled: props.unstyled,
-                __parentMetadata: {
-                    parent: metaData
-                }
-            });
+            const rejectButtonProps = mergeProps(
+                [
+                    {
+                        label: rejectLabel,
+                        icon: getPropValue('rejectIcon'),
+                        className: cx('rejectButton', { getPropValue }),
+                        onClick: reject,
+                        pt: ptm('rejectButton'),
+                        unstyled: props.unstyled,
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    }
+                ],
+                { useTailwind: context.useTailwind }
+            );
 
-            const acceptButtonProps = mergeProps({
-                ref: acceptBtnRef,
-                label: acceptLabel,
-                icon: getPropValue('acceptIcon'),
-                className: cx('acceptButton', { getPropValue }),
-                onClick: accept,
-                pt: ptm('acceptButton'),
-                unstyled: props.unstyled,
-                __parentMetadata: {
-                    parent: metaData
-                }
-            });
+            const acceptButtonProps = mergeProps(
+                [
+                    {
+                        ref: acceptBtnRef,
+                        label: acceptLabel,
+                        icon: getPropValue('acceptIcon'),
+                        className: cx('acceptButton', { getPropValue }),
+                        onClick: accept,
+                        pt: ptm('acceptButton'),
+                        unstyled: props.unstyled,
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    }
+                ],
+                { useTailwind: context.useTailwind }
+            );
 
             const content = (
                 <div {...footerProps}>
@@ -335,30 +357,36 @@ export const ConfirmPopup = React.memo(
             const footer = createFooter();
 
             const rootProps = mergeProps(
-                {
-                    ref: overlayRef,
-                    id: getPropValue('id'),
-                    className: cx('root', { context, getPropValue }),
-                    style: getPropValue('style'),
-                    onClick: onPanelClick
-                },
-                ConfirmPopupBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: overlayRef,
+                        id: getPropValue('id'),
+                        className: cx('root', { context, getPropValue }),
+                        style: getPropValue('style'),
+                        onClick: onPanelClick
+                    },
+                    ConfirmPopupBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: visibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: getPropValue('transitionOptions'),
-                    unmountOnExit: true,
-                    onEnter,
-                    onEntered,
-                    onExit,
-                    onExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: visibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: getPropValue('transitionOptions'),
+                        unmountOnExit: true,
+                        onEnter,
+                        onEntered,
+                        onExit,
+                        onExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/contextmenu/ContextMenu.js
+++ b/components/lib/contextmenu/ContextMenu.js
@@ -267,30 +267,36 @@ export const ContextMenu = React.memo(
 
         const createContextMenu = () => {
             const rootProps = mergeProps(
-                {
-                    id: props.id,
-                    className: classNames(props.className, cx('root', { context })),
-                    style: props.style,
-                    onClick: (e) => onMenuClick(e),
-                    onMouseEnter: (e) => onMenuMouseEnter(e)
-                },
-                ContextMenuBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        id: props.id,
+                        className: classNames(props.className, cx('root', { context })),
+                        style: props.style,
+                        onClick: (e) => onMenuClick(e),
+                        onMouseEnter: (e) => onMenuMouseEnter(e)
+                    },
+                    ContextMenuBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: visibleState,
-                    timeout: { enter: 250, exit: 0 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: onEnter,
-                    onEntered: onEntered,
-                    onExit: onExit,
-                    onExited: onExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: visibleState,
+                        timeout: { enter: 250, exit: 0 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: onEnter,
+                        onEntered: onEntered,
+                        onExit: onExit,
+                        onExited: onExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/contextmenu/ContextMenuSub.js
+++ b/components/lib/contextmenu/ContextMenuSub.js
@@ -3,9 +3,11 @@ import { CSSTransition } from '../csstransition/CSSTransition';
 import { useUpdateEffect } from '../hooks/Hooks';
 import { AngleRightIcon } from '../icons/angleright';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const ContextMenuSub = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [activeItemState, setActiveItemState] = React.useState(null);
     const submenuRef = React.useRef(null);
     const active = props.root || !props.resetMenu;
@@ -96,13 +98,16 @@ export const ContextMenuSub = React.memo((props) => {
     const createSeparator = (index) => {
         const key = props.id + '_separator_' + index;
         const separatorProps = mergeProps(
-            {
-                id: key,
-                key,
-                className: cx('separator'),
-                role: 'separator'
-            },
-            ptm('separator', { hostName: props.hostName })
+            [
+                {
+                    id: key,
+                    key,
+                    className: cx('separator'),
+                    role: 'separator'
+                },
+                ptm('separator', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...separatorProps}></li>;
@@ -137,39 +142,51 @@ export const ContextMenuSub = React.memo((props) => {
         const active = activeItemState === item;
         const key = item.id || props.id + '_' + index;
         const iconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            getPTOptions(item, 'icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                getPTOptions(item, 'icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props: props.menuProps });
         const submenuIconProps = mergeProps(
-            {
-                className: cx('submenuIcon')
-            },
-            getPTOptions(item, 'submenuIcon')
+            [
+                {
+                    className: cx('submenuIcon')
+                },
+                getPTOptions(item, 'submenuIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions(item, 'label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions(item, 'label')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(props.submenuIcon || <AngleRightIcon {...submenuIconProps} />, { ...submenuIconProps }, { props: props.menuProps });
         const label = item.label && <span {...labelProps}>{item.label}</span>;
         const submenu = createSubmenu(item, index);
         const actionProps = mergeProps(
-            {
-                href: item.url || '#',
-                className: cx('action', { item }),
-                target: item.target,
-                onClick: (event) => onItemClick(event, item, index),
-                role: 'menuitem',
-                'aria-haspopup': item.items != null,
-                'aria-disabled': item.disabled
-            },
-            getPTOptions(item, 'action')
+            [
+                {
+                    href: item.url || '#',
+                    className: cx('action', { item }),
+                    target: item.target,
+                    onClick: (event) => onItemClick(event, item, index),
+                    role: 'menuitem',
+                    'aria-haspopup': item.items != null,
+                    'aria-disabled': item.disabled
+                },
+                getPTOptions(item, 'action')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -197,16 +214,19 @@ export const ContextMenuSub = React.memo((props) => {
         }
 
         const menuitemProps = mergeProps(
-            {
-                id: key,
-                key,
-                role: 'none',
-                className: cx('menuitem', { item, active }),
-                style: item.style,
-                key,
-                onMouseEnter: (event) => onItemMouseEnter(event, item)
-            },
-            getPTOptions(item, 'menuitem')
+            [
+                {
+                    id: key,
+                    key,
+                    role: 'none',
+                    className: cx('menuitem', { item, active }),
+                    style: item.style,
+                    key,
+                    onMouseEnter: (event) => onItemMouseEnter(event, item)
+                },
+                getPTOptions(item, 'menuitem')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -227,21 +247,27 @@ export const ContextMenuSub = React.memo((props) => {
 
     const submenu = createMenu();
     const menuProps = mergeProps(
-        {
-            className: cx('menu', { menuProps: props })
-        },
-        ptm('menu', { hostName: props.hostName })
+        [
+            {
+                className: cx('menu', { menuProps: props })
+            },
+            ptm('menu', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const transitionProps = mergeProps(
-        {
-            classNames: cx('submenuTransition'),
-            in: active,
-            timeout: { enter: 0, exit: 0 },
-            unmountOnExit: true,
-            onEnter
-        },
-        ptm('menu.transition', { hostName: props.hostName })
+        [
+            {
+                classNames: cx('submenuTransition'),
+                in: active,
+                timeout: { enter: 0, exit: 0 },
+                unmountOnExit: true,
+                onEnter
+            },
+            ptm('menu.transition', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datascroller/DataScroller.js
+++ b/components/lib/datascroller/DataScroller.js
@@ -162,10 +162,13 @@ export const DataScroller = React.memo(
 
         const createHeader = () => {
             const headerProps = mergeProps(
-                {
-                    className: cx('header')
-                },
-                ptm('header')
+                [
+                    {
+                        className: cx('header')
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.header) {
@@ -177,10 +180,13 @@ export const DataScroller = React.memo(
 
         const createFooter = () => {
             const footerProps = mergeProps(
-                {
-                    className: cx('footer')
-                },
-                ptm('footer')
+                [
+                    {
+                        className: cx('footer')
+                    },
+                    ptm('footer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.footer) {
@@ -192,10 +198,13 @@ export const DataScroller = React.memo(
 
         const createItem = (_value, index) => {
             const itemProps = mergeProps(
-                {
-                    key: index + '_datascrollitem'
-                },
-                ptm('item')
+                [
+                    {
+                        key: index + '_datascrollitem'
+                    },
+                    ptm('item')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const content = props.itemTemplate ? props.itemTemplate(_value) : _value;
 
@@ -203,7 +212,7 @@ export const DataScroller = React.memo(
         };
 
         const createEmptyMessage = () => {
-            const emptyMessageProps = mergeProps(ptm('emptyMessage'));
+            const emptyMessageProps = mergeProps([ptm('emptyMessage')], { useTailwind: context.useTailwind });
 
             const content = ObjectUtils.getJSXElement(props.emptyMessage, props) || localeOption('emptyMessage');
 
@@ -212,18 +221,24 @@ export const DataScroller = React.memo(
 
         const createContent = () => {
             const contentProps = mergeProps(
-                {
-                    ref: contentRef,
-                    className: cx('content'),
-                    style: sx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        ref: contentRef,
+                        className: cx('content'),
+                        style: sx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const listProps = mergeProps(
-                {
-                    className: cx('list')
-                },
-                ptm('list')
+                [
+                    {
+                        className: cx('list')
+                    },
+                    ptm('list')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const content = ObjectUtils.isNotEmpty(dataToRenderState) ? dataToRenderState.map(createItem) : createEmptyMessage();
 
@@ -239,13 +254,16 @@ export const DataScroller = React.memo(
         const content = createContent();
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root'))
-            },
-            DataScrollerBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root'))
+                },
+                DataScrollerBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ariaLabel } from '../api/Api';
+import { ariaLabel, PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { useEventListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { BarsIcon } from '../icons/bars';
@@ -15,6 +15,7 @@ import { RowCheckbox } from './RowCheckbox';
 import { RowRadioButton } from './RowRadioButton';
 
 export const BodyCell = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [editingState, setEditingState] = React.useState(props.editing);
     const [editingRowDataState, setEditingRowDataState] = React.useState(props.rowData);
     const [styleObjectState, setStyleObjectState] = React.useState({});
@@ -48,7 +49,7 @@ export const BodyCell = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const field = getColumnProp('field') || `field_${props.index}`;
@@ -546,7 +547,7 @@ export const BodyCell = React.memo((props) => {
             field: field
         });
         const content = ObjectUtils.getJSXElement(getVirtualScrollerOption('loadingTemplate'), options);
-        const bodyCellProps = mergeProps(getColumnPTOptions('bodyCell'));
+        const bodyCellProps = mergeProps([getColumnPTOptions('bodyCell')], { useTailwind: context.useTailwind });
 
         return <td {...bodyCellProps}>{content}</td>;
     };
@@ -571,10 +572,13 @@ export const BodyCell = React.memo((props) => {
         const bodyClassName = ObjectUtils.getPropValue(getColumnProp('bodyClassName'), props.rowData, columnBodyOptions);
         const style = getStyle();
         const columnTitleProps = mergeProps(
-            {
-                className: cx('columnTitle')
-            },
-            getColumnPTOptions('columnTitle')
+            [
+                {
+                    className: cx('columnTitle')
+                },
+                getColumnPTOptions('columnTitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const title = props.responsiveLayout === 'stack' && <span {...columnTitleProps}>{ObjectUtils.getJSXElement(header, { props: props.tableProps })}</span>;
@@ -625,21 +629,27 @@ export const BodyCell = React.memo((props) => {
         } else if (rowReorder) {
             const showReorder = props.showRowReorderElement ? props.showRowReorderElement(props.rowData, { rowIndex: props.rowIndex, props: props.tableProps }) : true;
             const rowReorderIconProps = mergeProps(
-                {
-                    className: cx('rowReorderIcon')
-                },
-                getColumnPTOptions('rowReorderIcon')
+                [
+                    {
+                        className: cx('rowReorderIcon')
+                    },
+                    getColumnPTOptions('rowReorderIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const rowReorderIcon = getColumnProp('rowReorderIcon') || <BarsIcon {...rowReorderIconProps} />;
 
             content = showReorder ? IconUtils.getJSXIcon(rowReorderIcon, { ...rowReorderIconProps }, { props }) : null;
         } else if (expander) {
             const rowTogglerIconProps = mergeProps(
-                {
-                    className: cx('rowTogglerIcon'),
-                    'aria-hidden': true
-                },
-                getColumnPTOptions('rowTogglerIcon')
+                [
+                    {
+                        className: cx('rowTogglerIcon'),
+                        'aria-hidden': true
+                    },
+                    getColumnPTOptions('rowTogglerIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.expanded ? props.expandedRowIcon || <ChevronDownIcon {...rowTogglerIconProps} /> : props.collapsedRowIcon || <ChevronRightIcon {...rowTogglerIconProps} />;
             const togglerIcon = IconUtils.getJSXIcon(icon, { ...rowTogglerIconProps }, { props });
@@ -652,15 +662,18 @@ export const BodyCell = React.memo((props) => {
                 className: cx('rowToggler')
             };
             const rowTogglerProps = mergeProps(
-                {
-                    ...expanderProps,
-                    type: 'button',
-                    'aria-expanded': props.expanded,
-                    'aria-controls': ariaControls,
-                    tabIndex: props.tabIndex,
-                    'aria-label': label
-                },
-                getColumnPTOptions('rowToggler')
+                [
+                    {
+                        ...expanderProps,
+                        type: 'button',
+                        'aria-expanded': props.expanded,
+                        'aria-controls': ariaControls,
+                        tabIndex: props.tabIndex,
+                        'aria-label': label
+                    },
+                    getColumnPTOptions('rowToggler')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             content = (
@@ -676,9 +689,9 @@ export const BodyCell = React.memo((props) => {
             }
         } else if (isRowEditor && rowEditor) {
             let rowEditorProps = {};
-            const rowEditorSaveIconProps = mergeProps({ className: cx('rowEditorSaveIcon') }, getColumnPTOptions('rowEditorSaveIcon'));
-            const rowEditorCancelIconProps = mergeProps({ className: cx('rowEditorCancelIcon') }, getColumnPTOptions('rowEditorCancelIcon'));
-            const rowEditorInitIconProps = mergeProps({ className: cx('rowEditorInitIcon') }, getColumnPTOptions('rowEditorInitIcon'));
+            const rowEditorSaveIconProps = mergeProps([{ className: cx('rowEditorSaveIcon') }, getColumnPTOptions('rowEditorSaveIcon')], { useTailwind: context.useTailwind });
+            const rowEditorCancelIconProps = mergeProps([{ className: cx('rowEditorCancelIcon') }, getColumnPTOptions('rowEditorCancelIcon')], { useTailwind: context.useTailwind });
+            const rowEditorInitIconProps = mergeProps([{ className: cx('rowEditorInitIcon') }, getColumnPTOptions('rowEditorInitIcon')], { useTailwind: context.useTailwind });
             const rowEditorSaveIcon = IconUtils.getJSXIcon(props.rowEditorSaveIcon || <CheckIcon {...rowEditorSaveIconProps} />, { ...rowEditorSaveIconProps }, { props });
             const rowEditorCancelIcon = IconUtils.getJSXIcon(props.rowEditorCancelIcon || <TimesIcon {...rowEditorCancelIconProps} />, { ...rowEditorCancelIconProps }, { props });
             const rowEditorInitIcon = IconUtils.getJSXIcon(props.rowEditorInitIcon || <PencilIcon {...rowEditorInitIconProps} />, { ...rowEditorInitIconProps }, { props });
@@ -693,26 +706,32 @@ export const BodyCell = React.memo((props) => {
                 };
 
                 const rowEditorSaveButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        name: 'row-save',
-                        onClick: rowEditorProps.onSaveClick,
-                        className: rowEditorProps.saveClassName,
-                        tabIndex: props.tabIndex,
-                        'data-p-row-editor-save': true
-                    },
-                    getColumnPTOptions('rowEditorSaveButton')
+                    [
+                        {
+                            type: 'button',
+                            name: 'row-save',
+                            onClick: rowEditorProps.onSaveClick,
+                            className: rowEditorProps.saveClassName,
+                            tabIndex: props.tabIndex,
+                            'data-p-row-editor-save': true
+                        },
+                        getColumnPTOptions('rowEditorSaveButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const rowEditorCancelButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        name: 'row-cancel',
-                        onClick: rowEditorProps.onCancelClick,
-                        className: rowEditorProps.cancelClassName,
-                        tabIndex: props.tabIndex
-                    },
-                    getColumnPTOptions('rowEditorCancelButton')
+                    [
+                        {
+                            type: 'button',
+                            name: 'row-cancel',
+                            onClick: rowEditorProps.onCancelClick,
+                            className: rowEditorProps.cancelClassName,
+                            tabIndex: props.tabIndex
+                        },
+                        getColumnPTOptions('rowEditorCancelButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 content = (
@@ -735,15 +754,18 @@ export const BodyCell = React.memo((props) => {
                 };
 
                 const rowEditorInitButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        name: 'row-edit',
-                        onClick: rowEditorProps.onInitClick,
-                        className: rowEditorProps.initClassName,
-                        tabIndex: props.tabIndex,
-                        'data-p-row-editor-init': true
-                    },
-                    getColumnPTOptions('rowEditorInitButton')
+                    [
+                        {
+                            type: 'button',
+                            name: 'row-edit',
+                            onClick: rowEditorProps.onInitClick,
+                            className: rowEditorProps.initClassName,
+                            tabIndex: props.tabIndex,
+                            'data-p-row-editor-init': true
+                        },
+                        getColumnPTOptions('rowEditorInitButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 content = (
@@ -779,15 +801,18 @@ export const BodyCell = React.memo((props) => {
 
         if (!isRowEditor && editor) {
             const editorKeyHelperProps = mergeProps(
-                {
-                    tabIndex: '0',
-                    className: 'p-cell-editor-key-helper p-hidden-accessible',
-                    onFocus: (e) => onEditorFocus(e)
-                },
-                getColumnPTOptions('editorKeyHelperLabel')
+                [
+                    {
+                        tabIndex: '0',
+                        className: 'p-cell-editor-key-helper p-hidden-accessible',
+                        onFocus: (e) => onEditorFocus(e)
+                    },
+                    getColumnPTOptions('editorKeyHelperLabel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
-            const editorKeyHelperLabelProps = mergeProps(getColumnPTOptions('editorKeyHelper'));
+            const editorKeyHelperLabelProps = mergeProps([getColumnPTOptions('editorKeyHelper')], { useTailwind: context.useTailwind });
             /* eslint-disable */
             editorKeyHelper = (
                 <a ref={keyHelperRef} {...editorKeyHelperProps}>
@@ -798,25 +823,28 @@ export const BodyCell = React.memo((props) => {
         }
 
         const bodyCellProps = mergeProps(
-            {
-                style,
-                className: classNames(bodyClassName, getColumnProp('className'), cellClassName, cx('bodyCell', { selectionMode, editor, editingState, frozen, cellSelected, align, bodyProps: props, getCellParams })),
-                rowSpan: props.rowSpan,
-                tabIndex,
-                role: 'cell',
-                onClick: (e) => onClick(e),
-                onKeyDown: (e) => onKeyDown(e),
-                onBlur: (e) => onBlur(e),
-                onMouseDown: (e) => onMouseDown(e),
-                onMouseUp: (e) => onMouseUp(e),
-                'data-p-selectable-cell': props.allowCellSelection && props.isSelectable({ data: getCellParams(), index: props.rowIndex }),
-                'data-p-selection-column': getColumnProp('selectionMode') != null,
-                'data-p-editable-column': isEditable() != null,
-                'data-p-cell-editing': editingState,
-                'data-p-frozen-column': frozen
-            },
-            getColumnPTOptions('root'),
-            getColumnPTOptions('bodyCell')
+            [
+                {
+                    style,
+                    className: classNames(bodyClassName, getColumnProp('className'), cellClassName, cx('bodyCell', { selectionMode, editor, editingState, frozen, cellSelected, align, bodyProps: props, getCellParams })),
+                    rowSpan: props.rowSpan,
+                    tabIndex,
+                    role: 'cell',
+                    onClick: (e) => onClick(e),
+                    onKeyDown: (e) => onKeyDown(e),
+                    onBlur: (e) => onBlur(e),
+                    onMouseDown: (e) => onMouseDown(e),
+                    onMouseUp: (e) => onMouseUp(e),
+                    'data-p-selectable-cell': props.allowCellSelection && props.isSelectable({ data: getCellParams(), index: props.rowIndex }),
+                    'data-p-selection-column': getColumnProp('selectionMode') != null,
+                    'data-p-editable-column': isEditable() != null,
+                    'data-p-cell-editing': editingState,
+                    'data-p-frozen-column': frozen
+                },
+                getColumnPTOptions('root'),
+                getColumnPTOptions('bodyCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, DomHandler, mergeProps, ObjectUtils } from '../utils/Utils';
 import { BodyCell } from './BodyCell';
 
 export const BodyRow = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [editingState, setEditingState] = React.useState(false);
     const editing = props.onRowEditChange ? props.editing : editingState;
     const { ptm, cx } = props.ptCallbacks;
@@ -388,32 +390,35 @@ export const BodyRow = React.memo((props) => {
     const content = createContent();
     const tabIndex = getTabIndex();
     const rowProps = mergeProps(
-        {
-            role: 'row',
-            tabIndex: tabIndex,
-            className: classNames(rowClassName, cx('bodyRow', { rowProps: props })),
-            style: style,
-            onMouseDown: (e) => onMouseDown(e),
-            onMouseUp: (e) => onMouseUp(e),
-            onMouseEnter: (e) => onMouseEnter(e),
-            onMouseLeave: (e) => onMouseLeave(e),
-            onClick: (e) => onClick(e),
-            onDoubleClick: (e) => onDoubleClick(e),
-            onPointerDown: (e) => onPointerDown(e),
-            onPointerUp: (e) => onPointerUp(e),
-            onContextMenu: (e) => onRightClick(e),
-            onTouchEnd: (e) => onTouchEnd(e),
-            onKeyDown: (e) => onKeyDown(e),
-            onDragStart: (e) => onDragStart(e),
-            onDragOver: (e) => onDragOver(e),
-            onDragLeave: (e) => onDragLeave(e),
-            onDragEnd: (e) => onDragEnd(e),
-            onDrop: (e) => onDrop(e),
-            'data-p-selectable-row': props.allowRowSelection && props.isSelectable({ data: props.rowData, index: props.rowIndex }),
-            'data-p-highlight': props.selected,
-            'data-p-highlight-contextmenu': props.contextMenuSelected
-        },
-        getBodyRowPTOptions('bodyRow')
+        [
+            {
+                role: 'row',
+                tabIndex: tabIndex,
+                className: classNames(rowClassName, cx('bodyRow', { rowProps: props })),
+                style: style,
+                onMouseDown: (e) => onMouseDown(e),
+                onMouseUp: (e) => onMouseUp(e),
+                onMouseEnter: (e) => onMouseEnter(e),
+                onMouseLeave: (e) => onMouseLeave(e),
+                onClick: (e) => onClick(e),
+                onDoubleClick: (e) => onDoubleClick(e),
+                onPointerDown: (e) => onPointerDown(e),
+                onPointerUp: (e) => onPointerUp(e),
+                onContextMenu: (e) => onRightClick(e),
+                onTouchEnd: (e) => onTouchEnd(e),
+                onKeyDown: (e) => onKeyDown(e),
+                onDragStart: (e) => onDragStart(e),
+                onDragOver: (e) => onDragOver(e),
+                onDragLeave: (e) => onDragLeave(e),
+                onDragEnd: (e) => onDragEnd(e),
+                onDrop: (e) => onDrop(e),
+                'data-p-selectable-row': props.allowRowSelection && props.isSelectable({ data: props.rowData, index: props.rowIndex }),
+                'data-p-highlight': props.selected,
+                'data-p-highlight-contextmenu': props.contextMenuSelected
+            },
+            getBodyRowPTOptions('bodyRow')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <tr {...rowProps}>{content}</tr>;

--- a/components/lib/datatable/ColumnFilter.js
+++ b/components/lib/datatable/ColumnFilter.js
@@ -39,7 +39,7 @@ export const ColumnFilter = React.memo((props) => {
             ...params
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const field = getColumnProp('filterField') || getColumnProp('field');
@@ -505,10 +505,13 @@ export const ColumnFilter = React.memo((props) => {
         if (props.display === 'row') {
             const content = createFilterElement(filterModel, 0);
             const filterInputProps = mergeProps(
-                {
-                    className: cx('filterInput')
-                },
-                getColumnPTOptions('filterInput')
+                [
+                    {
+                        className: cx('filterInput')
+                    },
+                    getColumnPTOptions('filterInput')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...filterInputProps}>{content}</div>;
@@ -527,30 +530,36 @@ export const ColumnFilter = React.memo((props) => {
         }
 
         const filterIconProps = mergeProps(
-            {
-                'aria-hidden': true
-            },
-            getColumnPTOptions('filterIcon')
+            [
+                {
+                    'aria-hidden': true
+                },
+                getColumnPTOptions('filterIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.filterIcon || <FilterIcon {...filterIconProps} />;
         const columnFilterIcon = IconUtils.getJSXIcon(icon, { ...filterIconProps }, { props });
 
         const label = filterLabel();
         const filterMenuButtonProps = mergeProps(
-            {
-                type: 'button',
-                className: cx('filterMenuButton', { overlayVisibleState, hasFilter }),
-                'aria-haspopup': true,
-                'aria-expanded': overlayVisibleState,
-                onClick: (e) => toggleMenu(e),
-                onKeyDown: (e) => onToggleButtonKeyDown(e),
-                'aria-label': label
-            },
-            getColumnPTOptions('filterMenuButton', {
-                context: {
-                    active: hasFilter()
-                }
-            })
+            [
+                {
+                    type: 'button',
+                    className: cx('filterMenuButton', { overlayVisibleState, hasFilter }),
+                    'aria-haspopup': true,
+                    'aria-expanded': overlayVisibleState,
+                    onClick: (e) => toggleMenu(e),
+                    onKeyDown: (e) => onToggleButtonKeyDown(e),
+                    'aria-label': label
+                },
+                getColumnPTOptions('filterMenuButton', {
+                    context: {
+                        active: hasFilter()
+                    }
+                })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -567,10 +576,13 @@ export const ColumnFilter = React.memo((props) => {
         }
 
         const filterClearIconProps = mergeProps(
-            {
-                'aria-hidden': true
-            },
-            getColumnPTOptions('filterClearIcon')
+            [
+                {
+                    'aria-hidden': true
+                },
+                getColumnPTOptions('filterClearIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.filterClearIcon || <FilterSlashIcon {...filterClearIconProps} />;
         const filterClearIcon = IconUtils.getJSXIcon(icon, { ...filterClearIconProps }, { props });
@@ -578,17 +590,20 @@ export const ColumnFilter = React.memo((props) => {
         if (getColumnProp('showClearButton') && props.display === 'row') {
             const clearLabel = clearButtonLabel();
             const headerFilterClearButtonProps = mergeProps(
-                {
-                    className: cx('headerFilterClearButton', { hasRowFilter }),
-                    type: 'button',
-                    onClick: (e) => clearFilter(e),
-                    'aria-label': clearLabel
-                },
-                getColumnPTOptions('headerFilterClearButton', {
-                    context: {
-                        hidden: hasRowFilter()
-                    }
-                })
+                [
+                    {
+                        className: cx('headerFilterClearButton', { hasRowFilter }),
+                        type: 'button',
+                        onClick: (e) => clearFilter(e),
+                        'aria-label': clearLabel
+                    },
+                    getColumnPTOptions('headerFilterClearButton', {
+                        context: {
+                            hidden: hasRowFilter()
+                        }
+                    })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -607,27 +622,36 @@ export const ColumnFilter = React.memo((props) => {
             const _matchModes = matchModes();
             const _noFilterLabel = noFilterLabel();
             const filterSeparatorProps = mergeProps(
-                {
-                    className: cx('filterSeparator'),
-                    'data-p-column-filter-separator': true
-                },
-                getColumnPTOptions('filterSeparator')
+                [
+                    {
+                        className: cx('filterSeparator'),
+                        'data-p-column-filter-separator': true
+                    },
+                    getColumnPTOptions('filterSeparator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const filterRowItemProps = mergeProps(
-                {
-                    className: cx('filterRowItem', { isRowMatchModeSelected, isShowMatchModes }),
-                    onClick: (e) => clearFilter(e),
-                    onKeyDown: (e) => onRowMatchModeKeyDown(e, null, true)
-                },
-                getColumnPTOptions('filterRowItem')
+                [
+                    {
+                        className: cx('filterRowItem', { isRowMatchModeSelected, isShowMatchModes }),
+                        onClick: (e) => clearFilter(e),
+                        onKeyDown: (e) => onRowMatchModeKeyDown(e, null, true)
+                    },
+                    getColumnPTOptions('filterRowItem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const filterRowItemsProps = mergeProps(
-                {
-                    className: cx('filterRowItems')
-                },
-                getColumnPTOptions('filterRowItems')
+                [
+                    {
+                        className: cx('filterRowItems')
+                    },
+                    getColumnPTOptions('filterRowItems')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -636,17 +660,20 @@ export const ColumnFilter = React.memo((props) => {
                         const { value, label } = matchMode;
                         const tabIndex = i === 0 ? 0 : null;
                         const filterRowItemProps = mergeProps(
-                            {
-                                className: cx('filterRowItem', { isRowMatchModeSelected, isShowMatchModes, value }),
-                                onClick: () => onRowMatchModeChange(value),
-                                onKeyDown: (e) => onRowMatchModeKeyDown(e, matchMode),
-                                tabIndex
-                            },
-                            getColumnPTOptions('filterRowItem', {
-                                context: {
-                                    highlighted: matchMode && isRowMatchModeSelected(value)
-                                }
-                            })
+                            [
+                                {
+                                    className: cx('filterRowItem', { isRowMatchModeSelected, isShowMatchModes, value }),
+                                    onClick: () => onRowMatchModeChange(value),
+                                    onKeyDown: (e) => onRowMatchModeKeyDown(e, matchMode),
+                                    tabIndex
+                                },
+                                getColumnPTOptions('filterRowItem', {
+                                    context: {
+                                        highlighted: matchMode && isRowMatchModeSelected(value)
+                                    }
+                                })
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
 
                         return (
@@ -669,10 +696,13 @@ export const ColumnFilter = React.memo((props) => {
             const options = operatorOptions();
             const value = operator();
             const filterOperatorProps = mergeProps(
-                {
-                    className: cx('filterOperator')
-                },
-                getColumnPTOptions('filterOperator')
+                [
+                    {
+                        className: cx('filterOperator')
+                    },
+                    getColumnPTOptions('filterOperator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -737,17 +767,23 @@ export const ColumnFilter = React.memo((props) => {
     const createConstraints = () => {
         const _fieldConstraints = fieldConstraints();
         const filterConstraintsProps = mergeProps(
-            {
-                className: cx('filterConstraints')
-            },
-            getColumnPTOptions('filterConstraints')
+            [
+                {
+                    className: cx('filterConstraints')
+                },
+                getColumnPTOptions('filterConstraints')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const filterConstraintProps = mergeProps(
-            {
-                className: cx('filterConstraint')
-            },
-            getColumnPTOptions('filterConstraint')
+            [
+                {
+                    className: cx('filterConstraint')
+                },
+                getColumnPTOptions('filterConstraint')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -756,7 +792,7 @@ export const ColumnFilter = React.memo((props) => {
                     const matchModeDropdown = createMatchModeDropdown(fieldConstraint, i);
                     const menuFilterElement = createMenuFilterElement(fieldConstraint, i);
                     const removeButton = createRemoveButton(i);
-                    const filterRemoveProps = mergeProps(getColumnPTOptions('filterRemove'));
+                    const filterRemoveProps = mergeProps([getColumnPTOptions('filterRemove')], { useTailwind: context.useTailwind });
 
                     return (
                         <div {...filterConstraintProps} key={i}>
@@ -774,10 +810,13 @@ export const ColumnFilter = React.memo((props) => {
         if (isShowAddConstraint()) {
             const addRuleLabel = addRuleButtonLabel();
             const filterAddRuleProps = mergeProps(
-                {
-                    className: cx('filterAddRule')
-                },
-                getColumnPTOptions('filterAddRule')
+                [
+                    {
+                        className: cx('filterAddRule')
+                    },
+                    getColumnPTOptions('filterAddRule')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -831,10 +870,13 @@ export const ColumnFilter = React.memo((props) => {
         const clearButton = createFilterClearButton();
         const applyButton = createFilterApplyButton();
         const filterButtonbarProps = mergeProps(
-            {
-                className: cx('filterButtonBar')
-            },
-            getColumnPTOptions('filterButtonBar')
+            [
+                {
+                    className: cx('filterButtonBar')
+                },
+                getColumnPTOptions('filterButtonBar')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -867,28 +909,34 @@ export const ColumnFilter = React.memo((props) => {
         const filterFooter = ObjectUtils.getJSXElement(getColumnProp('filterFooter'), { field, filterModel, filterApplyCallback });
         const items = props.display === 'row' ? createRowItems() : createItems();
         const filterOverlayProps = mergeProps(
-            {
-                style,
-                className: cx('filterOverlay', { columnFilterProps: props, context, getColumnProp }),
-                onKeyDown: (e) => onContentKeyDown(e),
-                onClick: (e) => onContentClick(e),
-                onMouseDown: (e) => onContentMouseDown(e)
-            },
-            getColumnPTOptions('filterOverlay')
+            [
+                {
+                    style,
+                    className: cx('filterOverlay', { columnFilterProps: props, context, getColumnProp }),
+                    onKeyDown: (e) => onContentKeyDown(e),
+                    onClick: (e) => onContentClick(e),
+                    onMouseDown: (e) => onContentMouseDown(e)
+                },
+                getColumnPTOptions('filterOverlay')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: overlayVisibleState,
-                timeout: { enter: 120, exit: 100 },
-                unmountOnExit: true,
-                onEnter: onOverlayEnter,
-                onEntered: onOverlayEntered,
-                onExit: onOverlayExit,
-                onExited: onOverlayExited
-            },
-            getColumnPTOptions('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: overlayVisibleState,
+                    timeout: { enter: 120, exit: 100 },
+                    unmountOnExit: true,
+                    onEnter: onOverlayEnter,
+                    onEntered: onOverlayEntered,
+                    onExit: onOverlayExit,
+                    onExited: onOverlayExited
+                },
+                getColumnPTOptions('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -909,10 +957,13 @@ export const ColumnFilter = React.memo((props) => {
     const clearButton = createClearButton();
     const overlay = createOverlay();
     const columnFilter = mergeProps(
-        {
-            className: cx('columnFilter', { columnFilterProps: props })
-        },
-        getColumnPTOptions('columnFilter')
+        [
+            {
+                className: cx('columnFilter', { columnFilterProps: props })
+            },
+            getColumnPTOptions('columnFilter')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1493,18 +1493,24 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const createLoader = () => {
         if (props.loading) {
             const loadingIconProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('loadingIcon')
-                },
-                ptCallbacks.ptm('loadingIcon')
+                [
+                    {
+                        className: ptCallbacks.cx('loadingIcon')
+                    },
+                    ptCallbacks.ptm('loadingIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
             const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
             const loadingOverlayProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('loadingOverlay')
-                },
-                ptCallbacks.ptm('loadingOverlay')
+                [
+                    {
+                        className: ptCallbacks.cx('loadingOverlay')
+                    },
+                    ptCallbacks.ptm('loadingOverlay')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...loadingOverlayProps}>{loadingIcon}</div>;
@@ -1517,10 +1523,13 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         if (props.header) {
             const content = ObjectUtils.getJSXElement(props.header, { props });
             const headerProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('header')
-                },
-                ptCallbacks.ptm('header')
+                [
+                    {
+                        className: ptCallbacks.cx('header')
+                    },
+                    ptCallbacks.ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...headerProps}>{content}</div>;
@@ -1781,11 +1790,14 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         const _isVirtualScrollerDisabled = isVirtualScrollerDisabled();
         const virtualScrollerOptions = props.virtualScrollerOptions || {};
         const wrapperProps = mergeProps(
-            {
-                className: ptCallbacks.cx('wrapper'),
-                style: { ...ptCallbacks.sx('wrapper'), maxHeight: _isVirtualScrollerDisabled ? props.scrollHeight : null }
-            },
-            ptCallbacks.ptm('wrapper')
+            [
+                {
+                    className: ptCallbacks.cx('wrapper'),
+                    style: { ...ptCallbacks.sx('wrapper'), maxHeight: _isVirtualScrollerDisabled ? props.scrollHeight : null }
+                },
+                ptCallbacks.ptm('wrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -1814,12 +1826,15 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                         const tableBody = createTableBody(options, selectionModeInColumn, empty, _isVirtualScrollerDisabled);
                         const tableFooter = createTableFooter(options);
                         const tableProps = mergeProps(
-                            {
-                                className: classNames(props.tableClassName, ptCallbacks.cx('table')),
-                                style: props.tableStyle,
-                                role: 'table'
-                            },
-                            ptCallbacks.ptm('table')
+                            [
+                                {
+                                    className: classNames(props.tableClassName, ptCallbacks.cx('table')),
+                                    style: props.tableStyle,
+                                    role: 'table'
+                                },
+                                ptCallbacks.ptm('table')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
 
                         return (
@@ -1839,10 +1854,13 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         if (props.footer) {
             const content = ObjectUtils.getJSXElement(props.footer, { props });
             const footerProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('footer')
-                },
-                ptCallbacks.ptm('footer')
+                [
+                    {
+                        className: ptCallbacks.cx('footer')
+                    },
+                    ptCallbacks.ptm('footer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...footerProps}>{content}</div>;
@@ -1893,11 +1911,14 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const createResizeHelper = () => {
         if (props.resizableColumns) {
             const resizeHelperProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('resizeHelper'),
-                    style: ptCallbacks.sx('resizeHelper')
-                },
-                ptCallbacks.ptm('resizeHelper')
+                [
+                    {
+                        className: ptCallbacks.cx('resizeHelper'),
+                        style: ptCallbacks.sx('resizeHelper')
+                    },
+                    ptCallbacks.ptm('resizeHelper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div ref={resizeHelperRef} {...resizeHelperProps}></div>;
@@ -1910,22 +1931,28 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         if (props.reorderableColumns) {
             const style = { position: 'absolute', display: 'none' };
             const reorderIndicatorUpProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('reorderIndicatorUp'),
-                    style: ptCallbacks.sx('reorderIndicatorUp', { style })
-                },
-                ptCallbacks.ptm('reorderIndicatorUp')
+                [
+                    {
+                        className: ptCallbacks.cx('reorderIndicatorUp'),
+                        style: ptCallbacks.sx('reorderIndicatorUp', { style })
+                    },
+                    ptCallbacks.ptm('reorderIndicatorUp')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const reorderIndicatorUpIconProps = mergeProps(ptCallbacks.ptm('reorderIndicatorUpIcon'));
+            const reorderIndicatorUpIconProps = mergeProps([ptCallbacks.ptm('reorderIndicatorUpIcon')], { useTailwind: context.useTailwind });
             const reorderIndicatorUpIcon = IconUtils.getJSXIcon(props.reorderIndicatorUpIcon || <ArrowDownIcon {...reorderIndicatorUpIconProps} />, { ...reorderIndicatorUpIconProps }, { props });
             const reorderIndicatorDownProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('reorderIndicatorDown'),
-                    style: ptCallbacks.sx('reorderIndicatorDown', { style })
-                },
-                ptCallbacks.ptm('reorderIndicatorDown')
+                [
+                    {
+                        className: ptCallbacks.cx('reorderIndicatorDown'),
+                        style: ptCallbacks.sx('reorderIndicatorDown', { style })
+                    },
+                    ptCallbacks.ptm('reorderIndicatorDown')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const reorderIndicatorDownIconProps = mergeProps(ptCallbacks.ptm('reorderIndicatorDownIcon'));
+            const reorderIndicatorDownIconProps = mergeProps([ptCallbacks.ptm('reorderIndicatorDownIcon')], { useTailwind: context.useTailwind });
             const reorderIndicatorDownIcon = IconUtils.getJSXIcon(props.reorderIndicatorDownIcon || <ArrowUpIcon {...reorderIndicatorDownIconProps} />, { ...reorderIndicatorDownIconProps }, { props });
 
             return (
@@ -1959,14 +1986,17 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const resizeHelper = createResizeHelper();
     const reorderIndicators = createReorderIndicators();
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            className: classNames(props.className, ptCallbacks.cx('root', { selectable })),
-            style: props.style,
-            'data-scrollselectors': '.p-datatable-wrapper'
-        },
-        DataTableBase.getOtherProps(props),
-        ptCallbacks.ptm('root')
+        [
+            {
+                id: props.id,
+                className: classNames(props.className, ptCallbacks.cx('root', { selectable })),
+                style: props.style,
+                'data-scrollselectors': '.p-datatable-wrapper'
+            },
+            DataTableBase.getOtherProps(props),
+            ptCallbacks.ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/FooterCell.js
+++ b/components/lib/datatable/FooterCell.js
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { classNames, DomHandler, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const FooterCell = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [styleObjectState, setStyleObjectState] = React.useState({});
     const elementRef = React.useRef(null);
     const getColumnProps = () => ColumnBase.getCProps(props.column);
@@ -24,7 +26,7 @@ export const FooterCell = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const getColumnProp = (name) => ColumnBase.getCProp(props.column, name);
@@ -79,15 +81,18 @@ export const FooterCell = React.memo((props) => {
     const rowSpan = getColumnProp('rowSpan');
     const content = ObjectUtils.getJSXElement(getColumnProp('footer'), { props: props.tableProps });
     const footerCellProps = mergeProps(
-        {
-            style,
-            className: classNames(getColumnProp('footerClassName'), getColumnProp('className'), cx('footerCell', { getColumnProp, align })),
-            role: 'cell',
-            colSpan,
-            rowSpan
-        },
-        getColumnPTOptions('root'),
-        getColumnPTOptions('footerCell')
+        [
+            {
+                style,
+                className: classNames(getColumnProp('footerClassName'), getColumnProp('className'), cx('footerCell', { getColumnProp, align })),
+                role: 'cell',
+                colSpan,
+                rowSpan
+            },
+            getColumnPTOptions('root'),
+            getColumnPTOptions('footerCell')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/HeaderCell.js
+++ b/components/lib/datatable/HeaderCell.js
@@ -5,11 +5,13 @@ import { SortAltIcon } from '../icons/sortalt';
 import { SortAmountDownIcon } from '../icons/sortamountdown';
 import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 import { Tooltip } from '../tooltip/Tooltip';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 import { ColumnFilter } from './ColumnFilter';
 import { HeaderCheckbox } from './HeaderCheckbox';
 
 export const HeaderCell = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [styleObjectState, setStyleObjectState] = React.useState({});
     const elementRef = React.useRef(null);
     const prevColumn = usePrevious(props.column);
@@ -38,7 +40,7 @@ export const HeaderCell = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const isBadgeVisible = () => {
@@ -230,13 +232,16 @@ export const HeaderCell = React.memo((props) => {
     const createResizer = () => {
         if (props.resizableColumns && !getColumnProp('frozen')) {
             const columnResizerProps = mergeProps(
-                {
-                    className: cx('columnResizer'),
-                    onMouseDown: (e) => onResizerMouseDown(e),
-                    onClick: (e) => onResizerClick(e),
-                    onDoubleClick: (e) => onResizerDoubleClick(e)
-                },
-                getColumnPTOptions('columnResizer')
+                [
+                    {
+                        className: cx('columnResizer'),
+                        onMouseDown: (e) => onResizerMouseDown(e),
+                        onClick: (e) => onResizerClick(e),
+                        onDoubleClick: (e) => onResizerDoubleClick(e)
+                    },
+                    getColumnPTOptions('columnResizer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...columnResizerProps}></span>;
@@ -248,10 +253,13 @@ export const HeaderCell = React.memo((props) => {
     const createTitle = () => {
         const title = ObjectUtils.getJSXElement(getColumnProp('header'), { props: props.tableProps });
         const headerTitleProps = mergeProps(
-            {
-                className: cx('headerTitle')
-            },
-            getColumnPTOptions('headerTitle')
+            [
+                {
+                    className: cx('headerTitle')
+                },
+                getColumnPTOptions('headerTitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <span {...headerTitleProps}>{title}</span>;
@@ -260,13 +268,16 @@ export const HeaderCell = React.memo((props) => {
     const createSortIcon = ({ sorted, sortOrder }) => {
         if (getColumnProp('sortable')) {
             const sortIconProps = mergeProps(
-                {
-                    className: cx('sortIcon')
-                },
-                getColumnPTOptions('sortIcon')
+                [
+                    {
+                        className: cx('sortIcon')
+                    },
+                    getColumnPTOptions('sortIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
-            const sortProps = mergeProps(getColumnPTOptions('sort'));
+            const sortProps = mergeProps([getColumnPTOptions('sort')], { useTailwind: context.useTailwind });
 
             let icon = sorted ? sortOrder < 0 ? <SortAmountDownIcon {...sortIconProps} /> : <SortAmountUpAltIcon {...sortIconProps} /> : <SortAltIcon {...sortIconProps} />;
             let sortIcon = IconUtils.getJSXIcon(props.sortIcon || icon, { ...sortIconProps }, { props, sorted, sortOrder });
@@ -281,11 +292,14 @@ export const HeaderCell = React.memo((props) => {
         if (metaIndex !== -1 && isBadgeVisible()) {
             const value = props.groupRowsBy && props.groupRowsBy === props.groupRowSortField ? metaIndex : metaIndex + 1;
             const sortBadgeProps = mergeProps(
-                {
-                    className: cx('sortBadge')
-                },
-                getColumnPTOptions('root'),
-                getColumnPTOptions('sortBadge')
+                [
+                    {
+                        className: cx('sortBadge')
+                    },
+                    getColumnPTOptions('root'),
+                    getColumnPTOptions('sortBadge')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...sortBadgeProps}>{value}</span>;
@@ -334,10 +348,13 @@ export const HeaderCell = React.memo((props) => {
         const checkbox = createCheckbox();
         const filter = createFilter();
         const headerContentProps = mergeProps(
-            {
-                className: cx('headerContent')
-            },
-            getColumnPTOptions('headerContent')
+            [
+                {
+                    className: cx('headerContent')
+                },
+                getColumnPTOptions('headerContent')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -369,30 +386,33 @@ export const HeaderCell = React.memo((props) => {
         const resizer = createResizer();
         const header = createHeader(sortMeta);
         const headerCellProps = mergeProps(
-            {
-                className: classNames(headerClassName, cx('headerCell', { headerProps: props, frozen, sortMeta, align, _isSortableDisabled, getColumnProp })),
-                style,
-                role: 'columnheader',
-                onClick: (e) => onClick(e),
-                onKeyDown: (e) => onKeyDown(e),
-                onMouseDown: (e) => onMouseDown(e),
-                onDragStart: (e) => onDragStart(e),
-                onDragOver: (e) => onDragOver(e),
-                onDragLeave: (e) => onDragLeave(e),
-                onDrop: (e) => onDrop(e),
-                tabIndex,
-                colSpan,
-                rowSpan,
-                'aria-sort': ariaSort,
-                'data-p-sortable-column': getColumnProp('sortable'),
-                'data-p-resizable-column': props.resizableColumns,
-                'data-p-highlight': sortMeta.sorted,
-                'data-p-filter-column': !props.metaData.props.headerColumnGroup && props.filterDisplay === 'row',
-                'data-p-frozen-column': getColumnProp('frozen'),
-                'data-p-reorderable-column': props.reorderableColumns
-            },
-            getColumnPTOptions('root'),
-            getColumnPTOptions('headerCell')
+            [
+                {
+                    className: classNames(headerClassName, cx('headerCell', { headerProps: props, frozen, sortMeta, align, _isSortableDisabled, getColumnProp })),
+                    style,
+                    role: 'columnheader',
+                    onClick: (e) => onClick(e),
+                    onKeyDown: (e) => onKeyDown(e),
+                    onMouseDown: (e) => onMouseDown(e),
+                    onDragStart: (e) => onDragStart(e),
+                    onDragOver: (e) => onDragOver(e),
+                    onDragLeave: (e) => onDragLeave(e),
+                    onDrop: (e) => onDrop(e),
+                    tabIndex,
+                    colSpan,
+                    rowSpan,
+                    'aria-sort': ariaSort,
+                    'data-p-sortable-column': getColumnProp('sortable'),
+                    'data-p-resizable-column': props.resizableColumns,
+                    'data-p-highlight': sortMeta.sorted,
+                    'data-p-filter-column': !props.metaData.props.headerColumnGroup && props.filterDisplay === 'row',
+                    'data-p-frozen-column': getColumnProp('frozen'),
+                    'data-p-reorderable-column': props.reorderableColumns
+                },
+                getColumnPTOptions('root'),
+                getColumnPTOptions('headerCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/datatable/HeaderCheckbox.js
+++ b/components/lib/datatable/HeaderCheckbox.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, mergeProps } from '../utils/Utils';
 import { CheckIcon } from '../icons/check';
 import { ColumnBase } from '../column/ColumnBase';
 
 export const HeaderCheckbox = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [focusedState, setFocusedState] = React.useState(false);
     const getColumnProps = () => ColumnBase.getCProps(props.column);
     const { ptm, ptmo, cx } = props.ptCallbacks;
@@ -24,7 +26,7 @@ export const HeaderCheckbox = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const onFocus = () => {
@@ -55,33 +57,42 @@ export const HeaderCheckbox = React.memo((props) => {
     };
 
     const headerCheckboxIconProps = mergeProps(
-        {
-            className: cx('headerCheckboxIcon')
-        },
-        getColumnPTOptions('headerCheckboxIcon')
+        [
+            {
+                className: cx('headerCheckboxIcon')
+            },
+            getColumnPTOptions('headerCheckboxIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.checked ? props.checkIcon || <CheckIcon {...headerCheckboxIconProps} /> : null;
     const checkIcon = IconUtils.getJSXIcon(icon, { ...headerCheckboxIconProps }, { props });
     const tabIndex = props.disabled ? null : 0;
     const headerCheckboxWrapperProps = mergeProps(
-        {
-            className: cx('headerCheckboxWrapper'),
-            onClick: (e) => onClick(e)
-        },
-        getColumnPTOptions('headerCheckboxWrapper')
+        [
+            {
+                className: cx('headerCheckboxWrapper'),
+                onClick: (e) => onClick(e)
+            },
+            getColumnPTOptions('headerCheckboxWrapper')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const headerCheckboxProps = mergeProps(
-        {
-            className: cx('headerCheckbox', { headerProps: props, focusedState }),
-            role: 'checkbox',
-            'aria-checked': props.checked,
-            tabIndex: tabIndex,
-            onFocus: (e) => onFocus(e),
-            onBlur: (e) => onBlur(e),
-            onKeyDown: (e) => onKeyDown(e)
-        },
-        getColumnPTOptions('headerCheckbox')
+        [
+            {
+                className: cx('headerCheckbox', { headerProps: props, focusedState }),
+                role: 'checkbox',
+                'aria-checked': props.checked,
+                tabIndex: tabIndex,
+                onFocus: (e) => onFocus(e),
+                onBlur: (e) => onBlur(e),
+                onKeyDown: (e) => onKeyDown(e)
+            },
+            getColumnPTOptions('headerCheckbox')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/RowCheckbox.js
+++ b/components/lib/datatable/RowCheckbox.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
 import { CheckIcon } from '../icons/check';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, mergeProps } from '../utils/Utils';
 
 export const RowCheckbox = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [focusedState, setFocusedState] = React.useState(false);
     const getColumnProps = () => ColumnBase.getCProps(props.column);
     const { ptm, ptmo, cx } = props.ptCallbacks;
@@ -23,7 +25,7 @@ export const RowCheckbox = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(getColumnProps(), key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(getColumnProps(), key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const onFocus = () => {
@@ -52,34 +54,43 @@ export const RowCheckbox = React.memo((props) => {
     };
 
     const checkboxIconProps = mergeProps(
-        {
-            className: cx('checkboxIcon')
-        },
-        getColumnPTOptions('checkboxIcon')
+        [
+            {
+                className: cx('checkboxIcon')
+            },
+            getColumnPTOptions('checkboxIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.checked ? props.checkIcon || <CheckIcon {...checkboxIconProps} /> : null;
     const checkIcon = IconUtils.getJSXIcon(icon, { ...checkboxIconProps }, { props });
     const tabIndex = props.disabled ? null : '0';
     const checkboxWrapperProps = mergeProps(
-        {
-            className: cx('checkboxWrapper', { rowProps: props, focusedState }),
-            onClick: (e) => onClick(e)
-        },
-        getColumnPTOptions('checkboxWrapper')
+        [
+            {
+                className: cx('checkboxWrapper', { rowProps: props, focusedState }),
+                onClick: (e) => onClick(e)
+            },
+            getColumnPTOptions('checkboxWrapper')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const checkboxProps = mergeProps(
-        {
-            className: cx('checkbox', { rowProps: props, focusedState }),
-            role: 'checkbox',
-            'aria-checked': props.checked,
-            tabIndex: tabIndex,
-            onKeyDown: (e) => onKeyDown(e),
-            onFocus: (e) => onFocus(e),
-            onBlur: (e) => onBlur(e),
-            'aria-label': props.ariaLabel
-        },
-        getColumnPTOptions('checkbox')
+        [
+            {
+                className: cx('checkbox', { rowProps: props, focusedState }),
+                role: 'checkbox',
+                'aria-checked': props.checked,
+                tabIndex: tabIndex,
+                onKeyDown: (e) => onKeyDown(e),
+                onFocus: (e) => onFocus(e),
+                onBlur: (e) => onBlur(e),
+                'aria-label': props.ariaLabel
+            },
+            getColumnPTOptions('checkbox')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/RowRadioButton.js
+++ b/components/lib/datatable/RowRadioButton.js
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { DomHandler, mergeProps } from '../utils/Utils';
 
 export const RowRadioButton = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [focusedState, setFocusedState] = React.useState(false);
     const inputRef = React.useRef(null);
     const getColumnProps = () => ColumnBase.getCProps(props.column);
@@ -23,7 +25,7 @@ export const RowRadioButton = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(getColumnProps(), key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(getColumnProps(), key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const onFocus = () => {
@@ -56,47 +58,62 @@ export const RowRadioButton = React.memo((props) => {
 
     const name = `${props.tableSelector}_dt_radio`;
     const radiobuttonWrapperProps = mergeProps(
-        {
-            className: cx('radiobuttonWrapper', { rowProps: props, focusedState })
-        },
-        getColumnPTOptions('radiobuttonWrapper')
+        [
+            {
+                className: cx('radiobuttonWrapper', { rowProps: props, focusedState })
+            },
+            getColumnPTOptions('radiobuttonWrapper')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const hiddenInputWrapperProps = mergeProps(
-        {
-            className: 'p-hidden-accessible'
-        },
-        getColumnPTOptions('hiddenInputWrapper')
+        [
+            {
+                className: 'p-hidden-accessible'
+            },
+            getColumnPTOptions('hiddenInputWrapper')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const hiddenInputProps = mergeProps(
-        {
-            name,
-            type: 'radio',
-            checked: props.checked,
-            onFocus: (e) => onFocus(e),
-            onBlur: (e) => onBlur(e),
-            onChange: (e) => onChange(e),
-            onKeyDown: (e) => onKeyDown(e),
-            'aria-label': props.ariaLabel
-        },
-        getColumnPTOptions('hiddenInput')
+        [
+            {
+                name,
+                type: 'radio',
+                checked: props.checked,
+                onFocus: (e) => onFocus(e),
+                onBlur: (e) => onBlur(e),
+                onChange: (e) => onChange(e),
+                onKeyDown: (e) => onKeyDown(e),
+                'aria-label': props.ariaLabel
+            },
+            getColumnPTOptions('hiddenInput')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const radiobuttonProps = mergeProps(
-        {
-            className: cx('radiobutton', { rowProps: props, focusedState }),
-            onClick: (e) => onClick(e),
-            role: 'radio',
-            'aria-checked': props.checked
-        },
-        getColumnPTOptions('radiobutton')
+        [
+            {
+                className: cx('radiobutton', { rowProps: props, focusedState }),
+                onClick: (e) => onClick(e),
+                role: 'radio',
+                'aria-checked': props.checked
+            },
+            getColumnPTOptions('radiobutton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const radiobuttonIconProps = mergeProps(
-        {
-            className: cx('radiobuttonIcon')
-        },
-        getColumnPTOptions('radiobuttonIcon')
+        [
+            {
+                className: cx('radiobuttonIcon')
+            },
+            getColumnPTOptions('radiobuttonIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/RowTogglerButton.js
+++ b/components/lib/datatable/RowTogglerButton.js
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { ariaLabel } from '../api/Api';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, mergeProps } from '../utils/Utils';
 import { ChevronDownIcon } from '../icons/chevrondown';
 import { ChevronRightIcon } from '../icons/chevronright';
 import { ColumnBase } from '../column/ColumnBase';
 
 export const RowTogglerButton = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const { ptm, ptmo, cx } = props.ptCallbacks;
 
     const onClick = (event) => {
@@ -26,28 +28,34 @@ export const RowTogglerButton = React.memo((props) => {
             hostName: props.hostName
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const rowGroupTogglerIconProps = mergeProps(
-        {
-            className: cx('rowGroupTogglerIcon'),
-            'aria-hidden': true
-        },
-        getColumnPTOptions('rowGroupTogglerIcon')
+        [
+            {
+                className: cx('rowGroupTogglerIcon'),
+                'aria-hidden': true
+            },
+            getColumnPTOptions('rowGroupTogglerIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.expanded ? props.expandedRowIcon || <ChevronDownIcon {...rowGroupTogglerIconProps} /> : props.collapsedRowIcon || <ChevronRightIcon {...rowGroupTogglerIconProps} />;
     const togglerIcon = IconUtils.getJSXIcon(icon, { ...rowGroupTogglerIconProps }, { props });
     const label = props.expanded ? ariaLabel('collapseLabel') : ariaLabel('expandLabel');
     const rowGroupTogglerProps = mergeProps(
-        {
-            type: 'button',
-            onClick: (e) => onClick(e),
-            className: cx('rowGroupToggler'),
-            tabIndex: props.tabIndex,
-            'aria-label': label
-        },
-        getColumnPTOptions('rowGroupToggler')
+        [
+            {
+                type: 'button',
+                onClick: (e) => onClick(e),
+                className: cx('rowGroupToggler'),
+                tabIndex: props.tabIndex,
+                'aria-label': label
+            },
+            getColumnPTOptions('rowGroupToggler')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -2,12 +2,15 @@ import * as React from 'react';
 import { localeOption } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
+import { PrimeReactContext } from '../api/Api';
+
 import { DomHandler, ObjectUtils, mergeProps } from '../utils/Utils';
 import { BodyRow } from './BodyRow';
 import { RowTogglerButton } from './RowTogglerButton';
 
 export const TableBody = React.memo(
     React.forwardRef((props, ref) => {
+        const context = React.useContext(PrimeReactContext);
         const { ptm, ptmo, cx, isUnsyled } = props.ptCallbacks;
         const [rowGroupHeaderStyleObjectState, setRowGroupHeaderStyleObjectState] = React.useState({});
         const getColumnProps = (column) => ColumnBase.getCProps(column);
@@ -23,7 +26,7 @@ export const TableBody = React.memo(
                 }
             };
 
-            return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+            return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
         };
 
         const elementRef = React.useRef(null);
@@ -867,20 +870,26 @@ export const TableBody = React.memo(
                 const colSpan = getColumnsLength();
                 const content = ObjectUtils.getJSXElement(props.emptyMessage, { props: props.tableProps, frozen: props.frozenRow }) || localeOption('emptyMessage');
                 const emptyMessageProps = mergeProps(
-                    {
-                        className: cx('emptyMessage'),
-                        role: 'row'
-                    },
-                    getColumnPTOptions('emptyMessage')
+                    [
+                        {
+                            className: cx('emptyMessage'),
+                            role: 'row'
+                        },
+                        getColumnPTOptions('emptyMessage')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const bodyCellProps = mergeProps(
-                    {
-                        colSpan,
-                        role: 'cell'
-                    },
-                    getColumnPTOptions('root'),
-                    getColumnPTOptions('bodyCell')
+                    [
+                        {
+                            colSpan,
+                            role: 'cell'
+                        },
+                        getColumnPTOptions('root'),
+                        getColumnPTOptions('bodyCell')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -914,18 +923,24 @@ export const TableBody = React.memo(
                 // check if the user wants complete control of the rendering
                 if (!options.customRendering) {
                     const bodyCellProps = mergeProps(
-                        {
-                            colSpan
-                        },
-                        getColumnPTOptions('root'),
-                        getColumnPTOptions('bodyCell')
+                        [
+                            {
+                                colSpan
+                            },
+                            getColumnPTOptions('root'),
+                            getColumnPTOptions('bodyCell')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     const rowGroupHeaderNameProps = mergeProps(
-                        {
-                            className: cx('rowGroupHeaderName')
-                        },
-                        getColumnPTOptions('rowGroupHeaderName')
+                        [
+                            {
+                                className: cx('rowGroupHeaderName')
+                            },
+                            getColumnPTOptions('rowGroupHeaderName')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     content = (
@@ -937,12 +952,15 @@ export const TableBody = React.memo(
                 }
 
                 const rowGroupHeaderProps = mergeProps(
-                    {
-                        className: cx('rowGroupHeader'),
-                        style,
-                        role: 'row'
-                    },
-                    getColumnPTOptions('rowGroupHeader')
+                    [
+                        {
+                            className: cx('rowGroupHeader'),
+                            style,
+                            role: 'row'
+                        },
+                        getColumnPTOptions('rowGroupHeader')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <tr {...rowGroupHeaderProps}>{content}</tr>;
@@ -1045,24 +1063,30 @@ export const TableBody = React.memo(
                 // check if the user wants complete control of the rendering
                 if (!options.customRendering) {
                     const bodyCellProps = mergeProps(
-                        {
-                            colSpan,
-                            role: 'cell'
-                        },
-                        getColumnPTOptions('root'),
-                        getColumnPTOptions('bodyCell')
+                        [
+                            {
+                                colSpan,
+                                role: 'cell'
+                            },
+                            getColumnPTOptions('root'),
+                            getColumnPTOptions('bodyCell')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     content = <td {...bodyCellProps}>{content}</td>;
                 }
 
                 const rowExpansionProps = mergeProps(
-                    {
-                        id,
-                        className: cx('rowExpansion'),
-                        role: 'row'
-                    },
-                    getColumnPTOptions('rowExpansion')
+                    [
+                        {
+                            id,
+                            className: cx('rowExpansion'),
+                            role: 'row'
+                        },
+                        getColumnPTOptions('rowExpansion')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <tr {...rowExpansionProps}>{content}</tr>;
@@ -1075,11 +1099,14 @@ export const TableBody = React.memo(
             if (isSubheaderGrouping && shouldRenderRowGroupFooter(props.value, rowData, rowIndex - props.first, expanded)) {
                 const content = ObjectUtils.getJSXElement(props.rowGroupFooterTemplate, rowData, { index: rowIndex, colSpan, props: props.tableProps });
                 const rowGroupFooterProps = mergeProps(
-                    {
-                        className: cx('rowGroupFooter'),
-                        role: 'row'
-                    },
-                    getColumnPTOptions('rowGroupFooter')
+                    [
+                        {
+                            className: cx('rowGroupFooter'),
+                            role: 'row'
+                        },
+                        getColumnPTOptions('rowGroupFooter')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <tr {...rowGroupFooterProps}>{content}</tr>;
@@ -1117,11 +1144,14 @@ export const TableBody = React.memo(
         const content = props.empty ? createEmptyContent() : createContent();
         const ptKey = props.className === 'p-datatable-virtualscroller-spacer' ? 'virtualScrollerSpacer' : 'tbody';
         const tbodyProps = mergeProps(
-            {
-                style: props.style,
-                className: cx(ptKey, { className: props.className })
-            },
-            ptm(ptKey, { hostName: props.hostName })
+            [
+                {
+                    style: props.style,
+                    className: cx(ptKey, { className: props.className })
+                },
+                ptm(ptKey, { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/datatable/TableFooter.js
+++ b/components/lib/datatable/TableFooter.js
@@ -3,9 +3,11 @@ import { ColumnBase } from '../column/ColumnBase';
 import { ColumnGroupBase } from '../columngroup/ColumnGroupBase';
 import { RowBase } from '../row/RowBase';
 import { FooterCell } from './FooterCell';
+import { PrimeReactContext } from '../api/Api';
 import { mergeProps } from '../utils/Utils';
 
 export const TableFooter = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const { ptm, ptmo, cx } = props.ptCallbacks;
     const getRowProps = (row) => ColumnGroupBase.getCProps(row);
 
@@ -21,7 +23,7 @@ export const TableFooter = React.memo((props) => {
             hostName: props.hostName
         };
 
-        return mergeProps(ptm(`row.${key}`, { row: rowMetaData }), ptm(`row.${key}`, rowMetaData), ptmo(rProps, key, rowMetaData));
+        return mergeProps([ptm(`row.${key}`, { row: rowMetaData }), ptm(`row.${key}`, rowMetaData), ptmo(rProps, key, rowMetaData)], { useTailwind: context.useTailwind });
     };
 
     const getColumnGroupPTOptions = (key) => {
@@ -32,7 +34,7 @@ export const TableFooter = React.memo((props) => {
             hostName: props.hostName
         };
 
-        return mergeProps(ptm(`columnGroup.${key}`, { columnGroup: columnGroupMetaData }), ptm(`columnGroup.${key}`, columnGroupMetaData), ptmo(cGProps, key, columnGroupMetaData));
+        return mergeProps([ptm(`columnGroup.${key}`, { columnGroup: columnGroupMetaData }), ptm(`columnGroup.${key}`, columnGroupMetaData), ptmo(cGProps, key, columnGroupMetaData)], { useTailwind: context.useTailwind });
     };
 
     const hasFooter = () => {
@@ -64,10 +66,13 @@ export const TableFooter = React.memo((props) => {
 
             return rows.map((row, i) => {
                 const rootProps = mergeProps(
-                    {
-                        role: 'row'
-                    },
-                    getRowPTOptions(row, 'root')
+                    [
+                        {
+                            role: 'row'
+                        },
+                        getRowPTOptions(row, 'root')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -79,10 +84,13 @@ export const TableFooter = React.memo((props) => {
         }
 
         const footerRowProps = mergeProps(
-            {
-                role: 'row'
-            },
-            ptm('footerRow', { hostName: props.hostName })
+            [
+                {
+                    role: 'row'
+                },
+                ptm('footerRow', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <tr {...footerRowProps}>{createFooterCells(props.columns)}</tr>;
@@ -91,11 +99,14 @@ export const TableFooter = React.memo((props) => {
     if (hasFooter()) {
         const content = createContent();
         const tfootProps = mergeProps(
-            {
-                className: cx('tfoot')
-            },
-            getColumnGroupPTOptions('root'),
-            ptm('tfoot', { hostName: props.hostName })
+            [
+                {
+                    className: cx('tfoot')
+                },
+                getColumnGroupPTOptions('root'),
+                ptm('tfoot', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <tfoot {...tfootProps}>{content}</tfoot>;

--- a/components/lib/datatable/TableHeader.js
+++ b/components/lib/datatable/TableHeader.js
@@ -3,12 +3,14 @@ import { ColumnBase } from '../column/ColumnBase';
 import { ColumnGroupBase } from '../columngroup/ColumnGroupBase';
 import { useMountEffect } from '../hooks/Hooks';
 import { RowBase } from '../row/RowBase';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, mergeProps } from '../utils/Utils';
 import { ColumnFilter } from './ColumnFilter';
 import { HeaderCell } from './HeaderCell';
 import { HeaderCheckbox } from './HeaderCheckbox';
 
 export const TableHeader = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const [sortableDisabledFieldsState, setSortableDisabledFieldsState] = React.useState([]);
     const [allSortableDisabledState, setAllSortableDisabledState] = React.useState(false);
     const isSingleSort = props.sortMode === 'single';
@@ -40,7 +42,7 @@ export const TableHeader = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`columnGroup.${key}`, { columnGroup: columnGroupMetaData }), ptm(`columnGroup.${key}`, columnGroupMetaData), ptmo(cGProps, key, columnGroupMetaData));
+        return mergeProps([ptm(`columnGroup.${key}`, { columnGroup: columnGroupMetaData }), ptm(`columnGroup.${key}`, columnGroupMetaData), ptmo(cGProps, key, columnGroupMetaData)], { useTailwind: context.useTailwind });
     };
 
     const getColumnPTOptions = (column, key) => {
@@ -55,7 +57,7 @@ export const TableHeader = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetaData }), ptm(`column.${key}`, columnMetaData), ptmo(cProps, key, columnMetaData)], { useTailwind: context.useTailwind });
     };
 
     const getRowPTOptions = (row, key) => {
@@ -66,7 +68,7 @@ export const TableHeader = React.memo((props) => {
             hostName: props.hostName
         };
 
-        return mergeProps(ptm(`row.${key}`, { row: rowMetaData }), ptm(`row.${key}`, rowMetaData), ptmo(rProps, key, rowMetaData));
+        return mergeProps([ptm(`row.${key}`, { row: rowMetaData }), ptm(`row.${key}`, rowMetaData), ptmo(rProps, key, rowMetaData)], { useTailwind: context.useTailwind });
     };
 
     const isColumnSorted = (column) => {
@@ -211,13 +213,16 @@ export const TableHeader = React.memo((props) => {
                 const checkbox = createCheckbox(selectionMode);
                 const filterRow = createFilter(col, filter);
                 const headerCellProps = mergeProps(
-                    {
-                        style: colStyle,
-                        className: classNames(filterHeaderClassName, className, cx('headerCell', { frozen, column: col })),
-                        key: colKey
-                    },
-                    getColumnPTOptions(col, 'root'),
-                    getColumnPTOptions(col, 'headerCell')
+                    [
+                        {
+                            style: colStyle,
+                            className: classNames(filterHeaderClassName, className, cx('headerCell', { frozen, column: col })),
+                            key: colKey
+                        },
+                        getColumnPTOptions(col, 'root'),
+                        getColumnPTOptions(col, 'headerCell')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -238,10 +243,13 @@ export const TableHeader = React.memo((props) => {
 
             return rows.map((row, i) => {
                 const headerRowProps = mergeProps(
-                    {
-                        role: 'row'
-                    },
-                    getRowPTOptions(row, 'root')
+                    [
+                        {
+                            role: 'row'
+                        },
+                        getRowPTOptions(row, 'root')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -252,10 +260,13 @@ export const TableHeader = React.memo((props) => {
             });
         } else {
             const headerRowProps = mergeProps(
-                {
-                    role: 'row'
-                },
-                ptm('headerRow', { hostName: props.hostName })
+                [
+                    {
+                        role: 'row'
+                    },
+                    ptm('headerRow', { hostName: props.hostName })
+                ],
+                { useTailwind: context.useTailwind }
             );
             const headerRow = <tr {...headerRowProps}>{createHeaderCells(props.columns)}</tr>;
             const filterRow = props.filterDisplay === 'row' && <tr {...headerRowProps}>{createFilterCells()}</tr>;
@@ -271,11 +282,14 @@ export const TableHeader = React.memo((props) => {
 
     const content = createContent();
     const theadProps = mergeProps(
-        {
-            className: cx('thead')
-        },
-        getColumnGroupPTOptions('root'),
-        ptm('thead', { hostName: props.hostName })
+        [
+            {
+                className: cx('thead')
+            },
+            getColumnGroupPTOptions('root'),
+            ptm('thead', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <thead {...theadProps}>{content}</thead>;

--- a/components/lib/dataview/DataView.js
+++ b/components/lib/dataview/DataView.js
@@ -24,36 +24,45 @@ export const DataViewLayoutOptions = React.memo((inProps) => {
         event.preventDefault();
     };
 
-    const listIconProps = mergeProps(ptm('list'));
-    const gridIconProps = mergeProps(ptm('grid'));
+    const listIconProps = mergeProps([ptm('list')], { useTailwind: context.useTailwind });
+    const gridIconProps = mergeProps([ptm('grid')], { useTailwind: context.useTailwind });
     const listIcon = IconUtils.getJSXIcon(props.listIcon || <BarsIcon {...listIconProps} />, { ...listIconProps }, { props });
     const gridIcon = IconUtils.getJSXIcon(props.gridIcon || <ThLargeIcon {...gridIconProps} />, { ...gridIconProps }, { props });
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            style: props.style,
-            className: classNames(props.className, cx('root'))
-        },
-        DataViewLayoutOptionsBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: props.id,
+                style: props.style,
+                className: classNames(props.className, cx('root'))
+            },
+            DataViewLayoutOptionsBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const listButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('listButton'),
-            onClick: (event) => changeLayout(event, 'list')
-        },
-        ptm('listButton')
+        [
+            {
+                type: 'button',
+                className: cx('listButton'),
+                onClick: (event) => changeLayout(event, 'list')
+            },
+            ptm('listButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const gridButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('gridButton'),
-            onClick: (event) => changeLayout(event, 'grid')
-        },
-        ptm('gridButton')
+        [
+            {
+                type: 'button',
+                className: cx('gridButton'),
+                onClick: (event) => changeLayout(event, 'grid')
+            },
+            ptm('gridButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (
@@ -165,18 +174,24 @@ export const DataView = React.memo(
         const createLoader = () => {
             if (props.loading) {
                 const loadingIconProps = mergeProps(
-                    {
-                        className: cx('loadingIcon')
-                    },
-                    ptm('loadingIcon')
+                    [
+                        {
+                            className: cx('loadingIcon')
+                        },
+                        ptm('loadingIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
                 const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
                 const loadingOverlayProps = mergeProps(
-                    {
-                        className: cx('loadingOverlay')
-                    },
-                    ptm('loadingOverlay')
+                    [
+                        {
+                            className: cx('loadingOverlay')
+                        },
+                        ptm('loadingOverlay')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...loadingOverlayProps}>{loadingIcon}</div>;
@@ -205,10 +220,13 @@ export const DataView = React.memo(
             if (!props.loading) {
                 const content = props.emptyMessage || localeOption('emptyMessage');
                 const emptyMessageProps = mergeProps(
-                    {
-                        className: cx('emptyMessage')
-                    },
-                    ptm('emptyMessage')
+                    [
+                        {
+                            className: cx('emptyMessage')
+                        },
+                        ptm('emptyMessage')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...emptyMessageProps}>{content}</div>;
@@ -220,10 +238,13 @@ export const DataView = React.memo(
         const createHeader = () => {
             if (props.header) {
                 const headerProps = mergeProps(
-                    {
-                        className: cx('header')
-                    },
-                    ptm('header')
+                    [
+                        {
+                            className: cx('header')
+                        },
+                        ptm('header')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...headerProps}>{props.header}</div>;
@@ -235,10 +256,13 @@ export const DataView = React.memo(
         const createFooter = () => {
             if (props.footer) {
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    ptm('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        ptm('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{props.footer}</div>;
@@ -276,17 +300,23 @@ export const DataView = React.memo(
             const items = createItems(value);
 
             const gridProps = mergeProps(
-                {
-                    className: cx('grid')
-                },
-                ptm('grid')
+                [
+                    {
+                        className: cx('grid')
+                    },
+                    ptm('grid')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const contentProps = mergeProps(
-                {
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -319,14 +349,17 @@ export const DataView = React.memo(
         const footer = createFooter();
         const content = createContent(data);
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: props.style,
-                className: classNames(props.className, cx('root'))
-            },
-            DataViewBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: props.style,
+                    className: classNames(props.className, cx('root'))
+                },
+                DataViewBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/deferredcontent/DeferredContent.js
+++ b/components/lib/deferredcontent/DeferredContent.js
@@ -57,11 +57,14 @@ export const DeferredContent = React.forwardRef((inProps, ref) => {
     });
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef
-        },
-        DeferredContentBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef
+            },
+            DeferredContentBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <div {...rootProps}>{loadedState && props.children}</div>;

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -465,25 +465,31 @@ export const Dialog = React.forwardRef((inProps, ref) => {
             const ariaLabel = props.ariaCloseIconLabel || localeOption('close');
 
             const closeButtonIconProps = mergeProps(
-                {
-                    className: cx('closeButtonIcon'),
-                    'aria-hidden': true
-                },
-                ptm('closeButtonIcon')
+                [
+                    {
+                        className: cx('closeButtonIcon'),
+                        'aria-hidden': true
+                    },
+                    ptm('closeButtonIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.closeIcon || <TimesIcon {...closeButtonIconProps} />;
             const headerCloseIcon = IconUtils.getJSXIcon(icon, { ...closeButtonIconProps }, { props });
 
             const closeButtonProps = mergeProps(
-                {
-                    ref: closeRef,
-                    type: 'button',
-                    className: cx('closeButton'),
-                    'aria-label': ariaLabel,
-                    onClick: onClose
-                },
-                ptm('closeButton')
+                [
+                    {
+                        ref: closeRef,
+                        type: 'button',
+                        className: cx('closeButton'),
+                        'aria-label': ariaLabel,
+                        onClick: onClose
+                    },
+                    ptm('closeButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -500,10 +506,13 @@ export const Dialog = React.forwardRef((inProps, ref) => {
     const createMaximizeIcon = () => {
         let icon;
         const maximizableIconProps = mergeProps(
-            {
-                className: cx('maximizableIcon')
-            },
-            ptm('maximizableIcon')
+            [
+                {
+                    className: cx('maximizableIcon')
+                },
+                ptm('maximizableIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (!maximized) {
@@ -516,12 +525,15 @@ export const Dialog = React.forwardRef((inProps, ref) => {
 
         if (props.maximizable) {
             const maximizableButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('maximizableButton'),
-                    onClick: toggleMaximize
-                },
-                ptm('maximizableButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('maximizableButton'),
+                        onClick: toggleMaximize
+                    },
+                    ptm('maximizableButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -544,28 +556,37 @@ export const Dialog = React.forwardRef((inProps, ref) => {
             const headerId = idState + '_header';
 
             const headerProps = mergeProps(
-                {
-                    ref: headerRef,
-                    style: props.headerStyle,
-                    className: cx('header'),
-                    onMouseDown: onDragStart
-                },
-                ptm('header')
+                [
+                    {
+                        ref: headerRef,
+                        style: props.headerStyle,
+                        className: cx('header'),
+                        onMouseDown: onDragStart
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerTitleProps = mergeProps(
-                {
-                    id: headerId,
-                    className: cx('headerTitle')
-                },
-                ptm('headerTitle')
+                [
+                    {
+                        id: headerId,
+                        className: cx('headerTitle')
+                    },
+                    ptm('headerTitle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerIconsProps = mergeProps(
-                {
-                    className: cx('headerIcons')
-                },
-                ptm('headerIcons')
+                [
+                    {
+                        className: cx('headerIcons')
+                    },
+                    ptm('headerIcons')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -587,13 +608,16 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         const contentId = idState + '_content';
 
         const contentProps = mergeProps(
-            {
-                id: contentId,
-                ref: contentRef,
-                style: props.contentStyle,
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    id: contentId,
+                    ref: contentRef,
+                    style: props.contentStyle,
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <div {...contentProps}>{props.children}</div>;
@@ -603,11 +627,14 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         const footer = ObjectUtils.getJSXElement(props.footer, props);
 
         const footerProps = mergeProps(
-            {
-                ref: footerRef,
-                className: cx('footer')
-            },
-            ptm('footer')
+            [
+                {
+                    ref: footerRef,
+                    className: cx('footer')
+                },
+                ptm('footer')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return footer && <div {...footerProps}>{footer}</div>;
@@ -635,45 +662,54 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         };
 
         const maskProps = mergeProps(
-            {
-                ref: maskRef,
-                style: sx('mask'),
-                className: cx('mask', { maskVisibleState }),
-                onPointerUp: onMaskPointerUp
-            },
-            ptm('mask')
+            [
+                {
+                    ref: maskRef,
+                    style: sx('mask'),
+                    className: cx('mask', { maskVisibleState }),
+                    onPointerUp: onMaskPointerUp
+                },
+                ptm('mask')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                ref: dialogRef,
-                id: idState,
-                className: cx('root', { props, maximized, context }),
-                style: props.style,
-                onClick: props.onClick,
-                role: 'dialog',
-                'aria-labelledby': headerId,
-                'aria-describedby': contentId,
-                'aria-modal': props.modal,
-                onPointerDown: onDialogPointerDown
-            },
-            DialogBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: dialogRef,
+                    id: idState,
+                    className: cx('root', { props, maximized, context }),
+                    style: props.style,
+                    onClick: props.onClick,
+                    role: 'dialog',
+                    'aria-labelledby': headerId,
+                    'aria-describedby': contentId,
+                    'aria-modal': props.modal,
+                    onPointerDown: onDialogPointerDown
+                },
+                DialogBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                timeout: transitionTimeout,
-                in: visibleState,
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: onEnter,
-                onEntered: onEntered,
-                onExiting: onExiting,
-                onExited: onExited
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    timeout: transitionTimeout,
+                    in: visibleState,
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: onEnter,
+                    onEntered: onEntered,
+                    onExiting: onExiting,
+                    onExited: onExited
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/divider/Divider.js
+++ b/components/lib/divider/Divider.js
@@ -24,21 +24,27 @@ export const Divider = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef,
-            style: sx('root'),
-            className: cx('root', { horizontal, vertical }),
-            role: 'separator'
-        },
-        DividerBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef,
+                style: sx('root'),
+                className: cx('root', { horizontal, vertical }),
+                role: 'separator'
+            },
+            DividerBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const contentProps = mergeProps(
-        {
-            className: cx('content')
-        },
-        ptm('content')
+        [
+            {
+                className: cx('content')
+            },
+            ptm('content')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/dock/Dock.js
+++ b/components/lib/dock/Dock.js
@@ -58,22 +58,28 @@ export const Dock = React.memo(
             const contentClassName = classNames('p-dock-action', { 'p-disabled': disabled });
             const iconClassName = classNames('p-dock-action-icon', _icon);
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                getPTOptions('icon', item, index)
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    getPTOptions('icon', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(_icon, { ...iconProps }, { props });
             const actionProps = mergeProps(
-                {
-                    href: url || '#',
-                    role: 'menuitem',
-                    className: cx('action', { disabled }),
-                    target,
-                    'data-pr-tooltip': label,
-                    onClick: (e) => onItemClick(e, item)
-                },
-                getPTOptions('action', item, index)
+                [
+                    {
+                        href: url || '#',
+                        role: 'menuitem',
+                        className: cx('action', { disabled }),
+                        target,
+                        'data-pr-tooltip': label,
+                        onClick: (e) => onItemClick(e, item)
+                    },
+                    getPTOptions('action', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -97,14 +103,17 @@ export const Dock = React.memo(
             }
 
             const menuitemProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('menuitem', { currentIndexState, index }),
-                    role: 'none',
-                    onMouseEnter: () => onItemMouseEnter(index)
-                },
-                getPTOptions('menuitem', item, index)
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('menuitem', { currentIndexState, index }),
+                        role: 'none',
+                        onMouseEnter: () => onItemMouseEnter(index)
+                    },
+                    getPTOptions('menuitem', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuitemProps}>{content}</li>;
@@ -118,10 +127,13 @@ export const Dock = React.memo(
             if (props.header) {
                 const header = ObjectUtils.getJSXElement(props.header, { props });
                 const headerProps = mergeProps(
-                    {
-                        className: cx('header')
-                    },
-                    ptm('header')
+                    [
+                        {
+                            className: cx('header')
+                        },
+                        ptm('header')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...headerProps}>{header}</div>;
@@ -133,12 +145,15 @@ export const Dock = React.memo(
         const createList = () => {
             const items = createItems();
             const menuProps = mergeProps(
-                {
-                    className: cx('menu'),
-                    role: 'menu',
-                    onMouseLeave: onListMouseLeave
-                },
-                ptm('menu')
+                [
+                    {
+                        className: cx('menu'),
+                        role: 'menu',
+                        onMouseLeave: onListMouseLeave
+                    },
+                    ptm('menu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <ul {...menuProps}>{items}</ul>;
@@ -148,10 +163,13 @@ export const Dock = React.memo(
             if (props.footer) {
                 const footer = ObjectUtils.getJSXElement(props.footer, { props });
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    ptm('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        ptm('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{footer}</div>;
@@ -175,19 +193,25 @@ export const Dock = React.memo(
         const list = createList();
         const footer = createFooter();
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root')),
-                style: props.style
-            },
-            DockBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root')),
+                    style: props.style
+                },
+                DockBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const containerProps = mergeProps(
-            {
-                className: cx('container')
-            },
-            ptm('container')
+            [
+                {
+                    className: cx('container')
+                },
+                ptm('container')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -685,29 +685,38 @@ export const Dropdown = React.memo(
             }
 
             const hiddenSelectedMessageProps = mergeProps(
-                {
-                    className: 'p-hidden-accessible p-dropdown-hidden-select'
-                },
-                ptm('hiddenSelectedMessage')
+                [
+                    {
+                        className: 'p-hidden-accessible p-dropdown-hidden-select'
+                    },
+                    ptm('hiddenSelectedMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const selectProps = mergeProps(
-                {
-                    ref: inputRef,
-                    required: props.required,
-                    defaultValue: option.value,
-                    name: props.name,
-                    tabIndex: -1,
-                    'aria-hidden': 'true'
-                },
-                ptm('select')
+                [
+                    {
+                        ref: inputRef,
+                        required: props.required,
+                        defaultValue: option.value,
+                        name: props.name,
+                        tabIndex: -1,
+                        'aria-hidden': 'true'
+                    },
+                    ptm('select')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const optionProps = mergeProps(
-                {
-                    value: option.value
-                },
-                ptm('option')
+                [
+                    {
+                        value: option.value
+                    },
+                    ptm('option')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -721,27 +730,33 @@ export const Dropdown = React.memo(
 
         const createKeyboardHelper = () => {
             const hiddenSelectedMessageProps = mergeProps(
-                {
-                    className: 'p-hidden-accessible'
-                },
-                ptm('hiddenSelectedMessage')
+                [
+                    {
+                        className: 'p-hidden-accessible'
+                    },
+                    ptm('hiddenSelectedMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const inputProps = mergeProps(
-                {
-                    ref: focusInputRef,
-                    id: props.inputId,
-                    type: 'text',
-                    readOnly: true,
-                    'aria-haspopup': 'listbox',
-                    onFocus: onInputFocus,
-                    onBlur: onInputBlur,
-                    onKeyDown: onInputKeyDown,
-                    disabled: props.disabled,
-                    tabIndex: props.tabIndex,
-                    ...ariaProps
-                },
-                ptm('input')
+                [
+                    {
+                        ref: focusInputRef,
+                        id: props.inputId,
+                        type: 'text',
+                        readOnly: true,
+                        'aria-haspopup': 'listbox',
+                        onFocus: onInputFocus,
+                        onBlur: onInputBlur,
+                        onKeyDown: onInputKeyDown,
+                        disabled: props.disabled,
+                        tabIndex: props.tabIndex,
+                        ...ariaProps
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -757,32 +772,38 @@ export const Dropdown = React.memo(
             if (props.editable) {
                 const value = label || props.value || '';
                 const inputProps = mergeProps(
-                    {
-                        ref: inputRef,
-                        type: 'text',
-                        defaultValue: value,
-                        className: cx('input', { label }),
-                        disabled: props.disabled,
-                        placeholder: props.placeholder,
-                        maxLength: props.maxLength,
-                        onInput: onEditableInputChange,
-                        onFocus: onEditableInputFocus,
-                        onBlur: onInputBlur,
-                        'aria-haspopup': 'listbox',
-                        ...ariaProps
-                    },
-                    ptm('input')
+                    [
+                        {
+                            ref: inputRef,
+                            type: 'text',
+                            defaultValue: value,
+                            className: cx('input', { label }),
+                            disabled: props.disabled,
+                            placeholder: props.placeholder,
+                            maxLength: props.maxLength,
+                            onInput: onEditableInputChange,
+                            onFocus: onEditableInputFocus,
+                            onBlur: onInputBlur,
+                            'aria-haspopup': 'listbox',
+                            ...ariaProps
+                        },
+                        ptm('input')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <input {...inputProps} />;
             } else {
                 const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || 'empty';
                 const inputProps = mergeProps(
-                    {
-                        ref: inputRef,
-                        className: cx('input', { label })
-                    },
-                    ptm('input')
+                    [
+                        {
+                            ref: inputRef,
+                            className: cx('input', { label })
+                        },
+                        ptm('input')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <span {...inputProps}>{content}</span>;
@@ -792,11 +813,14 @@ export const Dropdown = React.memo(
         const createClearIcon = () => {
             if (props.value != null && props.showClear && !props.disabled) {
                 const clearIconProps = mergeProps(
-                    {
-                        className: cx('clearIcon'),
-                        onPointerUp: clear
-                    },
-                    ptm('clearIcon')
+                    [
+                        {
+                            className: cx('clearIcon'),
+                            onPointerUp: clear
+                        },
+                        ptm('clearIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.clearIcon || <TimesIcon {...clearIconProps} />;
 
@@ -808,24 +832,30 @@ export const Dropdown = React.memo(
 
         const createDropdownIcon = () => {
             const dropdownIconProps = mergeProps(
-                {
-                    className: cx('dropdownIcon')
-                },
-                ptm('dropdownIcon')
+                [
+                    {
+                        className: cx('dropdownIcon')
+                    },
+                    ptm('dropdownIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.dropdownIcon || <ChevronDownIcon {...dropdownIconProps} />;
             const dropdownIcon = IconUtils.getJSXIcon(icon, { ...dropdownIconProps }, { props });
 
             const ariaLabel = props.placeholder || props.ariaLabel;
             const triggerProps = mergeProps(
-                {
-                    className: cx('trigger'),
-                    role: 'button',
-                    'aria-haspopup': 'listbox',
-                    'aria-expanded': overlayVisibleState,
-                    'aria-label': ariaLabel
-                },
-                ptm('trigger')
+                [
+                    {
+                        className: cx('trigger'),
+                        role: 'button',
+                        'aria-haspopup': 'listbox',
+                        'aria-expanded': overlayVisibleState,
+                        'aria-label': ariaLabel
+                    },
+                    ptm('trigger')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...triggerProps}>{dropdownIcon}</div>;
@@ -843,19 +873,22 @@ export const Dropdown = React.memo(
         const dropdownIcon = createDropdownIcon();
         const clearIcon = createClearIcon();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root', { focusedState, overlayVisibleState })),
-                style: props.style,
-                onClick: (e) => onClick(e),
-                onMouseDown: props.onMouseDown,
-                onContextMenu: props.onContextMenu,
-                'data-p-disabled': props.disabled,
-                'data-p-focus': focusedState
-            },
-            otherProps,
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root', { focusedState, overlayVisibleState })),
+                    style: props.style,
+                    onClick: (e) => onClick(e),
+                    onMouseDown: props.onMouseDown,
+                    onContextMenu: props.onContextMenu,
+                    'data-p-disabled': props.disabled,
+                    'data-p-focus': focusedState
+                },
+                otherProps,
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/dropdown/DropdownItem.js
+++ b/components/lib/dropdown/DropdownItem.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const DropdownItem = React.memo((props) => {
     const { ptm, cx, selected, disabled, option, label } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -25,18 +27,21 @@ export const DropdownItem = React.memo((props) => {
 
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props.option) : props.label;
     const itemProps = mergeProps(
-        {
-            role: 'option',
-            key: props.label,
-            className: classNames(option.className, cx('item', { selected, disabled, label })),
-            style: props.style,
-            onClick: (e) => onClick(e),
-            'aria-label': label,
-            'aria-selected': selected,
-            'data-p-highlight': selected,
-            'data-p-disabled': disabled
-        },
-        getPTOptions('item', { selected, disabled, option, label })
+        [
+            {
+                role: 'option',
+                key: props.label,
+                className: classNames(option.className, cx('item', { selected, disabled, label })),
+                style: props.style,
+                onClick: (e) => onClick(e),
+                'aria-label': label,
+                'aria-selected': selected,
+                'data-p-highlight': selected,
+                'data-p-disabled': disabled
+            },
+            getPTOptions('item', { selected, disabled, option, label })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/dropdown/DropdownPanel.js
+++ b/components/lib/dropdown/DropdownPanel.js
@@ -56,10 +56,13 @@ export const DropdownPanel = React.memo(
             if (props.panelFooterTemplate) {
                 const content = ObjectUtils.getJSXElement(props.panelFooterTemplate, props, props.onOverlayHide);
                 const footerProps = mergeProps(
-                    {
-                        className: cx('footer')
-                    },
-                    getPTOptions('footer')
+                    [
+                        {
+                            className: cx('footer')
+                        },
+                        getPTOptions('footer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...footerProps}>{content}</div>;
@@ -83,10 +86,13 @@ export const DropdownPanel = React.memo(
         const createEmptyMessage = (emptyMessage, isFilter) => {
             const message = ObjectUtils.getJSXElement(emptyMessage, props) || localeOption(isFilter ? 'emptyFilterMessage' : 'emptyMessage');
             const emptyMessageProps = mergeProps(
-                {
-                    className: cx('emptyMessage')
-                },
-                getPTOptions('emptyMessage')
+                [
+                    {
+                        className: cx('emptyMessage')
+                    },
+                    getPTOptions('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...emptyMessageProps}>{message}</li>;
@@ -103,11 +109,14 @@ export const DropdownPanel = React.memo(
                 const groupChildrenContent = createGroupChildren(option, style);
                 const key = index + '_' + props.getOptionGroupRenderKey(option);
                 const itemGroupProps = mergeProps(
-                    {
-                        className: cx('itemGroup', { optionGroupLabel }),
-                        style
-                    },
-                    getPTOptions('itemGroup')
+                    [
+                        {
+                            className: cx('itemGroup', { optionGroupLabel }),
+                            style
+                        },
+                        getPTOptions('itemGroup')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -139,12 +148,15 @@ export const DropdownPanel = React.memo(
             if (props.showFilterClear && props.filterValue) {
                 const ariaLabel = localeOption('clear');
                 const clearIconProps = mergeProps(
-                    {
-                        className: cx('clearIcon'),
-                        'aria-label': ariaLabel,
-                        onClick: () => props.onFilterClearIconClick(() => DomHandler.focus(filterInputRef.current))
-                    },
-                    getPTOptions('clearIcon')
+                    [
+                        {
+                            className: cx('clearIcon'),
+                            'aria-label': ariaLabel,
+                            onClick: () => props.onFilterClearIconClick(() => DomHandler.focus(filterInputRef.current))
+                        },
+                        getPTOptions('clearIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.filterClearIcon || <TimesIcon {...clearIconProps} />;
                 const filterClearIcon = IconUtils.getJSXIcon(icon, { ...clearIconProps }, { props });
@@ -159,31 +171,40 @@ export const DropdownPanel = React.memo(
             if (props.filter) {
                 const clearIcon = createFilterClearIcon();
                 const filterIconProps = mergeProps(
-                    {
-                        className: cx('filterIcon')
-                    },
-                    getPTOptions('filterIcon')
+                    [
+                        {
+                            className: cx('filterIcon')
+                        },
+                        getPTOptions('filterIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.filterIcon || <SearchIcon {...filterIconProps} />;
                 const filterIcon = IconUtils.getJSXIcon(icon, { ...filterIconProps }, { props });
                 const filterContainerProps = mergeProps(
-                    {
-                        className: cx('filterContainer', { clearIcon })
-                    },
-                    getPTOptions('filterContainer')
+                    [
+                        {
+                            className: cx('filterContainer', { clearIcon })
+                        },
+                        getPTOptions('filterContainer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const filterInputProps = mergeProps(
-                    {
-                        ref: filterInputRef,
-                        type: 'text',
-                        autoComplete: 'off',
-                        className: cx('filterInput'),
-                        placeholder: props.filterPlaceholder,
-                        onKeyDown: props.onFilterInputKeyDown,
-                        onChange: (e) => onFilterInputChange(e),
-                        value: props.filterValue
-                    },
-                    getPTOptions('filterInput')
+                    [
+                        {
+                            ref: filterInputRef,
+                            type: 'text',
+                            autoComplete: 'off',
+                            className: cx('filterInput'),
+                            placeholder: props.filterPlaceholder,
+                            onKeyDown: props.onFilterInputKeyDown,
+                            onChange: (e) => onFilterInputChange(e),
+                            value: props.filterValue
+                        },
+                        getPTOptions('filterInput')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 let content = (
                     <div {...filterContainerProps}>
@@ -209,10 +230,13 @@ export const DropdownPanel = React.memo(
                 }
 
                 const headerProps = mergeProps(
-                    {
-                        className: cx('header')
-                    },
-                    getPTOptions('header')
+                    [
+                        {
+                            className: cx('header')
+                        },
+                        getPTOptions('header')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...headerProps}>{content}</div>;
@@ -236,13 +260,16 @@ export const DropdownPanel = React.memo(
                             const emptyMessage = props.hasFilter ? props.emptyFilterMessage : props.emptyMessage;
                             const content = isEmptyFilter ? createEmptyMessage(emptyMessage) : options.children;
                             const listProps = mergeProps(
-                                {
-                                    ref: options.contentRef,
-                                    style: options.style,
-                                    className: classNames(options.className, cx('list', { virtualScrollerProps: props.virtualScrollerOptions })),
-                                    role: 'listbox'
-                                },
-                                getPTOptions('list')
+                                [
+                                    {
+                                        ref: options.contentRef,
+                                        style: options.style,
+                                        className: classNames(options.className, cx('list', { virtualScrollerProps: props.virtualScrollerOptions })),
+                                        role: 'listbox'
+                                    },
+                                    getPTOptions('list')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return <ul {...listProps}>{content}</ul>;
@@ -254,19 +281,25 @@ export const DropdownPanel = React.memo(
             } else {
                 const items = createItems();
                 const wrapperProps = mergeProps(
-                    {
-                        className: cx('wrapper'),
-                        style: sx('wrapper')
-                    },
-                    getPTOptions('wrapper')
+                    [
+                        {
+                            className: cx('wrapper'),
+                            style: sx('wrapper')
+                        },
+                        getPTOptions('wrapper')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const listProps = mergeProps(
-                    {
-                        className: cx('list'),
-                        role: 'listbox'
-                    },
-                    getPTOptions('list')
+                    [
+                        {
+                            className: cx('list'),
+                            role: 'listbox'
+                        },
+                        getPTOptions('list')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -282,27 +315,33 @@ export const DropdownPanel = React.memo(
             const content = createContent();
             const footer = createFooter();
             const panelProps = mergeProps(
-                {
-                    className: classNames(props.panelClassName, cx('panel', { context })),
-                    style: sx('panel'),
-                    onClick: props.onClick
-                },
-                getPTOptions('panel')
+                [
+                    {
+                        className: classNames(props.panelClassName, cx('panel', { context })),
+                        style: sx('panel'),
+                        onClick: props.onClick
+                    },
+                    getPTOptions('panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: props.in,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: onEnter,
-                    onEntered: onEntered,
-                    onExit: props.onExit,
-                    onExited: props.onExited
-                },
-                getPTOptions('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: props.in,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: onEnter,
+                        onEntered: onEntered,
+                        onExit: props.onExit,
+                        onExited: props.onExited
+                    },
+                    getPTOptions('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/editor/Editor.js
+++ b/components/lib/editor/Editor.js
@@ -148,11 +148,14 @@ export const Editor = React.memo(
 
         const createToolbarHeader = () => {
             const toolbarProps = mergeProps(
-                {
-                    ref: toolbarRef,
-                    className: cx('toolbar')
-                },
-                ptm('toolbar')
+                [
+                    {
+                        ref: toolbarRef,
+                        className: cx('toolbar')
+                    },
+                    ptm('toolbar')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.showHeader === false) {
@@ -160,9 +163,9 @@ export const Editor = React.memo(
             } else if (props.headerTemplate) {
                 return <div {...toolbarProps}>{props.headerTemplate}</div>;
             } else {
-                const getMergeProps = (params, key) => mergeProps(params && { ...params }, ptm(key));
+                const getMergeProps = (params, key) => mergeProps([params && { ...params }, ptm(key)], { useTailwind: context.useTailwind });
 
-                const formatsProps = mergeProps({ className: 'ql-formats' }, ptm('formats'));
+                const formatsProps = mergeProps([{ className: 'ql-formats' }, ptm('formats')], { useTailwind: context.useTailwind });
 
                 return (
                     <div {...toolbarProps}>
@@ -212,20 +215,26 @@ export const Editor = React.memo(
 
         const header = createToolbarHeader();
         const contentProps = mergeProps(
-            {
-                ref: contentRef,
-                className: cx('content'),
-                style: props.style
-            },
-            ptm('content')
+            [
+                {
+                    ref: contentRef,
+                    className: cx('content'),
+                    style: props.style
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const content = <div {...contentProps}></div>;
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root'))
-            },
-            EditorBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root'))
+                },
+                EditorBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/fieldset/Fieldset.js
+++ b/components/lib/fieldset/Fieldset.js
@@ -69,33 +69,42 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
 
     const createContent = () => {
         const contentProps = mergeProps(
-            {
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const toggleableProps = mergeProps(
-            {
-                ref: contentRef,
-                id: contentId,
-                'aria-hidden': collapsed,
-                role: 'region',
-                'aria-labelledby': headerId,
-                className: cx('toggleableContent')
-            },
-            ptm('toggleableContent')
+            [
+                {
+                    ref: contentRef,
+                    id: contentId,
+                    'aria-hidden': collapsed,
+                    role: 'region',
+                    'aria-labelledby': headerId,
+                    className: cx('toggleableContent')
+                },
+                ptm('toggleableContent')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                timeout: { enter: 1000, exit: 450 },
-                in: !collapsed,
-                unmountOnExit: true,
-                options: props.transitionOptions
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    timeout: { enter: 1000, exit: 450 },
+                    in: !collapsed,
+                    unmountOnExit: true,
+                    options: props.transitionOptions
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -110,10 +119,13 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
     const createToggleIcon = () => {
         if (props.toggleable) {
             const togglerIconProps = mergeProps(
-                {
-                    className: cx('togglericon')
-                },
-                ptm('togglericon')
+                [
+                    {
+                        className: cx('togglericon')
+                    },
+                    ptm('togglericon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = collapsed ? props.expandIcon || <PlusIcon {...togglerIconProps} /> : props.collapseIcon || <MinusIcon {...togglerIconProps} />;
@@ -127,21 +139,27 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
 
     const createLegendContent = () => {
         const legendTextProps = mergeProps(
-            {
-                className: cx('legendTitle')
-            },
-            ptm('legendTitle')
+            [
+                {
+                    className: cx('legendTitle')
+                },
+                ptm('legendTitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const togglerProps = mergeProps(
-            {
-                id: headerId,
-                'aria-expanded': !collapsed,
-                'aria-controls': contentId,
-                href: '#' + contentId,
-                tabIndex: props.toggleable ? null : -1
-            },
-            ptm('toggler')
+            [
+                {
+                    id: headerId,
+                    'aria-expanded': !collapsed,
+                    'aria-controls': contentId,
+                    href: '#' + contentId,
+                    tabIndex: props.toggleable ? null : -1
+                },
+                ptm('toggler')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.toggleable) {
@@ -165,12 +183,15 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
 
     const createLegend = () => {
         const legendProps = mergeProps(
-            {
-                className: cx('legend'),
-                onClick: toggle
-            },
+            [
+                {
+                    className: cx('legend'),
+                    onClick: toggle
+                },
 
-            ptm('legend')
+                ptm('legend')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.legend != null || props.toggleable) {
@@ -187,15 +208,18 @@ export const Fieldset = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            id: idState,
-            ref: elementRef,
-            style: props.style,
-            className: classNames(props.className, cx('root')),
-            onClick: props.onClick
-        },
-        FieldsetBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: idState,
+                ref: elementRef,
+                style: props.style,
+                className: classNames(props.className, cx('root')),
+                onClick: props.onClick
+            },
+            FieldsetBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const legend = createLegend();

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -366,45 +366,57 @@ export const FileUpload = React.memo(
         const createChooseButton = () => {
             const { className, style, icon: _icon, iconOnly } = props.chooseOptions;
             const chooseButtonLabelProps = mergeProps(
-                {
-                    className: cx('chooseButtonLabel')
-                },
-                ptm('chooseButtonLabel')
+                [
+                    {
+                        className: cx('chooseButtonLabel')
+                    },
+                    ptm('chooseButtonLabel')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = iconOnly ? <span {...chooseButtonLabelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} /> : <span {...chooseButtonLabelProps}>{chooseButtonLabel}</span>;
             const inputProps = mergeProps(
-                {
-                    ref: fileInputRef,
-                    type: 'file',
-                    onChange: (e) => onFileSelect(e),
-                    multiple: props.multiple,
-                    accept: props.accept,
-                    disabled: chooseDisabled
-                },
-                ptm('input')
+                [
+                    {
+                        ref: fileInputRef,
+                        type: 'file',
+                        onChange: (e) => onFileSelect(e),
+                        multiple: props.multiple,
+                        accept: props.accept,
+                        disabled: chooseDisabled
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const input = <input {...inputProps} />;
             const chooseIconProps = mergeProps(
-                {
-                    className: cx('chooseIcon', { iconOnly })
-                },
-                ptm('chooseIcon')
+                [
+                    {
+                        className: cx('chooseIcon', { iconOnly })
+                    },
+                    ptm('chooseIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = _icon || <PlusIcon {...chooseIconProps} />;
             const chooseIcon = IconUtils.getJSXIcon(icon, { ...chooseIconProps }, { props });
             const chooseButtonProps = mergeProps(
-                {
-                    className: classNames(className, cx('chooseButton', { iconOnly, disabled, className, focusedState })),
-                    style,
-                    onClick: choose,
-                    onKeyDown: (e) => onKeyDown(e),
-                    onFocus,
-                    onBlur,
-                    tabIndex: 0,
-                    'data-p-disabled': disabled,
-                    'data-p-focus': focusedState
-                },
-                ptm('chooseButton')
+                [
+                    {
+                        className: classNames(className, cx('chooseButton', { iconOnly, disabled, className, focusedState })),
+                        style,
+                        onClick: choose,
+                        onKeyDown: (e) => onKeyDown(e),
+                        onFocus,
+                        onBlur,
+                        tabIndex: 0,
+                        'data-p-disabled': disabled,
+                        'data-p-focus': focusedState
+                    },
+                    ptm('chooseButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -425,24 +437,30 @@ export const FileUpload = React.memo(
         const createFile = (file, index, badgeOptions) => {
             const key = file.name + file.type + file.size;
             const thumbnailProps = mergeProps(
-                {
-                    role: 'presentation',
-                    className: cx('thumbnail'),
-                    src: file.objectURL,
-                    width: props.previewWidth
-                },
-                ptm('thumbnail')
+                [
+                    {
+                        role: 'presentation',
+                        className: cx('thumbnail'),
+                        src: file.objectURL,
+                        width: props.previewWidth
+                    },
+                    ptm('thumbnail')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const preview = isImage(file) ? <img {...thumbnailProps} alt={file.name} /> : null;
-            const detailsProps = mergeProps(ptm('details'));
-            const fileSizeProps = mergeProps(ptm('fileSize'));
+            const detailsProps = mergeProps([ptm('details')], { useTailwind: context.useTailwind });
+            const fileSizeProps = mergeProps([ptm('fileSize')], { useTailwind: context.useTailwind });
             const fileNameProps = mergeProps(
-                {
-                    className: cx('fileName')
-                },
-                ptm('fileName')
+                [
+                    {
+                        className: cx('fileName')
+                    },
+                    ptm('fileName')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const actionsProps = mergeProps(ptm('actions'));
+            const actionsProps = mergeProps([ptm('actions')], { useTailwind: context.useTailwind });
             const fileName = <div {...fileNameProps}>{file.name}</div>;
             const size = <div {...fileSizeProps}>{formatSize(file.size)}</div>;
 
@@ -493,11 +511,14 @@ export const FileUpload = React.memo(
             }
 
             const fileProps = mergeProps(
-                {
-                    key,
-                    className: cx('file')
-                },
-                ptm('file')
+                [
+                    {
+                        key,
+                        className: cx('file')
+                    },
+                    ptm('file')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...fileProps}>{content}</div>;
@@ -546,17 +567,23 @@ export const FileUpload = React.memo(
                 const uploadLabel = !uploadOptions.iconOnly ? uploadButtonLabel : '';
                 const cancelLabel = !cancelOptions.iconOnly ? cancelButtonLabel : '';
                 const uploadIconProps = mergeProps(
-                    {
-                        className: cx('uploadIcon', { iconOnly: uploadOptions.iconOnly })
-                    },
-                    ptm('uploadIcon')
+                    [
+                        {
+                            className: cx('uploadIcon', { iconOnly: uploadOptions.iconOnly })
+                        },
+                        ptm('uploadIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const uploadIcon = IconUtils.getJSXIcon(uploadOptions.icon || <UploadIcon {...uploadIconProps} />, { ...uploadIconProps }, { props });
                 const cancelIconProps = mergeProps(
-                    {
-                        className: cx('cancelIcon', { iconOnly: cancelOptions.iconOnly })
-                    },
-                    ptm('cancelIcon')
+                    [
+                        {
+                            className: cx('cancelIcon', { iconOnly: cancelOptions.iconOnly })
+                        },
+                        ptm('cancelIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const cancelIcon = IconUtils.getJSXIcon(cancelOptions.icon || <TimesIcon {...cancelIconProps} />, { ...cancelIconProps }, { props });
 
@@ -598,11 +625,14 @@ export const FileUpload = React.memo(
             }
 
             const buttonbarProps = mergeProps(
-                {
-                    className: classNames(props.headerClassName, cx('buttonbar')),
-                    style: props.headerStyle
-                },
-                ptm('buttonbar')
+                [
+                    {
+                        className: classNames(props.headerClassName, cx('buttonbar')),
+                        style: props.headerStyle
+                    },
+                    ptm('buttonbar')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let header = (
@@ -627,27 +657,33 @@ export const FileUpload = React.memo(
             }
 
             const rootProps = mergeProps(
-                {
-                    id: props.id,
-                    className: cx('root'),
-                    style: props.style
-                },
-                FileUploadBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        id: props.id,
+                        className: cx('root'),
+                        style: props.style
+                    },
+                    FileUploadBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const contentProps = mergeProps(
-                {
-                    ref: contentRef,
-                    className: classNames(props.contentClassName, cx('content')),
-                    style: props.contentStyle,
-                    onDragEnter: (e) => onDragEnter(e),
-                    onDragOver: (e) => onDragOver(e),
-                    onDragLeave: (e) => onDragLeave(e),
-                    onDrop: (e) => onDrop(e),
-                    'data-p-highlight': false
-                },
-                ptm('content')
+                [
+                    {
+                        ref: contentRef,
+                        className: classNames(props.contentClassName, cx('content')),
+                        style: props.contentStyle,
+                        onDragEnter: (e) => onDragEnter(e),
+                        onDragOver: (e) => onDragOver(e),
+                        onDragLeave: (e) => onDragLeave(e),
+                        onDrop: (e) => onDrop(e),
+                        'data-p-highlight': false
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -667,54 +703,69 @@ export const FileUpload = React.memo(
         const createBasic = () => {
             const chooseOptions = props.chooseOptions;
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const chooseLabel = chooseOptions.iconOnly ? <span {...labelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} /> : <span {...labelProps}>{chooseButtonLabel}</span>;
             const label = props.auto ? chooseLabel : <span {...labelProps}>{hasFiles ? filesState[0].name : chooseLabel}</span>;
             const chooseIconProps = mergeProps(
-                {
-                    className: cx('chooseIcon', { iconOnly: chooseOptions.iconOnly })
-                },
-                ptm('chooseIcon')
+                [
+                    {
+                        className: cx('chooseIcon', { iconOnly: chooseOptions.iconOnly })
+                    },
+                    ptm('chooseIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = chooseOptions.icon ? chooseOptions.icon : !chooseOptions.icon && (!hasFiles || props.auto) ? <PlusIcon {...chooseIconProps} /> : !chooseOptions.icon && hasFiles && !props.auto && <UploadIcon {...chooseIconProps} />;
             const chooseIcon = IconUtils.getJSXIcon(icon, { ...chooseIconProps }, { props, hasFiles });
             const inputProps = mergeProps(
-                {
-                    ref: fileInputRef,
-                    type: 'file',
-                    onChange: (e) => onFileSelect(e),
-                    multiple: props.multiple,
-                    accept: props.accept,
-                    disabled: disabled
-                },
-                ptm('input')
+                [
+                    {
+                        ref: fileInputRef,
+                        type: 'file',
+                        onChange: (e) => onFileSelect(e),
+                        multiple: props.multiple,
+                        accept: props.accept,
+                        disabled: disabled
+                    },
+                    ptm('input')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const input = !hasFiles && <input {...inputProps} />;
             const rootProps = mergeProps(
-                {
-                    className: classNames(props.className, cx('root')),
-                    style: props.style
-                },
-                FileUploadBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        className: classNames(props.className, cx('root')),
+                        style: props.style
+                    },
+                    FileUploadBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const basicButtonProps = mergeProps(
-                {
-                    className: classNames(chooseOptions.className, cx('basicButton', { hasFiles, disabled, focusedState })),
-                    style: chooseOptions.style,
-                    tabIndex: 0,
-                    onClick: onSimpleUploaderClick,
-                    onKeyDown: (e) => onKeyDown(e),
-                    onFocus,
-                    onBlur
-                },
-                FileUploadBase.getOtherProps(props),
-                ptm('basicButton')
+                [
+                    {
+                        className: classNames(chooseOptions.className, cx('basicButton', { hasFiles, disabled, focusedState })),
+                        style: chooseOptions.style,
+                        tabIndex: 0,
+                        onClick: onSimpleUploaderClick,
+                        onKeyDown: (e) => onKeyDown(e),
+                        onFocus,
+                        onBlur
+                    },
+                    FileUploadBase.getOtherProps(props),
+                    ptm('basicButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -143,10 +143,13 @@ export const Galleria = React.memo(
 
         const createHeader = () => {
             const headerProps = mergeProps(
-                {
-                    className: cx('header')
-                },
-                ptm('header')
+                [
+                    {
+                        className: cx('header')
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.header) {
@@ -158,10 +161,13 @@ export const Galleria = React.memo(
 
         const createFooter = () => {
             const footerProps = mergeProps(
-                {
-                    className: cx('footer')
-                },
-                ptm('footer')
+                [
+                    {
+                        className: cx('footer')
+                    },
+                    ptm('footer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.footer) {
@@ -176,23 +182,29 @@ export const Galleria = React.memo(
             const indicatorPosClassName = props.showIndicators && getPositionClassName('p-galleria-indicators', props.indicatorsPosition);
 
             const closeIconProps = mergeProps(
-                {
-                    className: cx('closeIcon'),
-                    'aria-hidden': true
-                },
-                ptm('closeIcon')
+                [
+                    {
+                        className: cx('closeIcon'),
+                        'aria-hidden': true
+                    },
+                    ptm('closeIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.closeIcon || <TimesIcon {...closeIconProps} />;
             const closeIcon = IconUtils.getJSXIcon(icon, { ...closeIconProps }, { props });
 
             const closeButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('closeButton'),
-                    'aria-label': localeOption('close'),
-                    onClick: hide
-                },
-                ptm('closeButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('closeButton'),
+                        'aria-label': localeOption('close'),
+                        onClick: hide
+                    },
+                    ptm('closeButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const closeButton = props.fullScreen && (
@@ -206,21 +218,27 @@ export const Galleria = React.memo(
             const footer = createFooter();
 
             const rootProps = mergeProps(
-                {
-                    ref: elementRef,
-                    id: props.id,
-                    className: classNames(props.className, cx('root', { context, thumbnailsPosClassName, indicatorPosClassName })),
-                    style: props.style
-                },
-                GalleriaBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: elementRef,
+                        id: props.id,
+                        className: classNames(props.className, cx('root', { context, thumbnailsPosClassName, indicatorPosClassName })),
+                        style: props.style
+                    },
+                    GalleriaBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const contentProps = mergeProps(
-                {
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const element = (
@@ -288,26 +306,32 @@ export const Galleria = React.memo(
 
             if (props.fullScreen) {
                 const maskProps = mergeProps(
-                    {
-                        className: cx('mask', { visibleState })
-                    },
-                    ptm('mask')
+                    [
+                        {
+                            className: cx('mask', { visibleState })
+                        },
+                        ptm('mask')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const transitionProps = mergeProps(
-                    {
-                        classNames: cx('transition'),
-                        in: visibleState,
-                        timeout: { enter: 150, exit: 150 },
-                        options: props.transitionOptions,
-                        unmountOnExit: true,
-                        onEnter,
-                        onEntering,
-                        onEntered,
-                        onExit,
-                        onExited
-                    },
-                    ptm('transition')
+                    [
+                        {
+                            classNames: cx('transition'),
+                            in: visibleState,
+                            timeout: { enter: 150, exit: 150 },
+                            options: props.transitionOptions,
+                            unmountOnExit: true,
+                            onEnter,
+                            onEntering,
+                            onEntered,
+                            onExit,
+                            onExited
+                        },
+                        ptm('transition')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const galleriaWrapper = (

--- a/components/lib/galleria/GalleriaItem.js
+++ b/components/lib/galleria/GalleriaItem.js
@@ -3,10 +3,12 @@ import { useMountEffect } from '../hooks/Hooks';
 import { ChevronLeftIcon } from '../icons/chevronleft';
 import { ChevronRightIcon } from '../icons/chevronright';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const GalleriaItem = React.memo(
     React.forwardRef((props, ref) => {
+        const context = React.useContext(PrimeReactContext);
         const { ptm, cx } = props;
 
         const getPTOptions = (key, options) => {
@@ -94,23 +96,29 @@ export const GalleriaItem = React.memo(
                 const isDisabled = !props.circular && props.activeItemIndex === 0;
 
                 const previousItemIconProps = mergeProps(
-                    {
-                        className: cx('previousItemIcon')
-                    },
-                    getPTOptions('previousItemIcon')
+                    [
+                        {
+                            className: cx('previousItemIcon')
+                        },
+                        getPTOptions('previousItemIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.itemPrevIcon || <ChevronLeftIcon {...previousItemIconProps} />;
                 const itemPrevIcon = IconUtils.getJSXIcon(icon, { ...previousItemIconProps }, { props });
 
                 const previousItemButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('previousItemButton', { isDisabled }),
-                        onClick: navBackward,
-                        disabled: isDisabled,
-                        'data-p-disabled': isDisabled
-                    },
-                    getPTOptions('previousItemButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('previousItemButton', { isDisabled }),
+                            onClick: navBackward,
+                            disabled: isDisabled,
+                            'data-p-disabled': isDisabled
+                        },
+                        getPTOptions('previousItemButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -129,23 +137,29 @@ export const GalleriaItem = React.memo(
                 const isDisabled = !props.circular && props.activeItemIndex === props.value.length - 1;
 
                 const nextItemIconProps = mergeProps(
-                    {
-                        className: cx('nextItemIcon')
-                    },
-                    getPTOptions('nextItemIcon')
+                    [
+                        {
+                            className: cx('nextItemIcon')
+                        },
+                        getPTOptions('nextItemIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.itemNextIcon || <ChevronRightIcon {...nextItemIconProps} />;
                 const itemNextIcon = IconUtils.getJSXIcon(icon, { ...nextItemIconProps }, { props });
 
                 const nextItemButtonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('nextItemButton', { isDisabled }),
-                        onClick: navForward,
-                        disabled: isDisabled,
-                        'data-p-disabled': isDisabled
-                    },
-                    getPTOptions('nextItemButton')
+                    [
+                        {
+                            type: 'button',
+                            className: cx('nextItemButton', { isDisabled }),
+                            onClick: navForward,
+                            disabled: isDisabled,
+                            'data-p-disabled': isDisabled
+                        },
+                        getPTOptions('nextItemButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -161,10 +175,13 @@ export const GalleriaItem = React.memo(
 
         const createCaption = () => {
             const captionProps = mergeProps(
-                {
-                    className: cx('caption')
-                },
-                getPTOptions('caption')
+                [
+                    {
+                        className: cx('caption')
+                    },
+                    getPTOptions('caption')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.caption) {
@@ -182,16 +199,19 @@ export const GalleriaItem = React.memo(
             let indicator = props.indicator && props.indicator(index);
 
             const indicatorProps = mergeProps(
-                {
-                    className: cx('indicator', { isActive }),
-                    key: key,
-                    tabIndex: 0,
-                    onClick: () => onIndicatorClick(index),
-                    onMouseEnter: () => onIndicatorMouseEnter(index),
-                    onKeyDown: (e) => onIndicatorKeyDown(e, index),
-                    'data-p-highlight': isActive
-                },
-                getPTOptions('indicator')
+                [
+                    {
+                        className: cx('indicator', { isActive }),
+                        key: key,
+                        tabIndex: 0,
+                        onClick: () => onIndicatorClick(index),
+                        onMouseEnter: () => onIndicatorMouseEnter(index),
+                        onKeyDown: (e) => onIndicatorKeyDown(e, index),
+                        'data-p-highlight': isActive
+                    },
+                    getPTOptions('indicator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (!indicator) {
@@ -209,10 +229,13 @@ export const GalleriaItem = React.memo(
             if (props.showIndicators) {
                 let indicators = [];
                 const indicatorsProps = mergeProps(
-                    {
-                        className: classNames(props.indicatorsContentClassName, cx('indicators'))
-                    },
-                    getPTOptions('indicators')
+                    [
+                        {
+                            className: classNames(props.indicatorsContentClassName, cx('indicators'))
+                        },
+                        getPTOptions('indicators')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 for (let i = 0; i < props.value.length; i++) {
@@ -232,25 +255,34 @@ export const GalleriaItem = React.memo(
         const indicators = createIndicators();
 
         const itemWrapperProps = mergeProps(
-            {
-                ref: ref,
-                className: cx('itemWrapper')
-            },
-            getPTOptions('itemWrapper')
+            [
+                {
+                    ref: ref,
+                    className: cx('itemWrapper')
+                },
+                getPTOptions('itemWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const itemContainerProps = mergeProps(
-            {
-                className: cx('itemContainer')
-            },
-            getPTOptions('itemContainer')
+            [
+                {
+                    className: cx('itemContainer')
+                },
+                getPTOptions('itemContainer')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const itemProps = mergeProps(
-            {
-                className: cx('item')
-            },
-            getPTOptions('item')
+            [
+                {
+                    className: cx('item')
+                },
+                getPTOptions('item')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/galleria/GalleriaThumbnails.js
+++ b/components/lib/galleria/GalleriaThumbnails.js
@@ -10,6 +10,7 @@ import { DomHandler, IconUtils, ObjectUtils, UniqueComponentId, classNames, merg
 
 const GalleriaThumbnailItem = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -38,24 +39,30 @@ const GalleriaThumbnailItem = React.memo((props) => {
     const content = props.template && props.template(props.item);
 
     const thumbnailItemProps = mergeProps(
-        {
-            className: classNames(props.className, cx('thumbnailItem', { subProps: props })),
-            'data-p-galleria-thumbnail-item-current': props.current,
-            'data-p-galleria-thumbnail-item-active': props.active,
-            'data-p-galleria-thumbnail-item-start': props.start,
-            'data-p-galleria-thumbnail-item-end': props.end
-        },
-        getPTOptions('thumbnailItem')
+        [
+            {
+                className: classNames(props.className, cx('thumbnailItem', { subProps: props })),
+                'data-p-galleria-thumbnail-item-current': props.current,
+                'data-p-galleria-thumbnail-item-active': props.active,
+                'data-p-galleria-thumbnail-item-start': props.start,
+                'data-p-galleria-thumbnail-item-end': props.end
+            },
+            getPTOptions('thumbnailItem')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const thumbnailItemContentProps = mergeProps(
-        {
-            className: cx('thumbnailItemContent'),
-            tabIndex: tabIndex,
-            onClick: onItemClick,
-            onKeyDown: onItemKeyDown
-        },
-        getPTOptions('thumbnailItemContent')
+        [
+            {
+                className: cx('thumbnailItemContent'),
+                tabIndex: tabIndex,
+                onClick: onItemClick,
+                onKeyDown: onItemKeyDown
+            },
+            getPTOptions('thumbnailItemContent')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (
@@ -365,21 +372,27 @@ export const GalleriaThumbnails = React.memo(
                 let isDisabled = (!props.circular && props.activeItemIndex === 0) || props.value.length <= numVisibleState;
 
                 const previousThumbnailIconProps = mergeProps(
-                    {
-                        className: cx('previousThumbnailIcon')
-                    },
-                    getPTOptions('previousThumbnailIcon')
+                    [
+                        {
+                            className: cx('previousThumbnailIcon')
+                        },
+                        getPTOptions('previousThumbnailIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.isVertical ? props.prevThumbnailIcon || <ChevronUpIcon {...previousThumbnailIconProps} /> : props.prevThumbnailIcon || <ChevronLeftIcon {...previousThumbnailIconProps} />;
                 const prevThumbnailIcon = IconUtils.getJSXIcon(icon, { ...previousThumbnailIconProps }, { props });
                 const previousThumbnailButtonProps = mergeProps(
-                    {
-                        className: cx('previousThumbnailButton', { isDisabled }),
-                        onClick: navBackward,
-                        disabled: isDisabled,
-                        'data-p-disabled': isDisabled
-                    },
-                    getPTOptions('previousThumbnailButton')
+                    [
+                        {
+                            className: cx('previousThumbnailButton', { isDisabled }),
+                            onClick: navBackward,
+                            disabled: isDisabled,
+                            'data-p-disabled': isDisabled
+                        },
+                        getPTOptions('previousThumbnailButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -398,22 +411,28 @@ export const GalleriaThumbnails = React.memo(
                 const isDisabled = (!props.circular && props.activeItemIndex === props.value.length - 1) || props.value.length <= numVisibleState;
 
                 const nextThumbnailIconProps = mergeProps(
-                    {
-                        className: cx('nextThumbnailIcon')
-                    },
-                    getPTOptions('nextThumbnailIcon')
+                    [
+                        {
+                            className: cx('nextThumbnailIcon')
+                        },
+                        getPTOptions('nextThumbnailIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.isVertical ? props.nextThumbnailIcon || <ChevronDownIcon {...nextThumbnailIconProps} /> : props.nextThumbnailIcon || <ChevronRightIcon {...nextThumbnailIconProps} />;
                 const nextThumbnailIcon = IconUtils.getJSXIcon(icon, { ...nextThumbnailIconProps }, { props });
 
                 const nextThumbnailButtonProps = mergeProps(
-                    {
-                        className: cx('nextThumbnailButton', { isDisabled }),
-                        onClick: navForward,
-                        disabled: isDisabled,
-                        'data-p-disabled': isDisabled
-                    },
-                    getPTOptions('nextThumbnailButton')
+                    [
+                        {
+                            className: cx('nextThumbnailButton', { isDisabled }),
+                            onClick: navForward,
+                            disabled: isDisabled,
+                            'data-p-disabled': isDisabled
+                        },
+                        getPTOptions('nextThumbnailButton')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -434,30 +453,39 @@ export const GalleriaThumbnails = React.memo(
             const forwardNavigator = createForwardNavigator();
 
             const thumbnailContainerProps = mergeProps(
-                {
-                    className: cx('thumbnailContainer')
-                },
-                getPTOptions('thumbnailContainer')
+                [
+                    {
+                        className: cx('thumbnailContainer')
+                    },
+                    getPTOptions('thumbnailContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const thumbnailItemsContainerProps = mergeProps(
-                {
-                    className: cx('thumbnailItemsContainer'),
-                    style: sx('thumbnailItemsContainer', { height })
-                },
-                getPTOptions('thumbnailItemsContainer')
+                [
+                    {
+                        className: cx('thumbnailItemsContainer'),
+                        style: sx('thumbnailItemsContainer', { height })
+                    },
+                    getPTOptions('thumbnailItemsContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const thumbnailItemsProps = mergeProps(
-                {
-                    ref: itemsContainerRef,
-                    className: cx('thumbnailItems'),
-                    onTransitionEnd: onTransitionEnd,
-                    onTouchStart: onTouchStart,
-                    onTouchMove: onTouchMove,
-                    onTouchEnd: onTouchEnd
-                },
-                getPTOptions('thumbnailItems')
+                [
+                    {
+                        ref: itemsContainerRef,
+                        className: cx('thumbnailItems'),
+                        onTransitionEnd: onTransitionEnd,
+                        onTouchStart: onTouchStart,
+                        onTouchMove: onTouchMove,
+                        onTouchEnd: onTouchEnd
+                    },
+                    getPTOptions('thumbnailItems')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -474,10 +502,13 @@ export const GalleriaThumbnails = React.memo(
         const content = createContent();
 
         const thumbnailWrapperProps = mergeProps(
-            {
-                className: cx('thumbnailWrapper')
-            },
-            getPTOptions('thumbnailWrapper')
+            [
+                {
+                    className: cx('thumbnailWrapper')
+                },
+                getPTOptions('thumbnailWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <div {...thumbnailWrapperProps}>{content}</div>;

--- a/components/lib/image/Image.js
+++ b/components/lib/image/Image.js
@@ -125,11 +125,14 @@ export const Image = React.memo(
 
         const createPreview = () => {
             const buttonProps = mergeProps(
-                {
-                    className: cx('button'),
-                    onClick: show
-                },
-                ptm('button')
+                [
+                    {
+                        className: cx('button'),
+                        onClick: show
+                    },
+                    ptm('button')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.preview) {
@@ -143,12 +146,12 @@ export const Image = React.memo(
             const { downloadable, alt, crossOrigin, referrerPolicy, useMap, loading } = props;
             const zoomOutDisabled = scaleState <= 0.5;
             const zoomInDisabled = scaleState >= 1.5;
-            const downloadIconProps = mergeProps(ptm('downloadIcon'));
-            const rotateRightIconProps = mergeProps(ptm('rotateRightIcon'));
-            const rotateLeftIconProps = mergeProps(ptm('rotateLeftIcon'));
-            const zoomOutIconProps = mergeProps(ptm('zoomOutIcon'));
-            const zoomInIconProps = mergeProps(ptm('zoomInIcon'));
-            const closeIconProps = mergeProps(ptm('closeIcon'));
+            const downloadIconProps = mergeProps([ptm('downloadIcon')], { useTailwind: context.useTailwind });
+            const rotateRightIconProps = mergeProps([ptm('rotateRightIcon')], { useTailwind: context.useTailwind });
+            const rotateLeftIconProps = mergeProps([ptm('rotateLeftIcon')], { useTailwind: context.useTailwind });
+            const zoomOutIconProps = mergeProps([ptm('zoomOutIcon')], { useTailwind: context.useTailwind });
+            const zoomInIconProps = mergeProps([ptm('zoomInIcon')], { useTailwind: context.useTailwind });
+            const closeIconProps = mergeProps([ptm('closeIcon')], { useTailwind: context.useTailwind });
             const downloadIcon = IconUtils.getJSXIcon(props.downloadIcon || <DownloadIcon />, { ...downloadIconProps }, { props });
             const rotateRightIcon = IconUtils.getJSXIcon(props.rotateRightIcon || <RefreshIcon />, { ...rotateRightIconProps }, { props });
             const rotateLeftIcon = IconUtils.getJSXIcon(props.rotateLeftIcon || <UndoIcon />, { ...rotateLeftIconProps }, { props });
@@ -157,112 +160,145 @@ export const Image = React.memo(
             const closeIcon = IconUtils.getJSXIcon(props.closeIcon || <TimesIcon />, { ...closeIconProps }, { props });
 
             const maskProps = mergeProps(
-                {
-                    ref: maskRef,
-                    className: cx('mask'),
-                    onPointerUp: hide
-                },
-                ptm('mask')
+                [
+                    {
+                        ref: maskRef,
+                        className: cx('mask'),
+                        onPointerUp: hide
+                    },
+                    ptm('mask')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const toolbarProps = mergeProps(
-                {
-                    className: cx('toolbar')
-                },
-                ptm('toolbar')
+                [
+                    {
+                        className: cx('toolbar')
+                    },
+                    ptm('toolbar')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const downloadButtonProps = mergeProps(
-                {
-                    className: cx('downloadButton'),
-                    onPointerUp: onDownload,
-                    type: 'button'
-                },
-                ptm('downloadButton')
+                [
+                    {
+                        className: cx('downloadButton'),
+                        onPointerUp: onDownload,
+                        type: 'button'
+                    },
+                    ptm('downloadButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const rotateRightButtonProps = mergeProps(
-                {
-                    className: cx('rotateRightButton'),
-                    onPointerUp: rotateRight,
-                    type: 'button'
-                },
-                ptm('rotateRightButton')
+                [
+                    {
+                        className: cx('rotateRightButton'),
+                        onPointerUp: rotateRight,
+                        type: 'button'
+                    },
+                    ptm('rotateRightButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const rotateLeftButtonProps = mergeProps(
-                {
-                    className: cx('rotateLeftButton'),
-                    onPointerUp: rotateLeft,
-                    type: 'button'
-                },
-                ptm('rotateLeftButton')
+                [
+                    {
+                        className: cx('rotateLeftButton'),
+                        onPointerUp: rotateLeft,
+                        type: 'button'
+                    },
+                    ptm('rotateLeftButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const zoomOutButtonProps = mergeProps(
-                {
-                    className: classNames(cx('zoomOutButton'), { 'p-disabled': zoomOutDisabled }),
-                    style: { pointerEvents: 'auto' },
-                    onPointerUp: zoomOut,
-                    type: 'button',
-                    disabled: zoomOutDisabled
-                },
-                ptm('zoomOutButton')
+                [
+                    {
+                        className: classNames(cx('zoomOutButton'), { 'p-disabled': zoomOutDisabled }),
+                        style: { pointerEvents: 'auto' },
+                        onPointerUp: zoomOut,
+                        type: 'button',
+                        disabled: zoomOutDisabled
+                    },
+                    ptm('zoomOutButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const zoomInButtonProps = mergeProps(
-                {
-                    className: classNames(cx('zoomInButton'), { 'p-disabled': zoomInDisabled }),
-                    style: { pointerEvents: 'auto' },
-                    onPointerUp: zoomIn,
-                    type: 'button',
-                    disabled: zoomInDisabled
-                },
-                ptm('zoomInButton')
+                [
+                    {
+                        className: classNames(cx('zoomInButton'), { 'p-disabled': zoomInDisabled }),
+                        style: { pointerEvents: 'auto' },
+                        onPointerUp: zoomIn,
+                        type: 'button',
+                        disabled: zoomInDisabled
+                    },
+                    ptm('zoomInButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const closeButtonProps = mergeProps(
-                {
-                    className: cx('closeButton'),
-                    type: 'button',
-                    'aria-label': localeOption('close')
-                },
-                ptm('closeButton')
+                [
+                    {
+                        className: cx('closeButton'),
+                        type: 'button',
+                        'aria-label': localeOption('close')
+                    },
+                    ptm('closeButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const previewProps = mergeProps(
-                {
-                    src: props.zoomSrc || props.src,
-                    className: cx('preview'),
-                    style: sx('preview', { rotateState, scaleState }),
-                    onPointerUp: onPreviewImageClick,
-                    crossOrigin: crossOrigin,
-                    referrerPolicy: referrerPolicy,
-                    useMap: useMap,
-                    loading: loading
-                },
-                ptm('preview')
+                [
+                    {
+                        src: props.zoomSrc || props.src,
+                        className: cx('preview'),
+                        style: sx('preview', { rotateState, scaleState }),
+                        onPointerUp: onPreviewImageClick,
+                        crossOrigin: crossOrigin,
+                        referrerPolicy: referrerPolicy,
+                        useMap: useMap,
+                        loading: loading
+                    },
+                    ptm('preview')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const previewContainerProps = mergeProps(
-                {
-                    ref: previewRef
-                },
-                ptm('previewContainer')
+                [
+                    {
+                        ref: previewRef
+                    },
+                    ptm('previewContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: previewVisibleState,
-                    timeout: { enter: 150, exit: 150 },
-                    unmountOnExit: true,
-                    onEntering: onEntering,
-                    onEntered: onEntered,
-                    onExit: onExit,
-                    onExiting: onExiting,
-                    onExited: onExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: previewVisibleState,
+                        timeout: { enter: 150, exit: 150 },
+                        unmountOnExit: true,
+                        onEntering: onEntering,
+                        onEntered: onEntered,
+                        onExit: onExit,
+                        onExiting: onExiting,
+                        onExited: onExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -295,40 +331,49 @@ export const Image = React.memo(
         const { src, alt, width, height, crossOrigin, referrerPolicy, useMap, loading } = props;
         const element = createElement();
         const iconProp = mergeProps(
-            {
-                className: cx('icon')
-            },
-            ptm('icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                ptm('icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.indicatorIcon || <EyeIcon {...iconProp} />;
         const indicatorIcon = IconUtils.getJSXIcon(icon, { ...iconProp }, { props });
         const content = props.template ? ObjectUtils.getJSXElement(props.template, props) : indicatorIcon;
         const preview = createPreview();
         const imageProp = mergeProps(
-            {
-                ref: imageRef,
-                src: src,
-                className: props.imageClassName,
-                width: width,
-                height: height,
-                crossOrigin: crossOrigin,
-                referrerPolicy: referrerPolicy,
-                useMap: useMap,
-                loading: loading,
-                style: props.imageStyle,
-                onError: props.onError
-            },
-            ptm('image')
+            [
+                {
+                    ref: imageRef,
+                    src: src,
+                    className: props.imageClassName,
+                    width: width,
+                    height: height,
+                    crossOrigin: crossOrigin,
+                    referrerPolicy: referrerPolicy,
+                    useMap: useMap,
+                    loading: loading,
+                    style: props.imageStyle,
+                    onError: props.onError
+                },
+                ptm('image')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const image = props.src && <img {...imageProp} alt={alt} />;
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: cx('root')
-            },
-            ImageBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: cx('root')
+                },
+                ImageBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/inplace/Inplace.js
+++ b/components/lib/inplace/Inplace.js
@@ -65,14 +65,17 @@ export const Inplace = React.forwardRef((inProps, ref) => {
 
     const createDisplay = (content) => {
         const displayProps = mergeProps(
-            {
-                onClick: open,
-                className: cx('display'),
-                onKeyDown: onDisplayKeyDown,
-                tabIndex: props.tabIndex,
-                'aria-label': props.ariaLabel
-            },
-            ptm('display')
+            [
+                {
+                    onClick: open,
+                    className: cx('display'),
+                    onKeyDown: onDisplayKeyDown,
+                    tabIndex: props.tabIndex,
+                    'aria-label': props.ariaLabel
+                },
+                ptm('display')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <div {...displayProps}>{content}</div>;
@@ -84,17 +87,22 @@ export const Inplace = React.forwardRef((inProps, ref) => {
         const ariaLabel = localeOption('close');
 
         if (props.closable) {
-            const closeButtonProps = mergeProps({
-                className: cx('closeButton'),
-                icon: closeIcon,
-                type: 'button',
-                onClick: close,
-                'aria-label': ariaLabel,
-                pt: ptm('closeButton'),
-                __parentMetadata: {
-                    parent: metaData
-                }
-            });
+            const closeButtonProps = mergeProps(
+                [
+                    {
+                        className: cx('closeButton'),
+                        icon: closeIcon,
+                        type: 'button',
+                        onClick: close,
+                        'aria-label': ariaLabel,
+                        pt: ptm('closeButton'),
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    }
+                ],
+                { useTailwind: context.useTailwind }
+            );
 
             return <Button {...closeButtonProps}></Button>;
         }
@@ -106,10 +114,13 @@ export const Inplace = React.forwardRef((inProps, ref) => {
         const closeButton = createCloseButton();
 
         const contentProps = mergeProps(
-            {
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -140,12 +151,15 @@ export const Inplace = React.forwardRef((inProps, ref) => {
     const children = createChildren();
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef,
-            className: classNames(props.className, cx('root'))
-        },
-        InplaceBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef,
+                className: classNames(props.className, cx('root'))
+            },
+            InplaceBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <div {...rootProps}>{children}</div>;

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -1072,26 +1072,32 @@ export const InputNumber = React.memo(
 
         const createUpButton = () => {
             const incrementIconProps = mergeProps(
-                {
-                    className: cx('incrementIcon')
-                },
-                ptm('incrementIcon')
+                [
+                    {
+                        className: cx('incrementIcon')
+                    },
+                    ptm('incrementIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.incrementButtonIcon || <AngleUpIcon {...incrementIconProps} />;
             const upButton = IconUtils.getJSXIcon(icon, { ...incrementIconProps }, { props });
             const incrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: classNames(props.incrementButtonClassName, cx('incrementButton')),
-                    onPointerLeave: onUpButtonMouseLeave,
-                    onPointerDown: (e) => onUpButtonMouseDown(e),
-                    onPointerUp: onUpButtonMouseUp,
-                    onKeyDown: (e) => onUpButtonKeyDown(e),
-                    onKeyUp: onUpButtonKeyUp,
-                    disabled: props.disabled,
-                    tabIndex: -1
-                },
-                ptm('incrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: classNames(props.incrementButtonClassName, cx('incrementButton')),
+                        onPointerLeave: onUpButtonMouseLeave,
+                        onPointerDown: (e) => onUpButtonMouseDown(e),
+                        onPointerUp: onUpButtonMouseUp,
+                        onKeyDown: (e) => onUpButtonKeyDown(e),
+                        onKeyUp: onUpButtonKeyUp,
+                        disabled: props.disabled,
+                        tabIndex: -1
+                    },
+                    ptm('incrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -1104,26 +1110,32 @@ export const InputNumber = React.memo(
 
         const createDownButton = () => {
             const decrementIconProps = mergeProps(
-                {
-                    className: cx('decrementIcon')
-                },
-                ptm('decrementIcon')
+                [
+                    {
+                        className: cx('decrementIcon')
+                    },
+                    ptm('decrementIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.decrementButtonIcon || <AngleDownIcon {...decrementIconProps} />;
             const downButton = IconUtils.getJSXIcon(icon, { ...decrementIconProps }, { props });
             const decrementButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: classNames(props.decrementButtonClassName, cx('decrementButton')),
-                    onPointerLeave: onDownButtonMouseLeave,
-                    onPointerDown: (e) => onDownButtonMouseDown(e),
-                    onPointerUp: onDownButtonMouseUp,
-                    onKeyDown: (e) => onDownButtonKeyDown(e),
-                    onKeyUp: onDownButtonKeyUp,
-                    disabled: props.disabled,
-                    tabIndex: -1
-                },
-                ptm('decrementButton')
+                [
+                    {
+                        type: 'button',
+                        className: classNames(props.decrementButtonClassName, cx('decrementButton')),
+                        onPointerLeave: onDownButtonMouseLeave,
+                        onPointerDown: (e) => onDownButtonMouseDown(e),
+                        onPointerUp: onDownButtonMouseUp,
+                        onKeyDown: (e) => onDownButtonKeyDown(e),
+                        onKeyUp: onDownButtonKeyUp,
+                        disabled: props.disabled,
+                        tabIndex: -1
+                    },
+                    ptm('decrementButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -1138,10 +1150,13 @@ export const InputNumber = React.memo(
             const upButton = props.showButtons && createUpButton();
             const downButton = props.showButtons && createDownButton();
             const buttonGroupProps = mergeProps(
-                {
-                    className: cx('buttonGroup')
-                },
-                ptm('buttonGroup')
+                [
+                    {
+                        className: cx('buttonGroup')
+                    },
+                    ptm('buttonGroup')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (stacked) {
@@ -1168,13 +1183,16 @@ export const InputNumber = React.memo(
         const inputElement = createInputElement();
         const buttonGroup = createButtonGroup();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: classNames(props.className, cx('root', { focusedState, stacked, horizontal, vertical })),
-                style: props.style
-            },
-            otherProps,
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: classNames(props.className, cx('root', { focusedState, stacked, horizontal, vertical })),
+                    style: props.style
+                },
+                otherProps,
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/inputswitch/InputSwitch.js
+++ b/components/lib/inputswitch/InputSwitch.js
@@ -88,45 +88,57 @@ export const InputSwitch = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
 
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root', { focusedState, checked })),
-                style: props.style,
-                onClick,
-                role: 'checkbox',
-                'aria-checked': checked
-            },
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root', { focusedState, checked })),
+                    style: props.style,
+                    onClick,
+                    role: 'checkbox',
+                    'aria-checked': checked
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const hiddenInputWrapperProps = mergeProps(
-            {
-                className: 'p-hidden-accessible'
-            },
-            ptm('hiddenInputWrapper')
+            [
+                {
+                    className: 'p-hidden-accessible'
+                },
+                ptm('hiddenInputWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputProps = mergeProps(
-            {
-                type: 'checkbox',
-                id: props.inputId,
-                name: props.name,
-                checked: checked,
-                onChange: toggle,
-                onFocus: onFocus,
-                onBlur: onBlur,
-                disabled: props.disabled,
-                role: 'switch',
-                tabIndex: props.tabIndex,
-                'aria-checked': checked,
-                ...ariaProps
-            },
-            ptm('hiddenInput')
+            [
+                {
+                    type: 'checkbox',
+                    id: props.inputId,
+                    name: props.name,
+                    checked: checked,
+                    onChange: toggle,
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    disabled: props.disabled,
+                    role: 'switch',
+                    tabIndex: props.tabIndex,
+                    'aria-checked': checked,
+                    ...ariaProps
+                },
+                ptm('hiddenInput')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const sliderProps = mergeProps(
-            {
-                className: cx('slider')
-            },
-            ptm('slider')
+            [
+                {
+                    className: cx('slider')
+                },
+                ptm('slider')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/inputtext/InputText.js
+++ b/components/lib/inputtext/InputText.js
@@ -68,15 +68,18 @@ export const InputText = React.memo(
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
 
         const rootProps = mergeProps(
-            {
-                className: cx('root', { isFilled }),
-                onBeforeInput: onBeforeInput,
-                onInput: onInput,
-                onKeyDown: onKeyDown,
-                onPaste: onPaste
-            },
-            InputTextBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: cx('root', { isFilled }),
+                    onBeforeInput: onBeforeInput,
+                    onInput: onInput,
+                    onKeyDown: onKeyDown,
+                    onPaste: onPaste
+                },
+                InputTextBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -123,19 +123,22 @@ export const InputTextarea = React.memo(
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: cx('root', { isFilled }),
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyUp: onKeyUp,
-                onKeyDown: onKeyDown,
-                onBeforeInput: onBeforeInput,
-                onInput: onInput,
-                onPaste: onPaste
-            },
-            InputTextareaBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: cx('root', { isFilled }),
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyUp: onKeyUp,
+                    onKeyDown: onKeyDown,
+                    onBeforeInput: onBeforeInput,
+                    onInput: onInput,
+                    onPaste: onPaste
+                },
+                InputTextareaBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/knob/Knob.js
+++ b/components/lib/knob/Knob.js
@@ -160,61 +160,76 @@ export const Knob = React.memo(
         }));
 
         const labelProps = mergeProps(
-            {
-                x: 50,
-                y: 57,
-                textAnchor: 'middle',
-                fill: props.textColor,
-                className: cx('label'),
-                name: props.name
-            },
-            ptm('label')
+            [
+                {
+                    x: 50,
+                    y: 57,
+                    textAnchor: 'middle',
+                    fill: props.textColor,
+                    className: cx('label'),
+                    name: props.name
+                },
+                ptm('label')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const text = props.showValue && <text {...labelProps}>{valueToDisplay()}</text>;
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root'),
-                style: props.style
-            },
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root'),
+                    style: props.style
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const svgProps = mergeProps(
-            {
-                viewBox: '0 0 100 100',
-                width: props.size,
-                height: props.size,
-                onClick: (e) => onClick(e),
-                onMouseDown: (e) => onMouseDown(e),
-                onMouseUp: (e) => onMouseUp(e),
-                onTouchStart: (e) => onTouchStart(e),
-                onTouchEnd: (e) => onTouchEnd(e)
-            },
-            ptm('svg')
+            [
+                {
+                    viewBox: '0 0 100 100',
+                    width: props.size,
+                    height: props.size,
+                    onClick: (e) => onClick(e),
+                    onMouseDown: (e) => onMouseDown(e),
+                    onMouseUp: (e) => onMouseUp(e),
+                    onTouchStart: (e) => onTouchStart(e),
+                    onTouchEnd: (e) => onTouchEnd(e)
+                },
+                ptm('svg')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rangeProps = mergeProps(
-            {
-                d: rangePath,
-                strokeWidth: props.strokeWidth,
-                stroke: props.rangeColor,
-                className: cx('range')
-            },
-            ptm('range')
+            [
+                {
+                    d: rangePath,
+                    strokeWidth: props.strokeWidth,
+                    stroke: props.rangeColor,
+                    className: cx('range')
+                },
+                ptm('range')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const valueProps = mergeProps(
-            {
-                d: valuePath,
-                strokeWidth: props.strokeWidth,
-                stroke: props.valueColor,
-                className: cx('value')
-            },
-            ptm('value')
+            [
+                {
+                    d: valuePath,
+                    strokeWidth: props.strokeWidth,
+                    stroke: props.valueColor,
+                    className: cx('value')
+                },
+                ptm('value')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/listbox/ListBox.js
+++ b/components/lib/listbox/ListBox.js
@@ -344,12 +344,15 @@ export const ListBox = React.memo(
                 const key = index + '_' + getOptionGroupRenderKey(option);
 
                 const itemGroupProps = mergeProps(
-                    {
-                        className: ptCallbacks.cx('itemGroup'),
-                        style: ptCallbacks.sx('itemGroup', { scrollerOptions }),
-                        role: 'group'
-                    },
-                    ptCallbacks.ptm('itemGroup')
+                    [
+                        {
+                            className: ptCallbacks.cx('itemGroup'),
+                            style: ptCallbacks.sx('itemGroup', { scrollerOptions }),
+                            role: 'group'
+                        },
+                        ptCallbacks.ptm('itemGroup')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -396,10 +399,13 @@ export const ListBox = React.memo(
 
         const createEmptyMessage = (emptyMessage, isFilter) => {
             const emptyMessageProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('emptyMessage')
-                },
-                ptCallbacks.ptm('emptyMessage')
+                [
+                    {
+                        className: ptCallbacks.cx('emptyMessage')
+                    },
+                    ptCallbacks.ptm('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const message = ObjectUtils.getJSXElement(emptyMessage, props) || localeOption(isFilter ? 'emptyFilterMessage' : 'emptyMessage');
@@ -417,15 +423,18 @@ export const ListBox = React.memo(
                         itemTemplate: (item, options) => item && createItem(item, options.index, options),
                         contentTemplate: (options) => {
                             const listProps = mergeProps(
-                                {
-                                    ref: options.contentRef,
-                                    style: ptCallbacks.sx('list', { options }),
-                                    className: ptCallbacks.cx('list', { options }),
-                                    role: 'listbox',
-                                    'aria-multiselectable': props.multiple,
-                                    ...ariaProps
-                                },
-                                ptCallbacks.ptm('list')
+                                [
+                                    {
+                                        ref: options.contentRef,
+                                        style: ptCallbacks.sx('list', { options }),
+                                        className: ptCallbacks.cx('list', { options }),
+                                        role: 'listbox',
+                                        'aria-multiselectable': props.multiple,
+                                        ...ariaProps
+                                    },
+                                    ptCallbacks.ptm('list')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return <ul {...listProps}>{options.children}</ul>;
@@ -438,13 +447,16 @@ export const ListBox = React.memo(
                 const items = createItems();
 
                 const listProps = mergeProps(
-                    {
-                        className: ptCallbacks.cx('list'),
-                        role: 'listbox',
-                        'aria-multiselectable': props.multiple,
-                        ...ariaProps
-                    },
-                    ptCallbacks.ptm('list')
+                    [
+                        {
+                            className: ptCallbacks.cx('list'),
+                            role: 'listbox',
+                            'aria-multiselectable': props.multiple,
+                            ...ariaProps
+                        },
+                        ptCallbacks.ptm('list')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <ul {...listProps}>{items}</ul>;
@@ -460,22 +472,28 @@ export const ListBox = React.memo(
         const header = createHeader();
 
         const wrapperProps = mergeProps(
-            {
-                className: ptCallbacks.cx('wrapper'),
-                style: props.listStyle
-            },
-            ptCallbacks.ptm('wrapper')
+            [
+                {
+                    className: ptCallbacks.cx('wrapper'),
+                    style: props.listStyle
+                },
+                ptCallbacks.ptm('wrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: ptCallbacks.cx('root'),
-                style: props.style
-            },
-            ListBoxBase.getOtherProps(props),
-            ptCallbacks.ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: ptCallbacks.cx('root'),
+                    style: props.style
+                },
+                ListBoxBase.getOtherProps(props),
+                ptCallbacks.ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/listbox/ListBoxHeader.js
+++ b/components/lib/listbox/ListBoxHeader.js
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { SearchIcon } from '../icons/search';
 import { InputText } from '../inputtext/InputText';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, mergeProps } from '../utils/Utils';
 
 export const ListBoxHeader = React.memo((props) => {
     const {
         ptCallbacks: { ptm, cx }
     } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -31,27 +33,36 @@ export const ListBoxHeader = React.memo((props) => {
 
     const createHeader = () => {
         const filterIconProps = mergeProps(
-            {
-                className: cx('filterIcon')
-            },
-            getPTOptions('filterIcon')
+            [
+                {
+                    className: cx('filterIcon')
+                },
+                getPTOptions('filterIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const icon = props.filterIcon || <SearchIcon {...filterIconProps} />;
         const filterIcon = IconUtils.getJSXIcon(icon, { ...filterIconProps }, { props });
 
         const headerProps = mergeProps(
-            {
-                className: cx('header')
-            },
-            getPTOptions('header')
+            [
+                {
+                    className: cx('header')
+                },
+                getPTOptions('header')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const filterContainerProps = mergeProps(
-            {
-                className: cx('filterContainer')
-            },
-            getPTOptions('filterContainer')
+            [
+                {
+                    className: cx('filterContainer')
+                },
+                getPTOptions('filterContainer')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (

--- a/components/lib/listbox/ListBoxItem.js
+++ b/components/lib/listbox/ListBoxItem.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const ListBoxItem = React.memo((props) => {
     const {
         ptCallbacks: { ptm, cx }
     } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -85,20 +87,23 @@ export const ListBoxItem = React.memo((props) => {
     const content = props.template ? ObjectUtils.getJSXElement(props.template, props.option) : props.label;
 
     const itemProps = mergeProps(
-        {
-            className: cx('item', { props }),
-            style: props.style,
-            onClick: onClick,
-            onTouchEnd: onTouchEnd,
-            onKeyDown: onKeyDown,
-            tabIndex: '-1',
-            'aria-label': props.label,
-            key: props.label,
-            role: 'option',
-            'aria-selected': props.selected,
-            'aria-disabled': props.disabled
-        },
-        getPTOptions('item')
+        [
+            {
+                className: cx('item', { props }),
+                style: props.style,
+                onClick: onClick,
+                onTouchEnd: onTouchEnd,
+                onKeyDown: onKeyDown,
+                tabIndex: '-1',
+                'aria-label': props.label,
+                key: props.label,
+                role: 'option',
+                'aria-selected': props.selected,
+                'aria-disabled': props.disabled
+            },
+            getPTOptions('item')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/megamenu/MegaMenu.js
+++ b/components/lib/megamenu/MegaMenu.js
@@ -241,13 +241,16 @@ export const MegaMenu = React.memo(
             const key = idState + '_separator__' + index;
 
             const separatorProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('separator'),
-                    role: 'separator'
-                },
-                ptm('separator')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('separator'),
+                        role: 'separator'
+                    },
+                    ptm('separator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...separatorProps}></li>;
@@ -256,10 +259,13 @@ export const MegaMenu = React.memo(
         const createSubmenuIcon = (item) => {
             if (item.items) {
                 const submenuIconProps = mergeProps(
-                    {
-                        className: cx('submenuIcon')
-                    },
-                    ptm('submenuIcon')
+                    [
+                        {
+                            className: cx('submenuIcon')
+                        },
+                        ptm('submenuIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const icon = vertical ? props.submenuIcon || <AngleRightIcon {...submenuIconProps} /> : props.submenuIcon || <AngleDownIcon {...submenuIconProps} />;
@@ -282,42 +288,54 @@ export const MegaMenu = React.memo(
                 const key = item.id || idState + '_' + index;
                 const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
                 const iconProps = mergeProps(
-                    {
-                        className: classNames(item.icon, cx('icon'))
-                    },
-                    ptm('icon')
+                    [
+                        {
+                            className: classNames(item.icon, cx('icon'))
+                        },
+                        ptm('icon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const labelProps = mergeProps(
-                    {
-                        className: cx('label')
-                    },
-                    ptm('label')
+                    [
+                        {
+                            className: cx('label')
+                        },
+                        ptm('label')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const iconClassName = classNames(item.icon, 'p-menuitem-icon');
                 const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props });
                 const label = item.label && <span {...labelProps}>{item.label}</span>;
 
                 const actionProps = mergeProps(
-                    {
-                        href: item.url || '#',
-                        className: cx('action', { item }),
-                        target: item.target,
-                        onClick: (event) => onLeafClick(event, item),
-                        role: 'menuitem',
-                        'aria-disabled': item.disabled
-                    },
-                    getPTOptions(item, 'action', index)
+                    [
+                        {
+                            href: item.url || '#',
+                            className: cx('action', { item }),
+                            target: item.target,
+                            onClick: (event) => onLeafClick(event, item),
+                            role: 'menuitem',
+                            'aria-disabled': item.disabled
+                        },
+                        getPTOptions(item, 'action', index)
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const submenuItemProps = mergeProps(
-                    {
-                        key,
-                        id: key,
-                        className: classNames(item.className, cx('submenuItem')),
-                        style: item.style,
-                        role: 'none'
-                    },
-                    getPTOptions(item, 'submenuItem', index)
+                    [
+                        {
+                            key,
+                            id: key,
+                            className: classNames(item.className, cx('submenuItem')),
+                            style: item.style,
+                            role: 'none'
+                        },
+                        getPTOptions(item, 'submenuItem', index)
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 let content = (
@@ -354,15 +372,18 @@ export const MegaMenu = React.memo(
 
             const key = submenu.id || idState + '_sub_' + index;
             const submenuHeaderProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: classNames(submenu.className, cx('submenuHeader', { submenu })),
-                    style: submenu.style,
-                    role: 'presentation',
-                    'data-p-disabled': submenu.disabled
-                },
-                ptm('submenuHeader')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: classNames(submenu.className, cx('submenuHeader', { submenu })),
+                        style: submenu.style,
+                        role: 'presentation',
+                        'data-p-disabled': submenu.disabled
+                    },
+                    ptm('submenuHeader')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -382,20 +403,26 @@ export const MegaMenu = React.memo(
             const submenus = createSubmenus(column);
 
             const columnProps = mergeProps(
-                {
-                    key: key,
-                    className: cx('column', { category })
-                },
-                ptm('column')
+                [
+                    {
+                        key: key,
+                        className: cx('column', { category })
+                    },
+                    ptm('column')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const submenuProps = mergeProps(
-                {
-                    className: cx('submenu'),
-                    style: { display: activeItemState === category ? 'block' : 'none' },
-                    role: 'menu'
-                },
-                ptm('submenu')
+                [
+                    {
+                        className: cx('submenu'),
+                        style: { display: activeItemState === category ? 'block' : 'none' },
+                        role: 'menu'
+                    },
+                    ptm('submenu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -420,17 +447,23 @@ export const MegaMenu = React.memo(
                 const columns = createColumns(category);
 
                 const panelProps = mergeProps(
-                    {
-                        className: cx('panel')
-                    },
-                    ptm('panel')
+                    [
+                        {
+                            className: cx('panel')
+                        },
+                        ptm('panel')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const gridProps = mergeProps(
-                    {
-                        className: cx('grid')
-                    },
-                    ptm('grid')
+                    [
+                        {
+                            className: cx('grid')
+                        },
+                        ptm('grid')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -554,18 +587,24 @@ export const MegaMenu = React.memo(
 
         const createCategory = (category, index) => {
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                getPTOptions(category, 'icon', index)
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    getPTOptions(category, 'icon', index)
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(category.icon, { ...iconProps }, { props });
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                getPTOptions(category, 'label', index)
+                [
+                    {
+                        className: cx('label')
+                    },
+                    getPTOptions(category, 'label', index)
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = category.label && <span {...labelProps}>{category.label}</span>;
             const itemContent = category.template ? ObjectUtils.getJSXElement(category.template, category) : null;
@@ -573,31 +612,37 @@ export const MegaMenu = React.memo(
             const panel = createCategoryPanel(category);
 
             const headerActionProps = mergeProps(
-                {
-                    href: category.url || '#',
-                    className: cx('headerAction', { category }),
-                    target: category.target,
-                    onClick: (e) => onCategoryClick(e, category),
-                    onKeyDown: (e) => onCategoryKeyDown(e, category),
-                    role: 'menuitem',
-                    'aria-haspopup': category.items != null,
-                    'data-p-disabled': category.disabled
-                },
-                getPTOptions(category, 'headerAction', index)
+                [
+                    {
+                        href: category.url || '#',
+                        className: cx('headerAction', { category }),
+                        target: category.target,
+                        onClick: (e) => onCategoryClick(e, category),
+                        onKeyDown: (e) => onCategoryKeyDown(e, category),
+                        role: 'menuitem',
+                        'aria-haspopup': category.items != null,
+                        'data-p-disabled': category.disabled
+                    },
+                    getPTOptions(category, 'headerAction', index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const key = category.id || idState + '_cat_' + index;
             const menuItemProps = mergeProps(
-                {
-                    key,
-                    id: key,
-                    className: classNames(category.className, cx('menuitem', { category, activeItemState })),
-                    style: category.style,
-                    onMouseEnter: (e) => onCategoryMouseEnter(e, category),
-                    role: 'none',
-                    'data-p-disabled': category.disabled || false
-                },
-                getPTOptions(category, 'menuitem', index)
+                [
+                    {
+                        key,
+                        id: key,
+                        className: classNames(category.className, cx('menuitem', { category, activeItemState })),
+                        style: category.style,
+                        onMouseEnter: (e) => onCategoryMouseEnter(e, category),
+                        role: 'none',
+                        'data-p-disabled': category.disabled || false
+                    },
+                    getPTOptions(category, 'menuitem', index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -616,11 +661,14 @@ export const MegaMenu = React.memo(
 
         const createMenu = () => {
             const menuProps = mergeProps(
-                {
-                    className: cx('menu'),
-                    role: 'menubar'
-                },
-                ptm('menu')
+                [
+                    {
+                        className: cx('menu'),
+                        role: 'menubar'
+                    },
+                    ptm('menu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.model) {
@@ -638,10 +686,13 @@ export const MegaMenu = React.memo(
 
         const createStartContent = () => {
             const startProps = mergeProps(
-                {
-                    className: cx('start')
-                },
-                ptm('start')
+                [
+                    {
+                        className: cx('start')
+                    },
+                    ptm('start')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.start) {
@@ -655,10 +706,13 @@ export const MegaMenu = React.memo(
 
         const createEndContent = () => {
             const endProps = mergeProps(
-                {
-                    className: cx('end')
-                },
-                ptm('end')
+                [
+                    {
+                        className: cx('end')
+                    },
+                    ptm('end')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.end) {
@@ -676,17 +730,20 @@ export const MegaMenu = React.memo(
             }
 
             const menuButtonProps = mergeProps(
-                {
-                    className: cx('menuButton'),
-                    href: '#',
-                    role: 'button',
-                    tabIndex: 0,
-                    onClick: (e) => toggle(e)
-                },
-                ptm('menuButton')
+                [
+                    {
+                        className: cx('menuButton'),
+                        href: '#',
+                        role: 'button',
+                        tabIndex: 0,
+                        onClick: (e) => toggle(e)
+                    },
+                    ptm('menuButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
-            const menuButtonIconProps = mergeProps(ptm('menuButtonIcon'));
+            const menuButtonIconProps = mergeProps([ptm('menuButtonIcon')], { useTailwind: context.useTailwind });
 
             const icon = props.menuIcon || <BarsIcon {...menuButtonIconProps} />;
             const menuIcon = IconUtils.getJSXIcon(icon, { ...menuButtonIconProps }, { props });
@@ -702,12 +759,15 @@ export const MegaMenu = React.memo(
         };
 
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root', { mobileActiveState })),
-                style: props.style
-            },
-            MegaMenuBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root', { mobileActiveState })),
+                    style: props.style
+                },
+                MegaMenuBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const menu = createMenu();

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -375,12 +375,15 @@ export const Mention = React.memo(
             const content = props.itemTemplate ? ObjectUtils.getJSXElement(props.itemTemplate, suggestion, { trigger: triggerState ? triggerState.key : '', index }) : formatValue(suggestion);
 
             const itemProps = mergeProps(
-                {
-                    key: key,
-                    className: cx('item'),
-                    onClick: (e) => onItemClick(e, suggestion)
-                },
-                getPTOptions(suggestion, 'item')
+                [
+                    {
+                        key: key,
+                        className: cx('item'),
+                        onClick: (e) => onItemClick(e, suggestion)
+                    },
+                    getPTOptions(suggestion, 'item')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -393,11 +396,14 @@ export const Mention = React.memo(
 
         const createList = () => {
             const itemsProps = mergeProps(
-                {
-                    ref: listRef,
-                    className: cx('items')
-                },
-                ptm('items')
+                [
+                    {
+                        ref: listRef,
+                        className: cx('items')
+                    },
+                    ptm('items')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.suggestions) {
@@ -415,32 +421,38 @@ export const Mention = React.memo(
             const list = createList();
 
             const panelProps = mergeProps(
-                {
-                    ref: overlayRef,
-                    className: cx('panel'),
-                    style: {
-                        maxHeight: props.scrollHeight,
-                        ...props.panelStyle
+                [
+                    {
+                        ref: overlayRef,
+                        className: cx('panel'),
+                        style: {
+                            maxHeight: props.scrollHeight,
+                            ...props.panelStyle
+                        },
+                        onClick: onPanelClick
                     },
-                    onClick: onPanelClick
-                },
-                ptm('panel')
+                    ptm('panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: overlayVisibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: onOverlayEnter,
-                    onEntering: onOverlayEntering,
-                    onEntered: onOverlayEntered,
-                    onExit: onOverlayExit,
-                    onExited: onOverlayExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: overlayVisibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: onOverlayEnter,
+                        onEntering: onOverlayEntering,
+                        onEntered: onOverlayEntered,
+                        onExit: onOverlayExit,
+                        onExited: onOverlayExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const panel = (
@@ -460,34 +472,40 @@ export const Mention = React.memo(
         const panel = createPanel();
 
         const inputMentionProps = mergeProps(
-            {
-                ref: inputRef,
-                id: props.inputId,
-                className: cx('input'),
-                style: props.inputStyle,
-                ...inputProps,
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyDown: onKeyDown,
-                onInput: onInput,
-                onKeyUp: onKeyUp,
-                onChange: onChange,
-                __parentMetadata: {
-                    parent: metaData
-                }
-            },
-            ptm('input')
+            [
+                {
+                    ref: inputRef,
+                    id: props.inputId,
+                    className: cx('input'),
+                    style: props.inputStyle,
+                    ...inputProps,
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyDown: onKeyDown,
+                    onInput: onInput,
+                    onKeyUp: onKeyUp,
+                    onChange: onChange,
+                    __parentMetadata: {
+                        parent: metaData
+                    }
+                },
+                ptm('input')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root', { focusedState, isFilled }),
-                style: props.style
-            },
-            MentionBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root', { focusedState, isFilled }),
+                    style: props.style
+                },
+                MentionBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -169,15 +169,18 @@ export const Menu = React.memo(
             const key = idState + '_sub_' + index;
             const items = submenu.items.map(createMenuItem);
             const submenuHeaderProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    role: 'presentation',
-                    className: classNames(submenu.className, cx('submenuHeader', { submenu })),
-                    style: sx('submenuHeader', { submenu }),
-                    'data-p-disabled': submenu.disabled
-                },
-                ptm('submenuHeader')
+                [
+                    {
+                        id: key,
+                        key,
+                        role: 'presentation',
+                        className: classNames(submenu.className, cx('submenuHeader', { submenu })),
+                        style: sx('submenuHeader', { submenu }),
+                        'data-p-disabled': submenu.disabled
+                    },
+                    ptm('submenuHeader')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -191,13 +194,16 @@ export const Menu = React.memo(
         const createSeparator = (index) => {
             const key = idState + '_separator_' + index;
             const separatorProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('separator'),
-                    role: 'separator'
-                },
-                ptm('separator')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('separator'),
+                        role: 'separator'
+                    },
+                    ptm('separator')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...separatorProps}></li>;
@@ -211,34 +217,43 @@ export const Menu = React.memo(
             const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props });
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const tabIndex = item.disabled ? null : 0;
             const key = item.id || idState + '_' + index;
             const actionProps = mergeProps(
-                {
-                    href: item.url || '#',
-                    className: cx('action', { item }),
-                    role: 'menuitem',
-                    target: item.target,
-                    onClick: (event) => onItemClick(event, item),
-                    onKeyDown: (event) => onItemKeyDown(event, item),
-                    tabIndex: tabIndex,
-                    'aria-disabled': item.disabled,
-                    'data-p-disabled': item.disabled
-                },
-                ptm('action')
+                [
+                    {
+                        href: item.url || '#',
+                        className: cx('action', { item }),
+                        role: 'menuitem',
+                        target: item.target,
+                        onClick: (event) => onItemClick(event, item),
+                        onKeyDown: (event) => onItemKeyDown(event, item),
+                        tabIndex: tabIndex,
+                        'aria-disabled': item.disabled,
+                        'data-p-disabled': item.disabled
+                    },
+                    ptm('action')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -264,15 +279,18 @@ export const Menu = React.memo(
             }
 
             const menuitemProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: classNames(item.className, cx('menuitem')),
-                    style: sx('menuitem', { item }),
-                    role: 'none',
-                    'data-p-disabled': item.disabled || false
-                },
-                ptm('menuitem')
+                [
+                    {
+                        id: key,
+                        key,
+                        className: classNames(item.className, cx('menuitem')),
+                        style: sx('menuitem', { item }),
+                        role: 'none',
+                        'data-p-disabled': item.disabled || false
+                    },
+                    ptm('menuitem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuitemProps}>{content}</li>;
@@ -290,36 +308,45 @@ export const Menu = React.memo(
             if (props.model) {
                 const menuitems = createMenu();
                 const rootProps = mergeProps(
-                    {
-                        className: classNames(props.className, cx('root', { context })),
-                        style: props.style,
-                        onClick: (e) => onPanelClick(e)
-                    },
-                    MenuBase.getOtherProps(props),
-                    ptm('root')
+                    [
+                        {
+                            className: classNames(props.className, cx('root', { context })),
+                            style: props.style,
+                            onClick: (e) => onPanelClick(e)
+                        },
+                        MenuBase.getOtherProps(props),
+                        ptm('root')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const menuProps = mergeProps(
-                    {
-                        className: cx('menu'),
-                        role: 'menu'
-                    },
-                    ptm('menu')
+                    [
+                        {
+                            className: cx('menu'),
+                            role: 'menu'
+                        },
+                        ptm('menu')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const transitionProps = mergeProps(
-                    {
-                        classNames: cx('transition'),
-                        in: visibleState,
-                        timeout: { enter: 120, exit: 100 },
-                        options: props.transitionOptions,
-                        unmountOnExit: true,
-                        onEnter,
-                        onEntered,
-                        onExit,
-                        onExited
-                    },
-                    ptm('transition')
+                    [
+                        {
+                            classNames: cx('transition'),
+                            in: visibleState,
+                            timeout: { enter: 120, exit: 100 },
+                            options: props.transitionOptions,
+                            unmountOnExit: true,
+                            onEnter,
+                            onEntered,
+                            onExit,
+                            onExited
+                        },
+                        ptm('transition')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (

--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -82,10 +82,13 @@ export const Menubar = React.memo(
             if (props.start) {
                 const start = ObjectUtils.getJSXElement(props.start, props);
                 const startProps = mergeProps(
-                    {
-                        className: cx('start')
-                    },
-                    ptm('start')
+                    [
+                        {
+                            className: cx('start')
+                        },
+                        ptm('start')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...startProps}>{start}</div>;
@@ -98,10 +101,13 @@ export const Menubar = React.memo(
             if (props.end) {
                 const end = ObjectUtils.getJSXElement(props.end, props);
                 const endProps = mergeProps(
-                    {
-                        className: cx('end')
-                    },
-                    ptm('end')
+                    [
+                        {
+                            className: cx('end')
+                        },
+                        ptm('end')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...endProps}>{end}</div>;
@@ -116,17 +122,20 @@ export const Menubar = React.memo(
             }
 
             const buttonProps = mergeProps(
-                {
-                    ref: menuButtonRef,
-                    href: '#',
-                    role: 'button',
-                    tabIndex: 0,
-                    className: cx('button'),
-                    onClick: (e) => toggle(e)
-                },
-                ptm('button')
+                [
+                    {
+                        ref: menuButtonRef,
+                        href: '#',
+                        role: 'button',
+                        tabIndex: 0,
+                        className: cx('button'),
+                        onClick: (e) => toggle(e)
+                    },
+                    ptm('button')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const popupIconProps = mergeProps(ptm('popupIcon'));
+            const popupIconProps = mergeProps([ptm('popupIcon')], { useTailwind: context.useTailwind });
             const icon = props.menuIcon || <BarsIcon {...popupIconProps} />;
             const menuIcon = IconUtils.getJSXIcon(icon, { ...popupIconProps }, { props });
 
@@ -142,13 +151,16 @@ export const Menubar = React.memo(
         const menuButton = createMenuButton();
         const submenu = <MenubarSub hostName="Menubar" id={idState} ref={rootMenuRef} menuProps={props} model={props.model} root mobileActive={mobileActiveState} onLeafClick={onLeafClick} submenuIcon={props.submenuIcon} ptm={ptm} cx={cx} />;
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: classNames(props.className, cx('root', { mobileActiveState })),
-                style: props.style
-            },
-            MenubarBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: classNames(props.className, cx('root', { mobileActiveState })),
+                    style: props.style
+                },
+                MenubarBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/menubar/MenubarSub.js
+++ b/components/lib/menubar/MenubarSub.js
@@ -3,10 +3,12 @@ import { useEventListener, useMountEffect, useUpdateEffect } from '../hooks/Hook
 import { AngleDownIcon } from '../icons/angledown';
 import { AngleRightIcon } from '../icons/angleright';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const MenubarSub = React.memo(
     React.forwardRef((props, ref) => {
+        const context = React.useContext(PrimeReactContext);
         const [activeItemState, setActiveItemState] = React.useState(null);
         const { ptm, cx } = props;
 
@@ -178,13 +180,16 @@ export const MenubarSub = React.memo(
         const createSeparator = (index) => {
             const key = props.id + '_separator_' + index;
             const separatorProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    className: cx('separator'),
-                    role: 'separator'
-                },
-                ptm('separator', { hostName: props.hostName })
+                [
+                    {
+                        id: key,
+                        key,
+                        className: cx('separator'),
+                        role: 'separator'
+                    },
+                    ptm('separator', { hostName: props.hostName })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...separatorProps}></li>;
@@ -221,25 +226,34 @@ export const MenubarSub = React.memo(
             const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                getPTOptions(item, 'icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    getPTOptions(item, 'icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props: props.menuProps });
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                getPTOptions(item, 'label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    getPTOptions(item, 'label')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const submenuIconClassName = 'p-submenu-icon';
             const submenuIconProps = mergeProps(
-                {
-                    className: cx('submenuIcon')
-                },
-                getPTOptions(item, 'submenuIcon')
+                [
+                    {
+                        className: cx('submenuIcon')
+                    },
+                    getPTOptions(item, 'submenuIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const submenuIcon =
                 item.items &&
@@ -250,16 +264,19 @@ export const MenubarSub = React.memo(
                 );
             const submenu = createSubmenu(item, index);
             const actionProps = mergeProps(
-                {
-                    href: item.url || '#',
-                    role: 'menuitem',
-                    className: cx('action', { item }),
-                    target: item.target,
-                    'aria-haspopup': item.items != null,
-                    onClick: (event) => onItemClick(event, item),
-                    onKeyDown: (event) => onItemKeyDown(event, item)
-                },
-                getPTOptions(item, 'action')
+                [
+                    {
+                        href: item.url || '#',
+                        role: 'menuitem',
+                        className: cx('action', { item }),
+                        target: item.target,
+                        'aria-haspopup': item.items != null,
+                        onClick: (event) => onItemClick(event, item),
+                        onKeyDown: (event) => onItemKeyDown(event, item)
+                    },
+                    getPTOptions(item, 'action')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -287,15 +304,18 @@ export const MenubarSub = React.memo(
             }
 
             const menuitemProps = mergeProps(
-                {
-                    id: key,
-                    key,
-                    role: 'none',
-                    className: classNames(item.className, cx('menuitem', { item, activeItemState })),
-                    onMouseEnter: (event) => onItemMouseEnter(event, item),
-                    'data-p-disabled': item.disabled || false
-                },
-                getPTOptions(item, 'menuitem')
+                [
+                    {
+                        id: key,
+                        key,
+                        role: 'none',
+                        className: classNames(item.className, cx('menuitem', { item, activeItemState })),
+                        onMouseEnter: (event) => onItemMouseEnter(event, item),
+                        'data-p-disabled': item.disabled || false
+                    },
+                    getPTOptions(item, 'menuitem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -318,13 +338,16 @@ export const MenubarSub = React.memo(
         const ptKey = props.root ? 'menu' : 'submenu';
         const submenu = createMenu();
         const menuProps = mergeProps(
-            {
-                ref,
-                className: cx(ptKey),
-                style: !props.root && { display: props.parentActive ? 'block' : 'none' },
-                role
-            },
-            ptm(ptKey)
+            [
+                {
+                    ref,
+                    className: cx(ptKey),
+                    style: !props.root && { display: props.parentActive ? 'block' : 'none' },
+                    role
+                },
+                ptm(ptKey)
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <ul {...menuProps}>{submenu}</ul>;

--- a/components/lib/message/Message.js
+++ b/components/lib/message/Message.js
@@ -29,10 +29,13 @@ export const Message = React.memo(
             const text = ObjectUtils.getJSXElement(props.text, props);
 
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let icon = props.icon;
@@ -59,10 +62,13 @@ export const Message = React.memo(
             const messageIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
 
             const textProps = mergeProps(
-                {
-                    className: cx('text')
-                },
-                ptm('text')
+                [
+                    {
+                        className: cx('text')
+                    },
+                    ptm('text')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -81,14 +87,17 @@ export const Message = React.memo(
         const content = createContent();
 
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root')),
-                style: props.style,
-                role: 'alert',
-                'aria-live': 'polite'
-            },
-            MessageBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root')),
+                    style: props.style,
+                    role: 'alert',
+                    'aria-live': 'polite'
+                },
+                MessageBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -92,23 +92,29 @@ export const Messages = React.memo(
         }));
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: props.className,
-                style: props.style
-            },
-            MessagesBase.getOtherProps(props),
-            ptCallbacks.ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: props.className,
+                    style: props.style
+                },
+                MessagesBase.getOtherProps(props),
+                ptCallbacks.ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: ptCallbacks.cx('transition'),
-                unmountOnExit: true,
-                timeout: { enter: 300, exit: 300 },
-                options: props.transitionOptions
-            },
-            ptCallbacks.ptm('transition')
+            [
+                {
+                    classNames: ptCallbacks.cx('transition'),
+                    unmountOnExit: true,
+                    timeout: { enter: 300, exit: 300 },
+                    options: props.transitionOptions
+                },
+                ptCallbacks.ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/messages/UIMessage.js
+++ b/components/lib/messages/UIMessage.js
@@ -7,10 +7,12 @@ import { InfoCircleIcon } from '../icons/infocircle';
 import { TimesIcon } from '../icons/times';
 import { TimesCircleIcon } from '../icons/timescircle';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, IconUtils, mergeProps } from '../utils/Utils';
 
 export const UIMessage = React.memo(
     React.forwardRef((props, ref) => {
+        const context = React.useContext(PrimeReactContext);
         const {
             message: messageInfo,
             metaData: parentMetaData,
@@ -54,26 +56,32 @@ export const UIMessage = React.memo(
                 const ariaLabel = localeOption('close');
 
                 const buttonIconProps = mergeProps(
-                    {
-                        className: cx('uimessage.buttonicon'),
-                        'aria-hidden': true
-                    },
-                    getPTOptions('buttonicon', parentParams),
-                    ptmo(pt, 'buttonicon', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('uimessage.buttonicon'),
+                            'aria-hidden': true
+                        },
+                        getPTOptions('buttonicon', parentParams),
+                        ptmo(pt, 'buttonicon', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const icon = _closeIcon || <TimesIcon {...buttonIconProps} />;
                 const closeIcon = IconUtils.getJSXIcon(icon, { ...buttonIconProps }, { props });
 
                 const buttonProps = mergeProps(
-                    {
-                        type: 'button',
-                        className: cx('uimessage.button'),
-                        'aria-label': ariaLabel,
-                        onClick: onClose
-                    },
-                    getPTOptions('button', parentParams),
-                    ptmo(pt, 'button', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            type: 'button',
+                            className: cx('uimessage.button'),
+                            'aria-label': ariaLabel,
+                            onClick: onClose
+                        },
+                        getPTOptions('button', parentParams),
+                        ptmo(pt, 'button', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -90,11 +98,14 @@ export const UIMessage = React.memo(
         const createMessage = () => {
             if (props.message) {
                 const iconProps = mergeProps(
-                    {
-                        className: cx('uimessage.icon')
-                    },
-                    getPTOptions('icon', parentParams),
-                    ptmo(pt, 'icon', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('uimessage.icon')
+                        },
+                        getPTOptions('icon', parentParams),
+                        ptmo(pt, 'icon', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 let icon = _icon;
@@ -121,19 +132,25 @@ export const UIMessage = React.memo(
                 const iconContent = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
 
                 const summaryProps = mergeProps(
-                    {
-                        className: cx('uimessage.summary')
-                    },
-                    getPTOptions('summary', parentParams),
-                    ptmo(pt, 'summary', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('uimessage.summary')
+                        },
+                        getPTOptions('summary', parentParams),
+                        ptmo(pt, 'summary', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const detailProps = mergeProps(
-                    {
-                        className: cx('uimessage.detail')
-                    },
-                    getPTOptions('detail', parentParams),
-                    ptmo(pt, 'detail', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('uimessage.detail')
+                        },
+                        getPTOptions('detail', parentParams),
+                        ptmo(pt, 'detail', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -154,23 +171,29 @@ export const UIMessage = React.memo(
         const message = createMessage();
 
         const wrapperProps = mergeProps(
-            {
-                className: classNames(_contentClassName, cx('uimessage.wrapper')),
-                style: contentStyle
-            },
-            getPTOptions('wrapper', parentParams),
-            ptmo(pt, 'wrapper', { ...params, hostName: props.hostName })
+            [
+                {
+                    className: classNames(_contentClassName, cx('uimessage.wrapper')),
+                    style: contentStyle
+                },
+                getPTOptions('wrapper', parentParams),
+                ptmo(pt, 'wrapper', { ...params, hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                ref,
-                className: classNames(_className, cx('uimessage.root', { severity })),
-                style,
-                onClick
-            },
-            getPTOptions('root', parentParams),
-            ptmo(pt, 'root', { ...params, hostName: props.hostName })
+            [
+                {
+                    ref,
+                    className: classNames(_className, cx('uimessage.root', { severity })),
+                    style,
+                    onClick
+                },
+                getPTOptions('root', parentParams),
+                ptmo(pt, 'root', { ...params, hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -534,28 +534,37 @@ export const MultiSelect = React.memo(
                     return value.map((val, i) => {
                         const label = getLabelByValue(val);
                         const iconProps = mergeProps(
-                            {
-                                key: i,
-                                className: cx('removeTokenIcon'),
-                                onClick: (e) => removeChip(e, val)
-                            },
-                            ptm('removeTokenIcon')
+                            [
+                                {
+                                    key: i,
+                                    className: cx('removeTokenIcon'),
+                                    onClick: (e) => removeChip(e, val)
+                                },
+                                ptm('removeTokenIcon')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
                         const icon = !props.disabled && (props.removeIcon ? IconUtils.getJSXIcon(props.removeIcon, { ...iconProps }, { props }) : <TimesCircleIcon {...iconProps} />);
 
                         const tokenProps = mergeProps(
-                            {
-                                className: cx('token')
-                            },
-                            ptm('token')
+                            [
+                                {
+                                    className: cx('token')
+                                },
+                                ptm('token')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
 
                         const tokenLabelProps = mergeProps(
-                            {
-                                key: label + i,
-                                className: cx('tokenLabel')
-                            },
-                            ptm('tokenLabel')
+                            [
+                                {
+                                    key: label + i,
+                                    className: cx('tokenLabel')
+                                },
+                                ptm('tokenLabel')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
 
                         return (
@@ -628,11 +637,14 @@ export const MultiSelect = React.memo(
 
         const createClearIcon = () => {
             const clearIconProps = mergeProps(
-                {
-                    className: cx('clearIcon'),
-                    onClick: (e) => updateModel(e, [], [])
-                },
-                ptm('clearIcon')
+                [
+                    {
+                        className: cx('clearIcon'),
+                        onClick: (e) => updateModel(e, [], [])
+                    },
+                    ptm('clearIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.clearIcon || <TimesIcon {...clearIconProps} />;
@@ -649,18 +661,24 @@ export const MultiSelect = React.memo(
             const content = getLabelContent();
 
             const labelContainerProps = mergeProps(
-                {
-                    ref: labelRef,
-                    className: cx('labelContainer')
-                },
-                ptm('labelContainer')
+                [
+                    {
+                        ref: labelRef,
+                        className: cx('labelContainer')
+                    },
+                    ptm('labelContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label', { empty })
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label', { empty })
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -677,17 +695,23 @@ export const MultiSelect = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
 
         const triggerIconProps = mergeProps(
-            {
-                className: cx('triggerIcon')
-            },
-            ptm('triggerIcon')
+            [
+                {
+                    className: cx('triggerIcon')
+                },
+                ptm('triggerIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const triggerProps = mergeProps(
-            {
-                className: cx('trigger')
-            },
-            ptm('trigger')
+            [
+                {
+                    className: cx('trigger')
+                },
+                ptm('trigger')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const dropdownIcon = <div {...triggerProps}>{props.dropdownIcon ? IconUtils.getJSXIcon(props.dropdownIcon, { ...triggerIconProps }, { props }) : <ChevronDownIcon {...triggerIconProps} />}</div>;
 
@@ -695,41 +719,50 @@ export const MultiSelect = React.memo(
         const clearIcon = !props.inline && createClearIcon();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                style: { ...props.style, ...sx('root') },
-                className: classNames(props.className, cx('root', { focusedState, overlayVisibleState })),
-                ...otherProps,
-                onClick: onClick
-            },
-            MultiSelectBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    style: { ...props.style, ...sx('root') },
+                    className: classNames(props.className, cx('root', { focusedState, overlayVisibleState })),
+                    ...otherProps,
+                    onClick: onClick
+                },
+                MultiSelectBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputWrapperProps = mergeProps(
-            {
-                className: 'p-hidden-accessible'
-            },
-            ptm('hiddenInputWrapper')
+            [
+                {
+                    className: 'p-hidden-accessible'
+                },
+                ptm('hiddenInputWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const inputProps = mergeProps(
-            {
-                ref: inputRef,
-                id: props.inputId,
-                name: props.name,
-                type: 'text',
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyDown: onKeyDown,
-                role: 'listbox',
-                'aria-expanded': overlayVisibleState,
-                disabled: props.disabled,
-                tabIndex: props.tabIndex,
-                ...ariaProps
-            },
-            ptm('input')
+            [
+                {
+                    ref: inputRef,
+                    id: props.inputId,
+                    name: props.name,
+                    type: 'text',
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyDown: onKeyDown,
+                    role: 'listbox',
+                    'aria-expanded': overlayVisibleState,
+                    disabled: props.disabled,
+                    tabIndex: props.tabIndex,
+                    ...ariaProps
+                },
+                ptm('input')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/multiselect/MultiSelectHeader.js
+++ b/components/lib/multiselect/MultiSelectHeader.js
@@ -6,10 +6,12 @@ import { SearchIcon } from '../icons/search';
 import { TimesIcon } from '../icons/times';
 import { InputText } from '../inputtext/InputText';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, UniqueComponentId, mergeProps } from '../utils/Utils';
 
 export const MultiSelectHeader = React.memo((props) => {
     const { ptm, cx, isUnstyled } = props;
+    const context = React.useContext(PrimeReactContext);
     const filterOptions = {
         filter: (e) => onFilter(e),
         reset: () => props.resetFilter()
@@ -45,10 +47,13 @@ export const MultiSelectHeader = React.memo((props) => {
 
     const createFilterElement = () => {
         const filterIconProps = mergeProps(
-            {
-                className: cx('filterIcon')
-            },
-            getPTOptions('filterIcon')
+            [
+                {
+                    className: cx('filterIcon')
+                },
+                getPTOptions('filterIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const icon = props.filterIcon || <SearchIcon {...filterIconProps} />;
@@ -56,10 +61,13 @@ export const MultiSelectHeader = React.memo((props) => {
 
         if (props.filter) {
             const filterContainerProps = mergeProps(
-                {
-                    className: cx('filterContainer')
-                },
-                getPTOptions('filterContainer')
+                [
+                    {
+                        className: cx('filterContainer')
+                    },
+                    getPTOptions('filterContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -102,18 +110,24 @@ export const MultiSelectHeader = React.memo((props) => {
     const selectAllId = props.id ? props.id + '_selectall' : UniqueComponentId();
 
     const headerSelectAllLabelProps = mergeProps(
-        {
-            htmlFor: selectAllId,
-            className: cx('headerSelectAllLabel')
-        },
-        getPTOptions('headerSelectAllLabel')
+        [
+            {
+                htmlFor: selectAllId,
+                className: cx('headerSelectAllLabel')
+            },
+            getPTOptions('headerSelectAllLabel')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const headerCheckboxIconProps = mergeProps(
-        {
-            className: cx('headerCheckboxIcon')
-        },
-        getPTOptions('headerCheckboxIcon')
+        [
+            {
+                className: cx('headerCheckboxIcon')
+            },
+            getPTOptions('headerCheckboxIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const checkedIcon = props.itemCheckboxIcon || <CheckIcon {...headerCheckboxIconProps} />;
@@ -127,30 +141,39 @@ export const MultiSelectHeader = React.memo((props) => {
     );
 
     const iconProps = mergeProps(
-        {
-            className: cx('closeIcon'),
-            'aria-hidden': true
-        },
-        getPTOptions('closeIcon')
+        [
+            {
+                className: cx('closeIcon'),
+                'aria-hidden': true
+            },
+            getPTOptions('closeIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.closeIcon || <TimesIcon {...iconProps} />;
     const closeIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
 
     const headerProps = mergeProps(
-        {
-            className: cx('header')
-        },
-        getPTOptions('header')
+        [
+            {
+                className: cx('header')
+            },
+            getPTOptions('header')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const closeButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('closeButton'),
-            'aria-label': localeOption('close'),
-            onClick: props.onClose
-        },
-        getPTOptions('closeButton')
+        [
+            {
+                type: 'button',
+                className: cx('closeButton'),
+                'aria-label': localeOption('close'),
+                onClick: props.onClose
+            },
+            getPTOptions('closeButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const closeElement = (

--- a/components/lib/multiselect/MultiSelectItem.js
+++ b/components/lib/multiselect/MultiSelectItem.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { CheckIcon } from '../icons/check';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const MultiSelectItem = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -36,10 +38,13 @@ export const MultiSelectItem = React.memo((props) => {
     };
 
     const checkboxIconProps = mergeProps(
-        {
-            className: cx('checkboxIcon')
-        },
-        getPTOptions('checkboxIcon')
+        [
+            {
+                className: cx('checkboxIcon')
+            },
+            getPTOptions('checkboxIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const icon = props.checkboxIcon || <CheckIcon {...checkboxIconProps} />;
@@ -49,33 +54,42 @@ export const MultiSelectItem = React.memo((props) => {
     const tabIndex = props.disabled ? null : props.tabIndex || 0;
 
     const checkboxContainerProps = mergeProps(
-        {
-            className: cx('checkboxContainer')
-        },
-        getPTOptions('checkboxContainer')
+        [
+            {
+                className: cx('checkboxContainer')
+            },
+            getPTOptions('checkboxContainer')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const checkboxProps = mergeProps(
-        {
-            className: cx('checkbox', { itemProps: props }),
-            'data-p-highlight': props.selected
-        },
-        getPTOptions('checkbox')
+        [
+            {
+                className: cx('checkbox', { itemProps: props }),
+                'data-p-highlight': props.selected
+            },
+            getPTOptions('checkbox')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const itemProps = mergeProps(
-        {
-            className: classNames(props.className, props.option.className, cx('item', { itemProps: props })),
-            style: props.style,
-            onClick: onClick,
-            tabIndex: tabIndex,
-            onKeyDown: onKeyDown,
-            role: 'option',
-            'aria-selected': props.selected,
-            'data-p-highlight': props.selected,
-            'data-p-disabled': props.disabled
-        },
-        getPTOptions('item')
+        [
+            {
+                className: classNames(props.className, props.option.className, cx('item', { itemProps: props })),
+                style: props.style,
+                onClick: onClick,
+                tabIndex: tabIndex,
+                onKeyDown: onKeyDown,
+                role: 'option',
+                'aria-selected': props.selected,
+                'data-p-highlight': props.selected,
+                'data-p-disabled': props.disabled
+            },
+            getPTOptions('item')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -128,10 +128,13 @@ export const MultiSelectPanel = React.memo(
             const emptyFilterMessage = ObjectUtils.getJSXElement(props.emptyFilterMessage, props) || localeOption('emptyFilterMessage');
 
             const emptyMessageProps = mergeProps(
-                {
-                    className: cx('emptyMessage')
-                },
-                getPTOptions('emptyMessage')
+                [
+                    {
+                        className: cx('emptyMessage')
+                    },
+                    getPTOptions('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...emptyMessageProps}>{emptyFilterMessage}</li>;
@@ -141,10 +144,13 @@ export const MultiSelectPanel = React.memo(
             const emptyMessage = ObjectUtils.getJSXElement(props.emptyMessage, props) || localeOption('emptyMessage');
 
             const emptyMessageProps = mergeProps(
-                {
-                    className: cx('emptyMessage')
-                },
-                getPTOptions('emptyMessage')
+                [
+                    {
+                        className: cx('emptyMessage')
+                    },
+                    getPTOptions('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...emptyMessageProps}>{emptyMessage}</li>;
@@ -158,11 +164,14 @@ export const MultiSelectPanel = React.memo(
                 const groupChildrenContent = createGroupChildren(option, style);
                 const key = index + '_' + props.getOptionGroupRenderKey(option);
                 const itemGroupProps = mergeProps(
-                    {
-                        className: cx('itemGroup'),
-                        style: sx('itemGroup', { scrollerOptions })
-                    },
-                    getPTOptions('itemGroup')
+                    [
+                        {
+                            className: cx('itemGroup'),
+                            style: sx('itemGroup', { scrollerOptions })
+                        },
+                        getPTOptions('itemGroup')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -223,14 +232,17 @@ export const MultiSelectPanel = React.memo(
                             const content = isEmptyFilter() ? createEmptyFilter() : options.children;
 
                             const listProps = mergeProps(
-                                {
-                                    ref: options.contentRef,
-                                    style: options.style,
-                                    className: classNames(options.className, cx('list', { virtualScrollerProps: props.virtualScrollerOptions })),
-                                    role: 'listbox',
-                                    'aria-multiselectable': true
-                                },
-                                getPTOptions('list')
+                                [
+                                    {
+                                        ref: options.contentRef,
+                                        style: options.style,
+                                        className: classNames(options.className, cx('list', { virtualScrollerProps: props.virtualScrollerOptions })),
+                                        role: 'listbox',
+                                        'aria-multiselectable': true
+                                    },
+                                    getPTOptions('list')
+                                ],
+                                { useTailwind: context.useTailwind }
                             );
 
                             return <ul {...listProps}>{content}</ul>;
@@ -243,20 +255,26 @@ export const MultiSelectPanel = React.memo(
                 const items = createItems();
 
                 const wrapperProps = mergeProps(
-                    {
-                        className: cx('wrapper'),
-                        style: { maxHeight: props.scrollHeight }
-                    },
-                    getPTOptions('wrapper')
+                    [
+                        {
+                            className: cx('wrapper'),
+                            style: { maxHeight: props.scrollHeight }
+                        },
+                        getPTOptions('wrapper')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const listProps = mergeProps(
-                    {
-                        className: cx('list'),
-                        role: 'listbox',
-                        'aria-multiselectable': true
-                    },
-                    getPTOptions('list')
+                    [
+                        {
+                            className: cx('list'),
+                            role: 'listbox',
+                            'aria-multiselectable': true
+                        },
+                        getPTOptions('list')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -274,12 +292,15 @@ export const MultiSelectPanel = React.memo(
             const footer = createFooter();
 
             const panelProps = mergeProps(
-                {
-                    className: classNames(props.panelClassName, cx('panel', { panelProps: props, context, allowOptionSelect })),
-                    style: props.panelStyle,
-                    onClick: props.onClick
-                },
-                getPTOptions('panel')
+                [
+                    {
+                        className: classNames(props.panelClassName, cx('panel', { panelProps: props, context, allowOptionSelect })),
+                        style: props.panelStyle,
+                        onClick: props.onClick
+                    },
+                    getPTOptions('panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.inline) {
@@ -292,18 +313,21 @@ export const MultiSelectPanel = React.memo(
             }
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: props.in,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter,
-                    onEntered,
-                    onExit: props.onExit,
-                    onExited: props.onExited
-                },
-                getPTOptions('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: props.in,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter,
+                        onEntered,
+                        onExit: props.onExit,
+                        onExited: props.onExited
+                    },
+                    getPTOptions('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -122,10 +122,13 @@ export const MultiStateCheckbox = React.memo(
                 [`${icon}`]: true
             });
             const iconProps = mergeProps(
-                {
-                    className: cx('icon', { icon })
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon', { icon })
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const content = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
@@ -154,38 +157,47 @@ export const MultiStateCheckbox = React.memo(
         const ariaChecked = !!selectedOption ? 'true' : 'false';
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root'),
-                style: props.style,
-                onClick: onClick
-            },
-            MultiStateCheckboxBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root'),
+                    style: props.style,
+                    onClick: onClick
+                },
+                MultiStateCheckboxBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const checkboxProps = mergeProps(
-            {
-                className: cx('checkbox', { focusedState, selectedOption }),
-                style: sx('checkbox', { selectedOption }),
-                tabIndex: props.tabIndex,
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyDown: onKeyDown,
-                role: 'checkbox',
-                'aria-checked': ariaChecked,
-                ...ariaProps
-            },
-            ptm('checkbox')
+            [
+                {
+                    className: cx('checkbox', { focusedState, selectedOption }),
+                    style: sx('checkbox', { selectedOption }),
+                    tabIndex: props.tabIndex,
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyDown: onKeyDown,
+                    role: 'checkbox',
+                    'aria-checked': ariaChecked,
+                    ...ariaProps
+                },
+                ptm('checkbox')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const srOnlyAriaProps = mergeProps(
-            {
-                className: 'p-sr-only p-hidden-accessible',
-                'aria-live': 'polite'
-            },
-            ptm('srOnlyAria')
+            [
+                {
+                    className: 'p-sr-only p-hidden-accessible',
+                    'aria-live': 'polite'
+                },
+                ptm('srOnlyAria')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -233,14 +233,17 @@ export const OrderList = React.memo(
         const visibleList = getVisibleList();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: classNames(props.className, cx('root')),
-                style: props.style
-            },
-            OrderListBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: classNames(props.className, cx('root')),
+                    style: props.style
+                },
+                OrderListBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/orderlist/OrderListControls.js
+++ b/components/lib/orderlist/OrderListControls.js
@@ -5,9 +5,11 @@ import { AngleDoubleDownIcon } from '../icons/angledoubledown';
 import { AngleDoubleUpIcon } from '../icons/angledoubleup';
 import { AngleDownIcon } from '../icons/angledown';
 import { AngleUpIcon } from '../icons/angleup';
+import { PrimeReactContext } from '../api/Api';
 import { ObjectUtils, mergeProps } from '../utils/Utils';
 
 export const OrderListControls = React.memo((props) => {
+    const context = React.useContext(PrimeReactContext);
     const moveUpIcon = props.moveUpIcon || <AngleUpIcon />;
     const moveTopIcon = props.moveTopIcon || <AngleDoubleUpIcon />;
     const moveDownIcon = props.moveDownIcon || <AngleDownIcon />;
@@ -127,66 +129,81 @@ export const OrderListControls = React.memo((props) => {
     };
 
     const controlsProps = mergeProps(
-        {
-            className: cx('controls')
-        },
-        ptm('controls', { hostName: props.hostName })
+        [
+            {
+                className: cx('controls')
+            },
+            ptm('controls', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const moveUpButtonProps = mergeProps(
-        {
-            type: 'button',
-            unstyled: unstyled,
-            icon: moveUpIcon,
-            onClick: moveUp,
-            'aria-label': ariaLabel('moveUp'),
-            __parentMetadata: {
-                parent: props.metaData
-            }
-        },
-        ptm('moveUpButton')
+        [
+            {
+                type: 'button',
+                unstyled: unstyled,
+                icon: moveUpIcon,
+                onClick: moveUp,
+                'aria-label': ariaLabel('moveUp'),
+                __parentMetadata: {
+                    parent: props.metaData
+                }
+            },
+            ptm('moveUpButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const moveTopButtonProps = mergeProps(
-        {
-            type: 'button',
-            unstyled: unstyled,
-            icon: moveTopIcon,
-            onClick: moveTop,
-            'aria-label': ariaLabel('moveTop'),
-            __parentMetadata: {
-                parent: props.metaData
-            }
-        },
-        ptm('moveTopButton')
+        [
+            {
+                type: 'button',
+                unstyled: unstyled,
+                icon: moveTopIcon,
+                onClick: moveTop,
+                'aria-label': ariaLabel('moveTop'),
+                __parentMetadata: {
+                    parent: props.metaData
+                }
+            },
+            ptm('moveTopButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const moveDownButtonProps = mergeProps(
-        {
-            type: 'button',
-            unstyled: unstyled,
-            icon: moveDownIcon,
-            onClick: moveDown,
-            'aria-label': ariaLabel('moveDown'),
-            __parentMetadata: {
-                parent: props.metaData
-            }
-        },
-        ptm('moveDownButton')
+        [
+            {
+                type: 'button',
+                unstyled: unstyled,
+                icon: moveDownIcon,
+                onClick: moveDown,
+                'aria-label': ariaLabel('moveDown'),
+                __parentMetadata: {
+                    parent: props.metaData
+                }
+            },
+            ptm('moveDownButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const moveBottomButtonProps = mergeProps(
-        {
-            type: 'button',
-            unstyled: unstyled,
-            icon: moveBottomIcon,
-            onClick: moveBottom,
-            'aria-label': ariaLabel('moveBottom'),
-            __parentMetadata: {
-                parent: props.metaData
-            }
-        },
-        ptm('moveBottomButton')
+        [
+            {
+                type: 'button',
+                unstyled: unstyled,
+                icon: moveBottomIcon,
+                onClick: moveBottom,
+                'aria-label': ariaLabel('moveBottom'),
+                __parentMetadata: {
+                    parent: props.metaData
+                }
+            },
+            ptm('moveBottomButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/orderlist/OrderListSubList.js
+++ b/components/lib/orderlist/OrderListSubList.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { SearchIcon } from '../icons/search';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const OrderListSubList = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const _ptm = (key, options) => {
         return ptm(key, {
@@ -96,13 +98,16 @@ export const OrderListSubList = React.memo((props) => {
 
     const createDropPoint = (index, key) => {
         const droppointProps = mergeProps(
-            {
-                className: cx('droppoint'),
-                onDragOver: (e) => onDragOver(e, index + 1),
-                onDragLeave: onDragLeave,
-                onDrop: onDrop
-            },
-            _ptm('droppoint')
+            [
+                {
+                    className: cx('droppoint'),
+                    onDragOver: (e) => onDragOver(e, index + 1),
+                    onDragLeave: onDragLeave,
+                    onDrop: onDrop
+                },
+                _ptm('droppoint')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li key={key} {...droppointProps}></li>;
@@ -110,10 +115,13 @@ export const OrderListSubList = React.memo((props) => {
 
     const createHeader = () => {
         const headerProps = mergeProps(
-            {
-                className: cx('header')
-            },
-            _ptm('header')
+            [
+                {
+                    className: cx('header')
+                },
+                _ptm('header')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return props.header ? <div {...headerProps}>{props.header}</div> : null;
@@ -127,19 +135,22 @@ export const OrderListSubList = React.memo((props) => {
 
                 if (props.dragdrop) {
                     const itemProps = mergeProps(
-                        {
-                            className: classNames(props.className, cx('item', { item, isSelected })),
-                            onClick: (e) => props.onItemClick({ originalEvent: e, value: item, index: i }),
-                            onKeyDown: (e) => props.onItemKeyDown({ originalEvent: e, value: item, index: i }),
-                            role: 'option',
-                            'aria-selected': isSelected(item),
-                            draggable: 'true',
-                            onDragStart: (e) => onDragStart(e, i),
-                            onDragEnd: onDragEnd,
-                            tabIndex: props.tabIndex,
-                            'data-p-highlight': isSelected(item)
-                        },
-                        getPTOptions(item, 'item')
+                        [
+                            {
+                                className: classNames(props.className, cx('item', { item, isSelected })),
+                                onClick: (e) => props.onItemClick({ originalEvent: e, value: item, index: i }),
+                                onKeyDown: (e) => props.onItemKeyDown({ originalEvent: e, value: item, index: i }),
+                                role: 'option',
+                                'aria-selected': isSelected(item),
+                                draggable: 'true',
+                                onDragStart: (e) => onDragStart(e, i),
+                                onDragEnd: onDragEnd,
+                                tabIndex: props.tabIndex,
+                                'data-p-highlight': isSelected(item)
+                            },
+                            getPTOptions(item, 'item')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     let items = [];
@@ -160,16 +171,19 @@ export const OrderListSubList = React.memo((props) => {
                     return items;
                 } else {
                     const itemProps = mergeProps(
-                        {
-                            role: 'option',
-                            tabIndex: props.tabIndex,
-                            className: classNames(props.className, cx('item', { item, isSelected })),
-                            onClick: (e) => props.onItemClick({ originalEvent: e, value: item, index: i }),
-                            onKeyDown: (e) => props.onItemKeyDown({ originalEvent: e, value: item, index: i }),
-                            'aria-selected': isSelected(item),
-                            'data-p-highlight': isSelected(item)
-                        },
-                        getPTOptions(item, 'item')
+                        [
+                            {
+                                role: 'option',
+                                tabIndex: props.tabIndex,
+                                className: classNames(props.className, cx('item', { item, isSelected })),
+                                onClick: (e) => props.onItemClick({ originalEvent: e, value: item, index: i }),
+                                onKeyDown: (e) => props.onItemKeyDown({ originalEvent: e, value: item, index: i }),
+                                'aria-selected': isSelected(item),
+                                'data-p-highlight': isSelected(item)
+                            },
+                            getPTOptions(item, 'item')
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     return (
@@ -188,15 +202,18 @@ export const OrderListSubList = React.memo((props) => {
     const createList = () => {
         const items = createItems();
         const listProps = mergeProps(
-            {
-                ref: listElementRef,
-                className: cx('list'),
-                style: props.listStyle,
-                onDragOver: onListMouseMove,
-                role: 'listbox',
-                'aria-multiselectable': true
-            },
-            _ptm('list')
+            [
+                {
+                    ref: listElementRef,
+                    className: cx('list'),
+                    style: props.listStyle,
+                    onDragOver: onListMouseMove,
+                    role: 'listbox',
+                    'aria-multiselectable': true
+                },
+                _ptm('list')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <ul {...listProps}>{items}</ul>;
@@ -204,39 +221,51 @@ export const OrderListSubList = React.memo((props) => {
 
     const createFilter = () => {
         const searchIconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            _ptm('icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                _ptm('icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.filterIcon || <SearchIcon {...searchIconProps} />;
         const filterIcon = IconUtils.getJSXIcon(icon, { ...searchIconProps }, { props });
 
         if (props.filter) {
             const filterProps = mergeProps(
-                {
-                    className: cx('filter')
-                },
-                _ptm('filter')
+                [
+                    {
+                        className: cx('filter')
+                    },
+                    _ptm('filter')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const filterInputProps = mergeProps(
-                {
-                    type: 'text',
-                    value: props.filterValue,
-                    onChange: props.onFilter,
-                    onKeyDown: onFilterInputKeyDown,
-                    placeholder: props.placeholder,
-                    className: cx('filterInput')
-                },
-                _ptm('filterInput')
+                [
+                    {
+                        type: 'text',
+                        value: props.filterValue,
+                        onChange: props.onFilter,
+                        onKeyDown: onFilterInputKeyDown,
+                        placeholder: props.placeholder,
+                        className: cx('filterInput')
+                    },
+                    _ptm('filterInput')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const filterIconProps = mergeProps(
-                {
-                    className: cx('filterIcon')
-                },
-                _ptm('filterIcon')
+                [
+                    {
+                        className: cx('filterIcon')
+                    },
+                    _ptm('filterIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -264,10 +293,13 @@ export const OrderListSubList = React.memo((props) => {
             }
 
             const filterContainerProps = mergeProps(
-                {
-                    className: cx('filterContainer')
-                },
-                _ptm('filterContainer')
+                [
+                    {
+                        className: cx('filterContainer')
+                    },
+                    _ptm('filterContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...filterContainerProps}>{content}</div>;
@@ -281,10 +313,13 @@ export const OrderListSubList = React.memo((props) => {
     const list = createList();
 
     const containerProps = mergeProps(
-        {
-            className: cx('container')
-        },
-        _ptm('container')
+        [
+            {
+                className: cx('container')
+            },
+            _ptm('container')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/organizationchart/OrganizationChart.js
+++ b/components/lib/organizationchart/OrganizationChart.js
@@ -75,14 +75,17 @@ export const OrganizationChart = React.memo(
         }));
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: props.style,
-                className: classNames(props.className, cx('root'))
-            },
-            OrganizationChartBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: props.style,
+                    className: classNames(props.className, cx('root'))
+                },
+                OrganizationChartBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/organizationchart/OrganizationChartNode.js
+++ b/components/lib/organizationchart/OrganizationChartNode.js
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ChevronDownIcon } from '../icons/chevrondown';
 import { ChevronUpIcon } from '../icons/chevronup';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, mergeProps } from '../utils/Utils';
 
 export const OrganizationChartNode = React.memo((props) => {
@@ -11,6 +12,7 @@ export const OrganizationChartNode = React.memo((props) => {
     const selected = props.isSelected(node);
     const visibility = !leaf && expandedState ? 'inherit' : 'hidden';
     const { ptm, cx, sx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const _ptm = (key, options) => {
         return ptm(key, {
@@ -49,17 +51,23 @@ export const OrganizationChartNode = React.memo((props) => {
 
     const createChildNodes = () => {
         const nodesProps = mergeProps(
-            {
-                className: cx('nodes'),
-                style: { visibility }
-            },
-            _ptm('nodes')
+            [
+                {
+                    className: cx('nodes'),
+                    style: { visibility }
+                },
+                _ptm('nodes')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const nodeCellProps = mergeProps(
-            {
-                colSpan: '2'
-            },
-            _ptm('nodeCell')
+            [
+                {
+                    colSpan: '2'
+                },
+                _ptm('nodeCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -89,23 +97,32 @@ export const OrganizationChartNode = React.memo((props) => {
     const createLinesMiddle = () => {
         const nodeChildLength = node.children && node.children.length;
         const linesProps = mergeProps(
-            {
-                className: cx('lines'),
-                style: { visibility }
-            },
-            _ptm('lines')
+            [
+                {
+                    className: cx('lines'),
+                    style: { visibility }
+                },
+                _ptm('lines')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const lineCellProps = mergeProps(
-            {
-                colSpan: colspan
-            },
-            _ptm('lineCell')
+            [
+                {
+                    colSpan: colspan
+                },
+                _ptm('lineCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const lineDownProps = mergeProps(
-            {
-                className: cx('lineDown')
-            },
-            _ptm('lineDown')
+            [
+                {
+                    className: cx('lineDown')
+                },
+                _ptm('lineDown')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -119,16 +136,22 @@ export const OrganizationChartNode = React.memo((props) => {
                     node.children.length > 1 &&
                     node.children.map((_, index) => {
                         const lineLeftProps = mergeProps(
-                            {
-                                className: cx('lineLeft', { index })
-                            },
-                            getNodePTOptions(index !== 0, 'lineLeft')
+                            [
+                                {
+                                    className: cx('lineLeft', { index })
+                                },
+                                getNodePTOptions(index !== 0, 'lineLeft')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
                         const lineRightProps = mergeProps(
-                            {
-                                className: cx('lineRight', { index, nodeChildLength })
-                            },
-                            getNodePTOptions(index !== nodeChildLength - 1, 'lineRight')
+                            [
+                                {
+                                    className: cx('lineRight', { index, nodeChildLength })
+                                },
+                                getNodePTOptions(index !== nodeChildLength - 1, 'lineRight')
+                            ],
+                            { useTailwind: context.useTailwind }
                         );
 
                         return [
@@ -146,25 +169,34 @@ export const OrganizationChartNode = React.memo((props) => {
 
     const createLinesDown = () => {
         const linesProps = mergeProps(
-            {
-                className: cx('lines'),
-                style: { visibility }
-            },
-            _ptm('lines')
+            [
+                {
+                    className: cx('lines'),
+                    style: { visibility }
+                },
+                _ptm('lines')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const lineCellProps = mergeProps(
-            {
-                colSpan: colspan
-            },
-            _ptm('lineCell')
+            [
+                {
+                    colSpan: colspan
+                },
+                _ptm('lineCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const lineDownProps = mergeProps(
-            {
-                className: cx('lineDown')
-            },
-            _ptm('lineDown')
+            [
+                {
+                    className: cx('lineDown')
+                },
+                _ptm('lineDown')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -179,10 +211,13 @@ export const OrganizationChartNode = React.memo((props) => {
     const createToggler = () => {
         if (!leaf) {
             const nodeTogglerIconProps = mergeProps(
-                {
-                    className: cx('nodeTogglerIcon')
-                },
-                _ptm('nodeTogglerIcon')
+                [
+                    {
+                        className: cx('nodeTogglerIcon')
+                    },
+                    _ptm('nodeTogglerIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let icon;
@@ -196,12 +231,15 @@ export const OrganizationChartNode = React.memo((props) => {
             const togglerIcon = IconUtils.getJSXIcon(icon, { ...nodeTogglerIconProps }, { props });
 
             const nodeTogglerProps = mergeProps(
-                {
-                    className: cx('nodeToggler'),
-                    onClick: (e) => toggleNode(e, node),
-                    href: '#'
-                },
-                getPTOptions('nodeToggler')
+                [
+                    {
+                        className: cx('nodeToggler'),
+                        onClick: (e) => toggleNode(e, node),
+                        href: '#'
+                    },
+                    getPTOptions('nodeToggler')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -227,22 +265,28 @@ export const OrganizationChartNode = React.memo((props) => {
         const toggler = createToggler();
 
         const cellProps = mergeProps(
-            {
-                colSpan: colspan
-            },
-            _ptm('cell')
+            [
+                {
+                    colSpan: colspan
+                },
+                _ptm('cell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const nodeProps = mergeProps(
-            {
-                className: cx('node', { selected, node, nodeProps: props }),
-                style: node.style,
-                onClick: (e) => onNodeClick(e, node)
-            },
-            getPTOptions('node')
+            [
+                {
+                    className: cx('node', { selected, node, nodeProps: props }),
+                    style: node.style,
+                    onClick: (e) => onNodeClick(e, node)
+                },
+                getPTOptions('node')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
-        const rowProps = mergeProps(_ptm('row'));
+        const rowProps = mergeProps([_ptm('row')], { useTailwind: context.useTailwind });
 
         return (
             <tr {...rowProps}>
@@ -262,10 +306,13 @@ export const OrganizationChartNode = React.memo((props) => {
     const childNodes = createChildNodes();
 
     const tableProps = mergeProps(
-        {
-            className: cx('table')
-        },
-        _ptm('table')
+        [
+            {
+                className: cx('table')
+            },
+            _ptm('table')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -221,23 +221,29 @@ export const OverlayPanel = React.forwardRef((inProps, ref) => {
 
     const createCloseIcon = () => {
         const closeIconProps = mergeProps(
-            {
-                className: cx('closeIcon'),
-                'aria-hidden': true
-            },
-            ptm('closeIcon')
+            [
+                {
+                    className: cx('closeIcon'),
+                    'aria-hidden': true
+                },
+                ptm('closeIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.closeIcon || <TimesIcon {...closeIconProps} />;
         const closeIcon = IconUtils.getJSXIcon(icon, { ...closeIconProps }, { props });
         const ariaLabel = props.ariaCloseLabel || localeOption('close');
         const closeButtonProps = mergeProps(
-            {
-                type: 'button',
-                className: cx('closeButton'),
-                onClick: (e) => onCloseClick(e),
-                'aria-label': ariaLabel
-            },
-            ptm('closeButton')
+            [
+                {
+                    type: 'button',
+                    className: cx('closeButton'),
+                    onClick: (e) => onCloseClick(e),
+                    'aria-label': ariaLabel
+                },
+                ptm('closeButton')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.showCloseIcon) {
@@ -255,39 +261,48 @@ export const OverlayPanel = React.forwardRef((inProps, ref) => {
     const createElement = () => {
         const closeIcon = createCloseIcon();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: cx('root', { context }),
-                style: props.style,
-                onClick: (e) => onPanelClick(e)
-            },
-            OverlayPanelBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: cx('root', { context }),
+                    style: props.style,
+                    onClick: (e) => onPanelClick(e)
+                },
+                OverlayPanelBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const contentProps = mergeProps(
-            {
-                className: cx('content'),
-                onClick: (e) => onContentClick(e),
-                onMouseDown: onContentClick
-            },
-            OverlayPanelBase.getOtherProps(props),
-            ptm('content')
+            [
+                {
+                    className: cx('content'),
+                    onClick: (e) => onContentClick(e),
+                    onMouseDown: onContentClick
+                },
+                OverlayPanelBase.getOtherProps(props),
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: visibleState,
-                timeout: { enter: 120, exit: 100 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: onEnter,
-                onEntered: onEntered,
-                onExit: onExit,
-                onExited: onExited
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: visibleState,
+                    timeout: { enter: 120, exit: 100 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: onEnter,
+                    onEntered: onEntered,
+                    onExit: onExit,
+                    onExited: onExited
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/paginator/CurrentPageReport.js
+++ b/components/lib/paginator/CurrentPageReport.js
@@ -25,10 +25,13 @@ export const CurrentPageReport = React.memo((inProps) => {
         .replace('{totalRecords}', report.totalRecords);
 
     const currentProps = mergeProps(
-        {
-            className: 'p-paginator-current'
-        },
-        props.ptm('current', { hostName: props.hostName })
+        [
+            {
+                className: 'p-paginator-current'
+            },
+            props.ptm('current', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const element = <span {...currentProps}>{text}</span>;

--- a/components/lib/paginator/FirstPageLink.js
+++ b/components/lib/paginator/FirstPageLink.js
@@ -23,22 +23,28 @@ export const FirstPageLink = React.memo((inProps) => {
     const className = classNames('p-paginator-first p-paginator-element p-link', { 'p-disabled': props.disabled });
     const iconClassName = 'p-paginator-icon';
     const firstPageIconProps = mergeProps(
-        {
-            className: cx('firstPageIcon')
-        },
-        getPTOptions('firstPageIcon')
+        [
+            {
+                className: cx('firstPageIcon')
+            },
+            getPTOptions('firstPageIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.firstPageLinkIcon || <AngleDoubleLeftIcon {...firstPageIconProps} />;
     const firstPageLinkIcon = IconUtils.getJSXIcon(icon, { ...firstPageIconProps }, { props });
     const firstPageButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('firstPageButton', { disabled: props.disabled }),
-            onClick: props.onClick,
-            disabled: props.disabled,
-            'aria-label': ariaLabel('firstPageLabel')
-        },
-        getPTOptions('firstPageButton')
+        [
+            {
+                type: 'button',
+                className: cx('firstPageButton', { disabled: props.disabled }),
+                onClick: props.onClick,
+                disabled: props.disabled,
+                'aria-label': ariaLabel('firstPageLabel')
+            },
+            getPTOptions('firstPageButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const element = (
         <button {...firstPageButtonProps}>

--- a/components/lib/paginator/LastPageLink.js
+++ b/components/lib/paginator/LastPageLink.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { ariaLabel } from '../api/Api';
+import { ariaLabel, PrimeReactContext } from '../api/Api';
 import { AngleDoubleRightIcon } from '../icons/angledoubleright';
 import { Ripple } from '../ripple/Ripple';
 import { classNames, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 import { LastPageLinkBase } from './PaginatorBase';
-import { PrimeReactContext } from '../api/Api';
 
 export const LastPageLink = React.memo((inProps) => {
     const context = React.useContext(PrimeReactContext);
@@ -23,22 +22,28 @@ export const LastPageLink = React.memo((inProps) => {
     const className = classNames('p-paginator-last p-paginator-element p-link', { 'p-disabled': props.disabled });
     const iconClassName = 'p-paginator-icon';
     const lastPageIconProps = mergeProps(
-        {
-            className: cx('lastPageIcon')
-        },
-        getPTOptions('lastPageIcon')
+        [
+            {
+                className: cx('lastPageIcon')
+            },
+            getPTOptions('lastPageIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.lastPageLinkIcon || <AngleDoubleRightIcon {...lastPageIconProps} />;
     const lastPageLinkIcon = IconUtils.getJSXIcon(icon, { ...lastPageIconProps }, { props });
     const lastPageButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('lastPageButton', { disabled: props.disabled }),
-            onClick: props.onClick,
-            disabled: props.disabled,
-            'aria-label': ariaLabel('lastPageLabel')
-        },
-        getPTOptions('lastPageButton')
+        [
+            {
+                type: 'button',
+                className: cx('lastPageButton', { disabled: props.disabled }),
+                onClick: props.onClick,
+                disabled: props.disabled,
+                'aria-label': ariaLabel('lastPageLabel')
+            },
+            getPTOptions('lastPageButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const element = (
         <button {...lastPageButtonProps}>

--- a/components/lib/paginator/NextPageLink.js
+++ b/components/lib/paginator/NextPageLink.js
@@ -24,23 +24,29 @@ export const NextPageLink = React.memo((inProps) => {
 
     const iconClassName = 'p-paginator-icon';
     const nextPageIconProps = mergeProps(
-        {
-            className: cx('nextPageIcon')
-        },
-        getPTOptions('nextPageIcon')
+        [
+            {
+                className: cx('nextPageIcon')
+            },
+            getPTOptions('nextPageIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.nextPageLinkIcon || <AngleRightIcon {...nextPageIconProps} />;
     const nextPageLinkIcon = IconUtils.getJSXIcon(icon, { ...nextPageIconProps }, { props });
 
     const nextPageButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('nextPageButton', { disabled: props.disabled }),
-            onClick: props.onClick,
-            disabled: props.disabled,
-            'aria-label': ariaLabel('nextPageLabel')
-        },
-        getPTOptions('nextPageButton')
+        [
+            {
+                type: 'button',
+                className: cx('nextPageButton', { disabled: props.disabled }),
+                onClick: props.onClick,
+                disabled: props.disabled,
+                'aria-label': ariaLabel('nextPageLabel')
+            },
+            getPTOptions('nextPageButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const element = (

--- a/components/lib/paginator/PageLinks.js
+++ b/components/lib/paginator/PageLinks.js
@@ -43,14 +43,17 @@ export const PageLinks = React.memo((inProps) => {
             });
 
             const pageButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    onClick: (e) => onPageLinkClick(e, pageLink),
-                    className: cx('pageButton', { pageLink, startPageInView, endPageInView, page: props.page }),
-                    disabled: props.disabled,
-                    'aria-label': ariaLabel('pageLabel', { page: pageLink })
-                },
-                getPTOptions(pageLink, 'pageButton')
+                [
+                    {
+                        type: 'button',
+                        onClick: (e) => onPageLinkClick(e, pageLink),
+                        className: cx('pageButton', { pageLink, startPageInView, endPageInView, page: props.page }),
+                        disabled: props.disabled,
+                        'aria-label': ariaLabel('pageLabel', { page: pageLink })
+                    },
+                    getPTOptions(pageLink, 'pageButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let element = (
@@ -83,10 +86,13 @@ export const PageLinks = React.memo((inProps) => {
     }
 
     const pagesProps = mergeProps(
-        {
-            className: cx('pages')
-        },
-        ptm('pages', { hostName: props.hostName })
+        [
+            {
+                className: cx('pages')
+            },
+            ptm('pages', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <span {...pagesProps}>{elements}</span>;

--- a/components/lib/paginator/Paginator.js
+++ b/components/lib/paginator/Paginator.js
@@ -16,6 +16,7 @@ import { RowsPerPageDropdown } from './RowsPerPageDropdown';
 export const Paginator = React.memo(
     React.forwardRef((inProps, ref) => {
         const context = React.useContext(PrimeReactContext);
+
         const props = PaginatorBase.getProps(inProps, context);
         const metaData = {
             props,
@@ -225,27 +226,36 @@ export const Paginator = React.memo(
 
             const elements = createElements();
             const leftProps = mergeProps(
-                {
-                    className: cx('left')
-                },
-                ptm('left')
+                [
+                    {
+                        className: cx('left')
+                    },
+                    ptm('left')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const leftElement = leftContent && <div {...leftProps}>{leftContent}</div>;
             const endProps = mergeProps(
-                {
-                    className: cx('end')
-                },
-                ptm('end')
+                [
+                    {
+                        className: cx('end')
+                    },
+                    ptm('end')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const rightElement = rightContent && <div {...endProps}>{rightContent}</div>;
             const rootProps = mergeProps(
-                {
-                    ref: elementRef,
-                    className: classNames(props.className, cx('root')),
-                    style: props.style
-                },
-                PaginatorBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: elementRef,
+                        className: classNames(props.className, cx('root')),
+                        style: props.style
+                    },
+                    PaginatorBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/paginator/PrevPageLink.js
+++ b/components/lib/paginator/PrevPageLink.js
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { ariaLabel } from '../api/Api';
+import { ariaLabel, PrimeReactContext } from '../api/Api';
 import { AngleLeftIcon } from '../icons/angleleft';
 import { Ripple } from '../ripple/Ripple';
 import { classNames, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 import { PrevPageLinkBase } from './PaginatorBase';
-import { PrimeReactContext } from '../api/Api';
 
 export const PrevPageLink = React.memo((inProps) => {
     const context = React.useContext(PrimeReactContext);
@@ -23,23 +22,29 @@ export const PrevPageLink = React.memo((inProps) => {
     const className = classNames('p-paginator-prev p-paginator-element p-link', { 'p-disabled': props.disabled });
     const iconClassName = 'p-paginator-icon';
     const prevPageIconProps = mergeProps(
-        {
-            className: cx('prevPageIcon')
-        },
-        getPTOptions('prevPageIcon')
+        [
+            {
+                className: cx('prevPageIcon')
+            },
+            getPTOptions('prevPageIcon')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const icon = props.prevPageLinkIcon || <AngleLeftIcon {...prevPageIconProps} />;
     const prevPageLinkIcon = IconUtils.getJSXIcon(icon, { ...prevPageIconProps }, { props });
 
     const prevPageButtonProps = mergeProps(
-        {
-            type: 'button',
-            className: cx('prevPageButton', { disabled: props.disabled }),
-            onClick: props.onClick,
-            disabled: props.disabled,
-            'aria-label': ariaLabel('previousPageLabel')
-        },
-        getPTOptions('prevPageButton')
+        [
+            {
+                type: 'button',
+                className: cx('prevPageButton', { disabled: props.disabled }),
+                onClick: props.onClick,
+                disabled: props.disabled,
+                'aria-label': ariaLabel('previousPageLabel')
+            },
+            getPTOptions('prevPageButton')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const element = (
         <button {...prevPageButtonProps}>

--- a/components/lib/panel/Panel.js
+++ b/components/lib/panel/Panel.js
@@ -84,17 +84,20 @@ export const Panel = React.forwardRef((inProps, ref) => {
         if (props.toggleable) {
             const buttonId = idState + '_label';
             const togglerProps = mergeProps(
-                {
-                    className: cx('toggler'),
-                    onClick: toggle,
-                    id: buttonId,
-                    'aria-controls': contentId,
-                    'aria-expanded': !collapsed,
-                    role: 'tab'
-                },
-                ptm('toggler')
+                [
+                    {
+                        className: cx('toggler'),
+                        onClick: toggle,
+                        id: buttonId,
+                        'aria-controls': contentId,
+                        'aria-expanded': !collapsed,
+                        role: 'tab'
+                    },
+                    ptm('toggler')
+                ],
+                { useTailwind: context.useTailwind }
             );
-            const togglerIconProps = mergeProps(ptm('togglericon'));
+            const togglerIconProps = mergeProps([ptm('togglericon')], { useTailwind: context.useTailwind });
 
             const icon = collapsed ? props.expandIcon || <PlusIcon {...togglerIconProps} /> : props.collapseIcon || <MinusIcon {...togglerIconProps} />;
             const toggleIcon = IconUtils.getJSXIcon(icon, togglerIconProps, { props, collapsed });
@@ -116,19 +119,25 @@ export const Panel = React.forwardRef((inProps, ref) => {
         const togglerElement = createToggleIcon();
 
         const titleProps = mergeProps(
-            {
-                id: headerId,
-                className: cx('title')
-            },
-            ptm('title')
+            [
+                {
+                    id: headerId,
+                    className: cx('title')
+                },
+                ptm('title')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const titleElement = <span {...titleProps}>{header}</span>;
 
         const iconsProps = mergeProps(
-            {
-                className: cx('icons')
-            },
-            ptm('icons')
+            [
+                {
+                    className: cx('icons')
+                },
+                ptm('icons')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const iconsElement = (
             <div {...iconsProps}>
@@ -138,10 +147,13 @@ export const Panel = React.forwardRef((inProps, ref) => {
         );
 
         const headerProps = mergeProps(
-            {
-                className: cx('header')
-            },
-            ptm('header')
+            [
+                {
+                    className: cx('header')
+                },
+                ptm('header')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const content = (
             <div {...headerProps}>
@@ -175,32 +187,41 @@ export const Panel = React.forwardRef((inProps, ref) => {
 
     const createContent = () => {
         const toggleableContentProps = mergeProps(
-            {
-                ref: contentRef,
-                className: cx('toggleableContent'),
-                'aria-hidden': collapsed,
-                role: 'region',
-                id: contentId,
-                'aria-labelledby': headerId
-            },
-            ptm('toggleablecontent')
+            [
+                {
+                    ref: contentRef,
+                    className: cx('toggleableContent'),
+                    'aria-hidden': collapsed,
+                    role: 'region',
+                    id: contentId,
+                    'aria-labelledby': headerId
+                },
+                ptm('toggleablecontent')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const contentProps = mergeProps(
-            {
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                timeout: { enter: 1000, exit: 450 },
-                in: !collapsed,
-                unmountOnExit: true,
-                options: props.transitionOptions
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    timeout: { enter: 1000, exit: 450 },
+                    in: !collapsed,
+                    unmountOnExit: true,
+                    options: props.transitionOptions
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -216,10 +237,13 @@ export const Panel = React.forwardRef((inProps, ref) => {
         const footer = ObjectUtils.getJSXElement(props.footer, props);
 
         const footerProps = mergeProps(
-            {
-                className: cx('footer')
-            },
-            ptm('footer')
+            [
+                {
+                    className: cx('footer')
+                },
+                ptm('footer')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const content = <div {...footerProps}>{footer}</div>;
@@ -240,14 +264,17 @@ export const Panel = React.forwardRef((inProps, ref) => {
     };
 
     const rootProps = mergeProps(
-        {
-            id: idState,
-            ref: elementRef,
-            style: props.style,
-            className: classNames(props.className, cx('root'))
-        },
-        PanelBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: idState,
+                ref: elementRef,
+                style: props.style,
+                className: classNames(props.className, cx('root'))
+            },
+            PanelBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const header = createHeader();
     const content = createContent();

--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -130,39 +130,51 @@ export const PanelMenu = React.memo(
             const active = isItemActive(item);
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const headerIconProps = mergeProps(
-                {
-                    className: cx('headerIcon', { item })
-                },
-                getPTOptions(item, 'headerIcon')
+                [
+                    {
+                        className: cx('headerIcon', { item })
+                    },
+                    getPTOptions(item, 'headerIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(item.icon, { ...headerIconProps }, { props });
             const submenuIconClassName = 'p-panelmenu-icon';
             const headerSubmenuIconProps = mergeProps(
-                {
-                    className: cx('headerSubmenuIcon')
-                },
-                getPTOptions(item, 'headerSubmenuIcon')
+                [
+                    {
+                        className: cx('headerSubmenuIcon')
+                    },
+                    getPTOptions(item, 'headerSubmenuIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const submenuIcon = item.items && IconUtils.getJSXIcon(active ? props.submenuIcon || <ChevronDownIcon {...headerSubmenuIconProps} /> : props.submenuIcon || <ChevronRightIcon {...headerSubmenuIconProps} />);
             const headerLabelProps = mergeProps(
-                {
-                    className: cx('headerLabel')
-                },
-                getPTOptions(item, 'headerLabel')
+                [
+                    {
+                        className: cx('headerLabel')
+                    },
+                    getPTOptions(item, 'headerLabel')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const label = item.label && <span {...headerLabelProps}>{item.label}</span>;
             const menuContentRef = React.createRef();
             const headerActionProps = mergeProps(
-                {
-                    href: item.url || '#',
-                    className: cx('headerAction'),
-                    onClick: (e) => onItemClick(e, item),
-                    'aria-expanded': active,
-                    id: headerId,
-                    'aria-controls': contentId,
-                    'aria-disabled': item.disabled
-                },
-                getPTOptions(item, 'headerAction')
+                [
+                    {
+                        href: item.url || '#',
+                        className: cx('headerAction'),
+                        onClick: (e) => onItemClick(e, item),
+                        'aria-expanded': active,
+                        id: headerId,
+                        'aria-controls': contentId,
+                        'aria-disabled': item.disabled
+                    },
+                    getPTOptions(item, 'headerAction')
+                ],
+                { useTailwind: context.useTailwind }
             );
             let content = (
                 <a {...headerActionProps}>
@@ -189,49 +201,64 @@ export const PanelMenu = React.memo(
             }
 
             const panelProps = mergeProps(
-                {
-                    key: key,
-                    className: cx('panel', { item }),
-                    style: item.style
-                },
-                getPTOptions(item, 'panel')
+                [
+                    {
+                        key: key,
+                        className: cx('panel', { item }),
+                        style: item.style
+                    },
+                    getPTOptions(item, 'panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerProps = mergeProps(
-                {
-                    className: cx('header', { active, item }),
-                    style: item.style
-                },
-                getPTOptions(item, 'header')
+                [
+                    {
+                        className: cx('header', { active, item }),
+                        style: item.style
+                    },
+                    getPTOptions(item, 'header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const menuContentProps = mergeProps(
-                {
-                    className: cx('menuContent')
-                },
-                getPTOptions(item, 'menuContent')
+                [
+                    {
+                        className: cx('menuContent')
+                    },
+                    getPTOptions(item, 'menuContent')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const toggleableContentProps = mergeProps(
-                {
-                    className: cx('toggleableContent', { active }),
-                    role: 'region',
-                    'aria-labelledby': headerId
-                },
-                getPTOptions(item, 'toggleableContent')
+                [
+                    {
+                        className: cx('toggleableContent', { active }),
+                        role: 'region',
+                        'aria-labelledby': headerId
+                    },
+                    getPTOptions(item, 'toggleableContent')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    timeout: { enter: 1000, exit: 450 },
-                    onEnter: onEnter,
-                    disabled: animationDisabled,
-                    in: active,
-                    unmountOnExit: true,
-                    options: props.transitionOptions
-                },
-                getPTOptions(item, 'transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        timeout: { enter: 1000, exit: 450 },
+                        onEnter: onEnter,
+                        disabled: animationDisabled,
+                        in: active,
+                        unmountOnExit: true,
+                        options: props.transitionOptions
+                    },
+                    getPTOptions(item, 'transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -254,12 +281,15 @@ export const PanelMenu = React.memo(
 
         const panels = createPanels();
         const rootProps = mergeProps(
-            {
-                className: cx('root'),
-                style: props.style
-            },
-            PanelMenuBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: cx('root'),
+                    style: props.style
+                },
+                PanelMenuBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/panelmenu/PanelMenuSub.js
+++ b/components/lib/panelmenu/PanelMenuSub.js
@@ -3,11 +3,13 @@ import { CSSTransition } from '../csstransition/CSSTransition';
 import { useMountEffect } from '../hooks/Hooks';
 import { ChevronDownIcon } from '../icons/chevrondown';
 import { ChevronRightIcon } from '../icons/chevronright';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const PanelMenuSub = React.memo((props) => {
-    const [activeItemState, setActiveItemState] = React.useState(null);
     const { ptm, cx } = props;
+    const [activeItemState, setActiveItemState] = React.useState(null);
+    const context = React.useContext(PrimeReactContext);
 
     const _ptm = (key, options) => {
         return ptm(key, {
@@ -91,13 +93,16 @@ export const PanelMenuSub = React.memo((props) => {
         const key = props.id + '_sep_' + index;
 
         const separatorProps = mergeProps(
-            {
-                id: key,
-                key,
-                className: cx('separator'),
-                role: 'separator'
-            },
-            _ptm('separator')
+            [
+                {
+                    id: key,
+                    key,
+                    className: cx('separator'),
+                    role: 'separator'
+                },
+                _ptm('separator')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...separatorProps}></li>;
@@ -107,21 +112,27 @@ export const PanelMenuSub = React.memo((props) => {
         const submenuRef = React.createRef();
 
         const toggleableContentProps = mergeProps(
-            {
-                className: cx('toggleableContent', { active })
-            },
-            _ptm('toggleableContent')
+            [
+                {
+                    className: cx('toggleableContent', { active })
+                },
+                _ptm('toggleableContent')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (item.items) {
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    timeout: { enter: 1000, exit: 450 },
-                    in: active,
-                    unmountOnExit: true
-                },
-                _ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        timeout: { enter: 1000, exit: 450 },
+                        in: active,
+                        unmountOnExit: true
+                    },
+                    _ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -146,38 +157,50 @@ export const PanelMenuSub = React.memo((props) => {
         const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
         const iconClassName = classNames('p-menuitem-icon', item.icon);
         const iconProps = mergeProps(
-            {
-                className: cx('icon', { item })
-            },
-            getPTOptions(item, 'icon')
+            [
+                {
+                    className: cx('icon', { item })
+                },
+                getPTOptions(item, 'icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props: props.menuProps });
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions(item, 'label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions(item, 'label')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const label = item.label && <span {...labelProps}>{item.label}</span>;
         const submenuIconClassName = 'p-panelmenu-icon';
         const submenuIconProps = mergeProps(
-            {
-                className: cx('submenuicon')
-            },
-            getPTOptions(item, 'submenuicon')
+            [
+                {
+                    className: cx('submenuicon')
+                },
+                getPTOptions(item, 'submenuicon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(active ? props.submenuIcon || <ChevronDownIcon {...submenuIconProps} /> : props.submenuIcon || <ChevronRightIcon {...submenuIconProps} />);
         const submenu = createSubmenu(item, active, index);
         const actionProps = mergeProps(
-            {
-                href: item.url || '#',
-                className: cx('action', { item }),
-                target: item.target,
-                onClick: (event) => onItemClick(event, item, index),
-                role: 'menuitem',
-                'aria-disabled': item.disabled
-            },
-            getPTOptions(item, 'action')
+            [
+                {
+                    href: item.url || '#',
+                    className: cx('action', { item }),
+                    target: item.target,
+                    onClick: (event) => onItemClick(event, item, index),
+                    role: 'menuitem',
+                    'aria-disabled': item.disabled
+                },
+                getPTOptions(item, 'action')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -205,14 +228,17 @@ export const PanelMenuSub = React.memo((props) => {
         }
 
         const menuitemProps = mergeProps(
-            {
-                key,
-                id: key,
-                className: cx('menuitem', { item }),
-                style: item.style,
-                role: 'none'
-            },
-            getPTOptions(item, 'menuitem')
+            [
+                {
+                    key,
+                    id: key,
+                    className: cx('menuitem', { item }),
+                    style: item.style,
+                    role: 'none'
+                },
+                getPTOptions(item, 'menuitem')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -235,11 +261,14 @@ export const PanelMenuSub = React.memo((props) => {
 
     const ptKey = props.root ? 'menu' : 'submenu';
     const menuProps = mergeProps(
-        {
-            className: classNames(cx(ptKey), props.className),
-            role: 'tree'
-        },
-        ptm(ptKey)
+        [
+            {
+                className: classNames(cx(ptKey), props.className),
+                role: 'tree'
+            },
+            ptm(ptKey)
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <ul {...menuProps}>{menu}</ul>;

--- a/components/lib/passthrough/index.d.ts
+++ b/components/lib/passthrough/index.d.ts
@@ -1,6 +1,7 @@
 export interface PassThroughOptions {
     mergeSections?: boolean | undefined;
     mergeProps?: boolean | undefined;
+    useTailwind?: boolean | undefined;
 }
 
 export declare function usePassThrough(pt1: object, pt2: object, options?: PassThroughOptions): object;

--- a/components/lib/passthrough/index.js
+++ b/components/lib/passthrough/index.js
@@ -2,14 +2,16 @@
  * @todo: Add dynamic params support;
  *
  * Exp;
- * usePassThrough(pt1, pt2, pt3, pt*, { mergeSections: true });
- * usePassThrough(pt1, { mergeSections: true });
+ * usePassThrough(pt1, pt2, { mergeSections: true });
+ *
+ * When useTailwind is enabled, mergeProps is overridden to true
  */
-export const usePassThrough = (pt1 = {}, pt2 = {}, { mergeSections = true, mergeProps = false } = {}) => {
+export const usePassThrough = (pt1 = {}, pt2 = {}, { mergeSections = true, mergeProps = false, useTailwind = false } = {}) => {
     return {
         _usept: {
             mergeSections,
-            mergeProps
+            mergeProps: mergeProps || useTailwind,
+            useTailwind
         },
         originalValue: pt1,
         value: { ...pt1, ...pt2 }

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -261,8 +261,8 @@ export const Password = React.memo(
         const createIcon = () => {
             let icon;
 
-            const hideIconProps = mergeProps(ptm('hideIcon'));
-            const showIconProps = mergeProps(ptm('showIcon'));
+            const hideIconProps = mergeProps([ptm('hideIcon')], { useTailwind: context.useTailwind });
+            const showIconProps = mergeProps([ptm('showIcon')], { useTailwind: context.useTailwind });
 
             if (unmaskedState) {
                 icon = props.hideIcon || <EyeSlashIcon {...hideIconProps} />;
@@ -297,32 +297,44 @@ export const Password = React.memo(
             const header = ObjectUtils.getJSXElement(props.header, props);
             const footer = ObjectUtils.getJSXElement(props.footer, props);
             const panelProps = mergeProps(
-                {
-                    className: cx('panel', { context }),
-                    style: props.panelStyle,
-                    onClick: onPanelClick
-                },
-                ptm('panel')
+                [
+                    {
+                        className: cx('panel', { context }),
+                        style: props.panelStyle,
+                        onClick: onPanelClick
+                    },
+                    ptm('panel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const meterProps = mergeProps(
-                {
-                    className: cx('meter')
-                },
-                ptm('meter')
+                [
+                    {
+                        className: cx('meter')
+                    },
+                    ptm('meter')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const meterLabelProps = mergeProps(
-                {
-                    className: cx('meterLabel', { strength }),
-                    style: { width }
-                },
-                ptm('meterLabel')
+                [
+                    {
+                        className: cx('meterLabel', { strength }),
+                        style: { width }
+                    },
+                    ptm('meterLabel')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const infoProps = mergeProps(
-                {
-                    className: cx('info', { strength })
-                },
-                ptm('info')
+                [
+                    {
+                        className: cx('info', { strength })
+                    },
+                    ptm('info')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const content = props.content ? (
@@ -337,18 +349,21 @@ export const Password = React.memo(
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: overlayVisibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter: onOverlayEnter,
-                    onEntered: onOverlayEntered,
-                    onExit: onOverlayExit,
-                    onExited: onOverlayExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: overlayVisibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter: onOverlayEnter,
+                        onEntered: onOverlayEntered,
+                        onExit: onOverlayExit,
+                        onExited: onOverlayExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const panel = (
@@ -379,36 +394,42 @@ export const Password = React.memo(
         const panel = createPanel();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root', { isFilled, focusedState }),
-                style: props.style
-            },
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root', { isFilled, focusedState }),
+                    style: props.style
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const inputTextProps = mergeProps(
-            {
-                ref: inputRef,
-                id: props.inputId,
-                ...inputProps,
-                className: cx('input'),
-                onBlur: onBlur,
-                onFocus: onFocus,
-                onInput: onInput,
-                onKeyUp: onKeyup,
-                style: props.inputStyle,
-                tabIndex: props.tabIndex,
-                tooltip: props.tooltip,
-                tooltipOptions: props.tooltipOptions,
-                type: type,
-                value: props.value,
-                __parentMetadata: {
-                    parent: metaData
-                }
-            },
-            ptm('input')
+            [
+                {
+                    ref: inputRef,
+                    id: props.inputId,
+                    ...inputProps,
+                    className: cx('input'),
+                    onBlur: onBlur,
+                    onFocus: onFocus,
+                    onInput: onInput,
+                    onKeyUp: onKeyup,
+                    style: props.inputStyle,
+                    tabIndex: props.tabIndex,
+                    tooltip: props.tooltip,
+                    tooltipOptions: props.tooltipOptions,
+                    type: type,
+                    value: props.value,
+                    __parentMetadata: {
+                        parent: metaData
+                    }
+                },
+                ptm('input')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/picklist/PickList.js
+++ b/components/lib/picklist/PickList.js
@@ -288,14 +288,17 @@ export const PickList = React.memo(
         const targetList = getVisibleList(props.target, 'target');
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root')),
-                style: props.style
-            },
-            PickListBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root')),
+                    style: props.style
+                },
+                PickListBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/picklist/PickListControls.js
+++ b/components/lib/picklist/PickListControls.js
@@ -4,10 +4,12 @@ import { AngleDoubleDownIcon } from '../icons/angledoubledown';
 import { AngleDoubleUpIcon } from '../icons/angledoubleup';
 import { AngleDownIcon } from '../icons/angledown';
 import { AngleUpIcon } from '../icons/angleup';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const PickListControls = React.memo((props) => {
     const { ptm, cx, unstyled } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const moveUpIcon = props.moveUpIcon || <AngleUpIcon />;
     const moveTopIcon = props.moveTopIcon || <AngleDoubleUpIcon />;
@@ -137,10 +139,13 @@ export const PickListControls = React.memo((props) => {
     };
 
     const controlsProps = mergeProps(
-        {
-            className: classNames(props.className, cx('controls'))
-        },
-        ptm('controls', { hostName: props.hostName })
+        [
+            {
+                className: classNames(props.className, cx('controls'))
+            },
+            ptm('controls', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/picklist/PickListItem.js
+++ b/components/lib/picklist/PickListItem.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, mergeProps } from '../utils/Utils';
 
 export const PickListItem = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -35,15 +37,18 @@ export const PickListItem = React.memo((props) => {
     const content = props.template ? props.template(props.value) : props.value;
 
     const itemProps = mergeProps(
-        {
-            className: classNames(props.className, cx('item', { subProps: props })),
-            onClick,
-            onKeyDown,
-            tabIndex: props.tabIndex,
-            role: 'option',
-            'aria-selected': props.selected
-        },
-        getPTOptions('item')
+        [
+            {
+                className: classNames(props.className, cx('item', { subProps: props })),
+                onClick,
+                onKeyDown,
+                tabIndex: props.tabIndex,
+                role: 'option',
+                'aria-selected': props.selected
+            },
+            getPTOptions('item')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/picklist/PickListSubList.js
+++ b/components/lib/picklist/PickListSubList.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { SearchIcon } from '../icons/search';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 import { PickListItem } from './PickListItem';
 
 export const PickListSubList = React.memo(
     React.forwardRef((props, ref) => {
         const listElementRef = React.useRef(null);
+        const context = React.useContext(PrimeReactContext);
         const { ptm, cx } = props;
 
         const getPTOptions = (key, options) => {
@@ -119,10 +121,13 @@ export const PickListSubList = React.memo(
 
         const createHeader = () => {
             const headerProps = mergeProps(
-                {
-                    className: cx('header')
-                },
-                getPTOptions('header')
+                [
+                    {
+                        className: cx('header')
+                    },
+                    getPTOptions('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.header) {
@@ -148,32 +153,41 @@ export const PickListSubList = React.memo(
         const createFilter = () => {
             const iconClassName = 'p-picklist-filter-icon';
             const filterIconProps = mergeProps(
-                {
-                    className: cx('filterIcon')
-                },
-                getPTOptions('filterIcon')
+                [
+                    {
+                        className: cx('filterIcon')
+                    },
+                    getPTOptions('filterIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.type === 'source' ? props.sourceFilterIcon || <SearchIcon {...filterIconProps} /> : props.targetFilterIcon || <SearchIcon {...filterIconProps} />;
             const filterIcon = IconUtils.getJSXIcon(icon, { ...filterIconProps }, { props });
 
             if (props.showFilter) {
                 const filterProps = mergeProps(
-                    {
-                        className: cx('filter')
-                    },
-                    getPTOptions('filter')
+                    [
+                        {
+                            className: cx('filter')
+                        },
+                        getPTOptions('filter')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const filterInputProps = mergeProps(
-                    {
-                        type: 'text',
-                        value: props.filterValue,
-                        onChange: onFilter,
-                        onKeyDown: onFilterInputKeyDown,
-                        placeholder: props.placeholder,
-                        className: cx('filterInput')
-                    },
-                    getPTOptions('filterInput')
+                    [
+                        {
+                            type: 'text',
+                            value: props.filterValue,
+                            onChange: onFilter,
+                            onKeyDown: onFilterInputKeyDown,
+                            placeholder: props.placeholder,
+                            className: cx('filterInput')
+                        },
+                        getPTOptions('filterInput')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 let content = (
@@ -200,10 +214,13 @@ export const PickListSubList = React.memo(
                 }
 
                 const filterContainerProps = mergeProps(
-                    {
-                        className: cx('filterContainer')
-                    },
-                    getPTOptions('filterContainer')
+                    [
+                        {
+                            className: cx('filterContainer')
+                        },
+                        getPTOptions('filterContainer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...filterContainerProps}>{content}</div>;
@@ -216,13 +233,16 @@ export const PickListSubList = React.memo(
             const items = createItems();
 
             const listProps = mergeProps(
-                {
-                    className: classNames(props.listClassName, cx('list')),
-                    role: 'listbox',
-                    'aria-multiselectable': true,
-                    style: props.style
-                },
-                getPTOptions('list')
+                [
+                    {
+                        className: classNames(props.listClassName, cx('list')),
+                        role: 'listbox',
+                        'aria-multiselectable': true,
+                        style: props.style
+                    },
+                    getPTOptions('list')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <ul {...listProps}>{items}</ul>;
@@ -233,11 +253,14 @@ export const PickListSubList = React.memo(
         const list = createList();
 
         const listWrapperProps = mergeProps(
-            {
-                className: classNames(props.className, cx('listWrapper')),
-                ref: listElementRef
-            },
-            getPTOptions('listWrapper')
+            [
+                {
+                    className: classNames(props.className, cx('listWrapper')),
+                    ref: listElementRef
+                },
+                getPTOptions('listWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/picklist/PickListTransferControls.js
+++ b/components/lib/picklist/PickListTransferControls.js
@@ -9,10 +9,12 @@ import { AngleDownIcon } from '../icons/angledown';
 import { AngleLeftIcon } from '../icons/angleleft';
 import { AngleRightIcon } from '../icons/angleright';
 import { AngleUpIcon } from '../icons/angleup';
+import { PrimeReactContext } from '../api/Api';
 import { IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const PickListTransferControls = React.memo((props) => {
     const viewChanged = useMatchMedia(`(max-width: ${props.breakpoint})`, props.breakpoint);
+    const context = React.useContext(PrimeReactContext);
     const { ptm, cx, unstyled } = props;
 
     function getIconComponent(iconType) {
@@ -125,10 +127,13 @@ export const PickListTransferControls = React.memo((props) => {
     };
 
     const buttonsProps = mergeProps(
-        {
-            className: classNames(props.className, cx('buttons'))
-        },
-        ptm('buttons', { hostName: props.hostName })
+        [
+            {
+                className: classNames(props.className, cx('buttons'))
+            },
+            ptm('buttons', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/progressbar/ProgressBar.js
+++ b/components/lib/progressbar/ProgressBar.js
@@ -29,30 +29,39 @@ export const ProgressBar = React.memo(
         const createDeterminate = () => {
             const label = createLabel();
             const rootProps = mergeProps(
-                {
-                    className: classNames(props.className, cx('root')),
-                    style: props.style,
-                    role: 'progressbar',
-                    'aria-valuemin': '0',
-                    'aria-valuenow': props.value,
-                    'aria-valuemax': '100'
-                },
-                ProgressBarBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        className: classNames(props.className, cx('root')),
+                        style: props.style,
+                        role: 'progressbar',
+                        'aria-valuemin': '0',
+                        'aria-valuenow': props.value,
+                        'aria-valuemax': '100'
+                    },
+                    ProgressBarBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const valueProps = mergeProps(
-                {
-                    className: cx('value'),
-                    style: { width: props.value + '%', display: 'flex', backgroundColor: props.color }
-                },
-                ptm('value')
+                [
+                    {
+                        className: cx('value'),
+                        style: { width: props.value + '%', display: 'flex', backgroundColor: props.color }
+                    },
+                    ptm('value')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -64,28 +73,37 @@ export const ProgressBar = React.memo(
 
         const createIndeterminate = () => {
             const rootProps = mergeProps(
-                {
-                    className: classNames(props.className, cx('root')),
-                    style: props.style,
-                    role: 'progressbar'
-                },
-                ProgressBarBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        className: classNames(props.className, cx('root')),
+                        style: props.style,
+                        role: 'progressbar'
+                    },
+                    ProgressBarBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const containerProps = mergeProps(
-                {
-                    className: cx('container')
-                },
-                ptm('container')
+                [
+                    {
+                        className: cx('container')
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const valueProps = mergeProps(
-                {
-                    className: cx('value'),
-                    style: { backgroundColor: props.color }
-                },
-                ptm('value')
+                [
+                    {
+                        className: cx('value'),
+                        style: { backgroundColor: props.color }
+                    },
+                    ptm('value')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/progressspinner/ProgressSpinner.js
+++ b/components/lib/progressspinner/ProgressSpinner.js
@@ -23,37 +23,46 @@ export const ProgressSpinner = React.memo(
         }));
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: props.style,
-                className: classNames(props.className, cx('root')),
-                role: 'alert',
-                'aria-busy': true
-            },
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: props.style,
+                    className: classNames(props.className, cx('root')),
+                    role: 'alert',
+                    'aria-busy': true
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const spinnerProps = mergeProps(
-            {
-                className: cx('spinner'),
-                viewBox: '25 25 50 50',
-                style: sx('spinner')
-            },
-            ptm('spinner')
+            [
+                {
+                    className: cx('spinner'),
+                    viewBox: '25 25 50 50',
+                    style: sx('spinner')
+                },
+                ptm('spinner')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const circleProps = mergeProps(
-            {
-                className: cx('circle'),
-                cx: '50',
-                cy: '50',
-                r: '20',
-                fill: props.fill,
-                strokeWidth: props.strokeWidth,
-                strokeMiterlimit: '10'
-            },
-            ptm('circle')
+            [
+                {
+                    className: cx('circle'),
+                    cx: '50',
+                    cy: '50',
+                    r: '20',
+                    fill: props.fill,
+                    strokeWidth: props.strokeWidth,
+                    strokeMiterlimit: '10'
+                },
+                ptm('circle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -124,50 +124,65 @@ export const RadioButton = React.memo(
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
 
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root', { focusedState })),
-                style: props.style,
-                onClick: onClick
-            },
-            RadioButtonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root', { focusedState })),
+                    style: props.style,
+                    onClick: onClick
+                },
+                RadioButtonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputWrapperProps = mergeProps(
-            {
-                className: 'p-hidden-accessible'
-            },
-            ptm('hiddenInputWrapper')
+            [
+                {
+                    className: 'p-hidden-accessible'
+                },
+                ptm('hiddenInputWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const hiddenInputProps = mergeProps(
-            {
-                type: 'radio',
-                name: props.name,
-                defaultChecked: props.checked,
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyDown: onKeyDown,
-                disabled: props.disabled,
-                required: props.required,
-                tabIndex: props.tabIndex,
-                ...ariaProps
-            },
-            ptm('hiddenInput')
+            [
+                {
+                    type: 'radio',
+                    name: props.name,
+                    defaultChecked: props.checked,
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyDown: onKeyDown,
+                    disabled: props.disabled,
+                    required: props.required,
+                    tabIndex: props.tabIndex,
+                    ...ariaProps
+                },
+                ptm('hiddenInput')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const inputProps = mergeProps(
-            {
-                className: cx('input', { focusedState })
-            },
-            ptm('input')
+            [
+                {
+                    className: cx('input', { focusedState })
+                },
+                ptm('input')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const iconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            ptm('icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                ptm('icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/rating/Rating.js
+++ b/components/lib/rating/Rating.js
@@ -92,29 +92,38 @@ export const Rating = React.memo(
             return Array.from({ length: props.stars }, (_, i) => i + 1).map((value) => {
                 const active = value <= props.value;
                 const onIconProps = mergeProps(
-                    {
-                        className: cx('onIcon')
-                    },
-                    getPTOptions(props.value, 'onIcon')
+                    [
+                        {
+                            className: cx('onIcon')
+                        },
+                        getPTOptions(props.value, 'onIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const offIconProps = mergeProps(
-                    {
-                        className: cx('onIcon')
-                    },
-                    getPTOptions(props.value, 'offIcon')
+                    [
+                        {
+                            className: cx('onIcon')
+                        },
+                        getPTOptions(props.value, 'offIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = active ? { type: props.onIcon || <StarFillIcon {...onIconProps} /> } : { type: props.offIcon || <StarIcon {...offIconProps} /> };
                 const content = IconUtils.getJSXIcon(icon.type, active ? { ...onIconProps } : { ...offIconProps }, { props });
 
                 const itemProps = mergeProps(
-                    {
-                        key: value,
-                        className: cx('item', { active }),
-                        tabIndex: tabIndex,
-                        onClick: (e) => rate(e, value),
-                        onKeyDown: (e) => onStarKeyDown(e, value)
-                    },
-                    getPTOptions(props.value, 'item')
+                    [
+                        {
+                            key: value,
+                            className: cx('item', { active }),
+                            tabIndex: tabIndex,
+                            onClick: (e) => rate(e, value),
+                            onKeyDown: (e) => onStarKeyDown(e, value)
+                        },
+                        getPTOptions(props.value, 'item')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -128,22 +137,28 @@ export const Rating = React.memo(
         const createCancelIcon = () => {
             if (props.cancel) {
                 const cancelIconProps = mergeProps(
-                    {
-                        className: cx('cancelIcon')
-                    },
-                    ptm('cancelIcon')
+                    [
+                        {
+                            className: cx('cancelIcon')
+                        },
+                        ptm('cancelIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.cancelIcon || <BanIcon {...cancelIconProps} />;
                 const content = IconUtils.getJSXIcon(icon, { ...cancelIconProps, ...props.cancelIconProps }, { props });
 
                 const cancelItemProps = mergeProps(
-                    {
-                        className: cx('cancelItem'),
-                        onClick: clear,
-                        tabIndex: tabIndex,
-                        onKeyDown: onCancelKeyDown
-                    },
-                    ptm('cancelItem')
+                    [
+                        {
+                            className: cx('cancelItem'),
+                            onClick: clear,
+                            tabIndex: tabIndex,
+                            onKeyDown: onCancelKeyDown
+                        },
+                        ptm('cancelItem')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...cancelItemProps}>{content}</div>;
@@ -159,14 +174,17 @@ export const Rating = React.memo(
 
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root'),
-                style: props.style
-            },
-            RatingBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root'),
+                    style: props.style
+                },
+                RatingBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const cancelIcon = createCancelIcon();

--- a/components/lib/ripple/Ripple.js
+++ b/components/lib/ripple/Ripple.js
@@ -102,10 +102,13 @@ export const Ripple = React.memo(
         });
 
         const rootProps = mergeProps(
-            {
-                className: classNames(cx('root'))
-            },
-            ptm('root')
+            [
+                {
+                    className: classNames(cx('root'))
+                },
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (context && context.ripple) || PrimeReact.ripple ? <span role="presentation" ref={inkRef} {...rootProps} onAnimationEnd={onAnimationEnd}></span> : null;

--- a/components/lib/row/Row.js
+++ b/components/lib/row/Row.js
@@ -12,12 +12,15 @@ export const Row = (inProps) => {
     });
 
     const rootProps = mergeProps(
-        {
-            className: props.className,
-            style: props.style
-        },
-        RowBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                className: props.className,
+                style: props.style
+            },
+            RowBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <tr {...rootProps}>{props.children}</tr>;

--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -170,48 +170,63 @@ export const ScrollPanel = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            ref: containerRef,
-            style: props.style,
-            className: cx('root')
-        },
-        ScrollPanelBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: props.id,
+                ref: containerRef,
+                style: props.style,
+                className: cx('root')
+            },
+            ScrollPanelBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const wrapperProps = mergeProps(
-        {
-            className: cx('wrapper')
-        },
-        ptm('wrapper')
+        [
+            {
+                className: cx('wrapper')
+            },
+            ptm('wrapper')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const contentProps = mergeProps(
-        {
-            className: cx('content'),
-            onScroll: moveBar,
-            onMouseEnter: moveBar
-        },
-        ptm('content')
+        [
+            {
+                className: cx('content'),
+                onScroll: moveBar,
+                onMouseEnter: moveBar
+            },
+            ptm('content')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const barXProps = mergeProps(
-        {
-            ref: xBarRef,
-            className: cx('barx'),
-            onMouseDown: onXBarMouseDown
-        },
-        ptm('barx')
+        [
+            {
+                ref: xBarRef,
+                className: cx('barx'),
+                onMouseDown: onXBarMouseDown
+            },
+            ptm('barx')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const barYProps = mergeProps(
-        {
-            ref: yBarRef,
-            className: cx('bary'),
-            onMouseDown: onYBarMouseDown
-        },
-        ptm('bary')
+        [
+            {
+                ref: yBarRef,
+                className: cx('bary'),
+                onMouseDown: onYBarMouseDown
+            },
+            ptm('bary')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/scrolltop/ScrollTop.js
+++ b/components/lib/scrolltop/ScrollTop.js
@@ -84,37 +84,46 @@ export const ScrollTop = React.memo(
         });
 
         const iconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            ptm('icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                ptm('icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.icon || <ChevronUpIcon {...iconProps} />;
         const scrollIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
         const rootProps = mergeProps(
-            {
-                ref: scrollElementRef,
-                type: 'button',
-                className: classNames(props.className, cx('root')),
-                style: props.style,
-                onClick
-            },
-            ScrollTopBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: scrollElementRef,
+                    type: 'button',
+                    className: classNames(props.className, cx('root')),
+                    style: props.style,
+                    onClick
+                },
+                ScrollTopBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: visibleState,
-                timeout: { enter: 150, exit: 150 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter,
-                onEntered,
-                onExited
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: visibleState,
+                    timeout: { enter: 150, exit: 150 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter,
+                    onEntered,
+                    onExited
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/selectbutton/SelectButton.js
+++ b/components/lib/selectbutton/SelectButton.js
@@ -128,15 +128,18 @@ export const SelectButton = React.memo(
         const items = createItems();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root'),
-                style: props.style,
-                role: 'group'
-            },
-            SelectButtonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root'),
+                    style: props.style,
+                    role: 'group'
+                },
+                SelectButtonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/selectbutton/SelectButtonItem.js
+++ b/components/lib/selectbutton/SelectButtonItem.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const SelectButtonItem = React.memo((props) => {
     const [focusedState, setFocusedState] = React.useState(false);
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -45,10 +47,13 @@ export const SelectButtonItem = React.memo((props) => {
 
     const createContent = () => {
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions('label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions('label')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return props.template ? ObjectUtils.getJSXElement(props.template, props.option) : <span {...labelProps}>{props.label}</span>;
@@ -57,18 +62,21 @@ export const SelectButtonItem = React.memo((props) => {
     const content = createContent();
 
     const buttonProps = mergeProps(
-        {
-            className: classNames(props.className, cx('button', { itemProps: props, focusedState })),
-            role: 'button',
-            'aria-label': props.label,
-            'aria-pressed': props.selected,
-            onClick: onClick,
-            onKeyDown: onKeyDown,
-            tabIndex: props.tabIndex,
-            onFocus: onFocus,
-            onBlur: onBlur
-        },
-        getPTOptions('button')
+        [
+            {
+                className: classNames(props.className, cx('button', { itemProps: props, focusedState })),
+                role: 'button',
+                'aria-label': props.label,
+                'aria-pressed': props.selected,
+                onClick: onClick,
+                onKeyDown: onKeyDown,
+                tabIndex: props.tabIndex,
+                onFocus: onFocus,
+                onBlur: onBlur
+            },
+            getPTOptions('button')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/sidebar/Sidebar.js
+++ b/components/lib/sidebar/Sidebar.js
@@ -164,21 +164,27 @@ export const Sidebar = React.forwardRef((inProps, ref) => {
 
     const createCloseIcon = () => {
         const closeButtonProps = mergeProps(
-            {
-                type: 'button',
-                ref: closeIconRef,
-                className: cx('closeButton'),
-                onClick: (e) => onClose(e),
-                'aria-label': ariaLabel
-            },
-            ptm('closeButton')
+            [
+                {
+                    type: 'button',
+                    ref: closeIconRef,
+                    className: cx('closeButton'),
+                    onClick: (e) => onClose(e),
+                    'aria-label': ariaLabel
+                },
+                ptm('closeButton')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const closeIconProps = mergeProps(
-            {
-                className: cx('closeIcon')
-            },
-            ptm('closeIcon')
+            [
+                {
+                    className: cx('closeIcon')
+                },
+                ptm('closeIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const icon = props.closeIcon || <TimesIcon {...closeIconProps} />;
@@ -216,59 +222,77 @@ export const Sidebar = React.forwardRef((inProps, ref) => {
         };
 
         const maskProps = mergeProps(
-            {
-                ref: maskRef,
-                style: sx('mask'),
-                className: cx('mask', { maskVisibleState }),
-                onMouseDown: (e) => onMaskClick(e)
-            },
-            ptm('mask')
+            [
+                {
+                    ref: maskRef,
+                    style: sx('mask'),
+                    className: cx('mask', { maskVisibleState }),
+                    onMouseDown: (e) => onMaskClick(e)
+                },
+                ptm('mask')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                className: cx('root', { context }),
-                style: props.style,
-                role: 'complementary'
-            },
-            SidebarBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    className: cx('root', { context }),
+                    style: props.style,
+                    role: 'complementary'
+                },
+                SidebarBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const headerProps = mergeProps(
-            {
-                className: cx('header')
-            },
-            ptm('header')
+            [
+                {
+                    className: cx('header')
+                },
+                ptm('header')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const contentProps = mergeProps(
-            {
-                className: cx('content')
-            },
-            ptm('content')
+            [
+                {
+                    className: cx('content')
+                },
+                ptm('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const iconsProps = mergeProps(
-            {
-                className: cx('icons')
-            },
-            ptm('icons')
+            [
+                {
+                    className: cx('icons')
+                },
+                ptm('icons')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: visibleState,
-                timeout: transitionTimeout,
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEntered,
-                onExiting,
-                onExited
-            },
-            ptm('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: visibleState,
+                    timeout: transitionTimeout,
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEntered,
+                    onExiting,
+                    onExited
+                },
+                ptm('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/skeleton/Skeleton.js
+++ b/components/lib/skeleton/Skeleton.js
@@ -24,13 +24,16 @@ export const Skeleton = React.memo(
         const style = props.size ? { width: props.size, height: props.size, borderRadius: props.borderRadius } : { width: props.width, height: props.height, borderRadius: props.borderRadius };
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: classNames(props.className, cx('root')),
-                style: { ...style, ...sx('root') }
-            },
-            SkeletonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root')),
+                    style: { ...style, ...sx('root') }
+                },
+                SkeletonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <div {...rootProps}></div>;

--- a/components/lib/slidemenu/SlideMenu.js
+++ b/components/lib/slidemenu/SlideMenu.js
@@ -137,21 +137,27 @@ export const SlideMenu = React.memo(
 
         const createBackward = () => {
             const previousIconProps = mergeProps(
-                {
-                    className: cx('previousIcon')
-                },
-                ptm('previousIcon')
+                [
+                    {
+                        className: cx('previousIcon')
+                    },
+                    ptm('previousIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.backIcon || <ChevronLeftIcon {...previousIconProps} />;
             const backIcon = IconUtils.getJSXIcon(icon, { ...previousIconProps }, { props });
-            const previousLabelProps = mergeProps(ptm('previousLabel'));
+            const previousLabelProps = mergeProps([ptm('previousLabel')], { useTailwind: context.useTailwind });
             const previousProps = mergeProps(
-                {
-                    ref: backward,
-                    className: cx('previous', { levelState }),
-                    onClick: (e) => navigateBack(e)
-                },
-                ptm('previous')
+                [
+                    {
+                        ref: backward,
+                        className: cx('previous', { levelState }),
+                        onClick: (e) => navigateBack(e)
+                    },
+                    ptm('previous')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -166,46 +172,58 @@ export const SlideMenu = React.memo(
             const wrapperStyle = { height: props.viewportHeight + 'px' };
             const backward = createBackward();
             const rootProps = mergeProps(
-                {
-                    ref: menuRef,
-                    id: props.id,
-                    className: cx('root'),
-                    style: props.style,
-                    onClick: (e) => onPanelClick(e)
-                },
-                SlideMenuBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: menuRef,
+                        id: props.id,
+                        className: cx('root'),
+                        style: props.style,
+                        onClick: (e) => onPanelClick(e)
+                    },
+                    SlideMenuBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const wrapperProps = mergeProps(
-                {
-                    className: cx('wrapper'),
-                    style: wrapperStyle
-                },
-                ptm('wrapper')
+                [
+                    {
+                        className: cx('wrapper'),
+                        style: wrapperStyle
+                    },
+                    ptm('wrapper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const contentProps = mergeProps(
-                {
-                    ref: slideMenuContent,
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        ref: slideMenuContent,
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: !props.popup || visibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter,
-                    onEntered,
-                    onExit,
-                    onExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: !props.popup || visibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter,
+                        onEntered,
+                        onExit,
+                        onExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/slidemenu/SlideMenuSub.js
+++ b/components/lib/slidemenu/SlideMenuSub.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import { AngleRightIcon } from '../icons/angleright';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const SlideMenuSub = React.memo((props) => {
     const [activeItemState, setActiveItemState] = React.useState(null);
     const [renderSubMenu, setRenderSubMenu] = React.useState({});
     const { ptm, cx, sx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (item, key) => {
         return ptm(key, {
@@ -47,13 +49,16 @@ export const SlideMenuSub = React.memo((props) => {
         const key = props.id + '_sep_' + index;
 
         const separatorProps = mergeProps(
-            {
-                id: key,
-                key,
-                className: cx('separator'),
-                role: 'separator'
-            },
-            ptm('separator', { hostName: props.hostName })
+            [
+                {
+                    id: key,
+                    key,
+                    className: cx('separator'),
+                    role: 'separator'
+                },
+                ptm('separator', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...separatorProps}></li>;
@@ -97,36 +102,48 @@ export const SlideMenuSub = React.memo((props) => {
         const active = activeItemState === item;
         const iconClassName = classNames('p-menuitem-icon', item.icon);
         const iconProps = mergeProps(
-            {
-                className: cx('icon')
-            },
-            getPTOptions(item, 'icon')
+            [
+                {
+                    className: cx('icon')
+                },
+                getPTOptions(item, 'icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props: props.menuProps });
         const submenuIconProps = mergeProps(
-            {
-                className: cx('submenuIcon')
-            },
-            getPTOptions(item, 'submenuIcon')
+            [
+                {
+                    className: cx('submenuIcon')
+                },
+                getPTOptions(item, 'submenuIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions(item, 'label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions(item, 'label')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(props.submenuIcon || <AngleRightIcon {...submenuIconProps} />, { ...submenuIconProps }, { props });
         const label = item.label && <span {...labelProps}>{item.label}</span>;
         const submenu = createSubmenu(item, index);
         const actionProps = mergeProps(
-            {
-                href: item.url || '#',
-                className: cx('action'),
-                target: item.target,
-                onClick: (event) => onItemClick(event, item, index),
-                'aria-disabled': item.disabled
-            },
-            getPTOptions(item, 'action')
+            [
+                {
+                    href: item.url || '#',
+                    className: cx('action'),
+                    target: item.target,
+                    onClick: (event) => onItemClick(event, item, index),
+                    'aria-disabled': item.disabled
+                },
+                getPTOptions(item, 'action')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -153,13 +170,16 @@ export const SlideMenuSub = React.memo((props) => {
         }
 
         const menuitemProps = mergeProps(
-            {
-                id: key,
-                key,
-                className: cx('menuitem', { active, item }),
-                style: item.style
-            },
-            getPTOptions(item, 'menuitem')
+            [
+                {
+                    id: key,
+                    key,
+                    className: cx('menuitem', { active, item }),
+                    style: item.style
+                },
+                getPTOptions(item, 'menuitem')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -180,11 +200,14 @@ export const SlideMenuSub = React.memo((props) => {
 
     const items = createItems();
     const menuProps = mergeProps(
-        {
-            className: cx('menu', { subProps: props }),
-            style: sx('menu', { subProps: props })
-        },
-        ptm('menu', { hostName: props.hostName })
+        [
+            {
+                className: cx('menu', { subProps: props }),
+                style: sx('menu', { subProps: props })
+            },
+            ptm('menu', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <ul {...menuProps}>{items}</ul>;

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -203,21 +203,24 @@ export const Slider = React.memo(
             };
 
             const handleProps = mergeProps(
-                {
-                    className: cx('handle', { index, handleIndex }),
-                    style: { ...sx('handle', { dragging, leftValue, bottomValue }), ...style },
-                    tabIndex: props.tabIndex,
-                    role: 'slider',
-                    onMouseDown: (event) => onMouseDown(event, index),
-                    onTouchStart: (event) => onTouchStart(event, index),
-                    onKeyDown: (event) => onKeyDown(event, index),
-                    'aria-valuemin': props.min,
-                    'aria-valuemax': props.max,
-                    'aria-valuenow': leftValue || bottomValue || 0,
-                    'aria-orientation': props.orientation,
-                    ...ariaProps
-                },
-                ptm('handle')
+                [
+                    {
+                        className: cx('handle', { index, handleIndex }),
+                        style: { ...sx('handle', { dragging, leftValue, bottomValue }), ...style },
+                        tabIndex: props.tabIndex,
+                        role: 'slider',
+                        onMouseDown: (event) => onMouseDown(event, index),
+                        onTouchStart: (event) => onTouchStart(event, index),
+                        onKeyDown: (event) => onKeyDown(event, index),
+                        'aria-valuemin': props.min,
+                        'aria-valuemax': props.max,
+                        'aria-valuenow': leftValue || bottomValue || 0,
+                        'aria-orientation': props.orientation,
+                        ...ariaProps
+                    },
+                    ptm('handle')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...handleProps}></span>;
@@ -235,11 +238,14 @@ export const Slider = React.memo(
             const rangeStyle = horizontal ? { left: rangeSliderPosition + '%', width: rangeSliderWidth + '%' } : { bottom: rangeSliderPosition + '%', height: rangeSliderWidth + '%' };
 
             const rangeProps = mergeProps(
-                {
-                    className: cx('range'),
-                    style: { ...sx('range'), ...rangeStyle }
-                },
-                ptm('range')
+                [
+                    {
+                        className: cx('range'),
+                        style: { ...sx('range'), ...rangeStyle }
+                    },
+                    ptm('range')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -262,11 +268,14 @@ export const Slider = React.memo(
             const handle = horizontal ? createHandle(handleValue, null, null) : createHandle(null, handleValue, null);
 
             const rangeProps = mergeProps(
-                {
-                    className: cx('range'),
-                    style: { ...sx('range'), ...rangeStyle }
-                },
-                ptm('range')
+                [
+                    {
+                        className: cx('range'),
+                        style: { ...sx('range'), ...rangeStyle }
+                    },
+                    ptm('range')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -287,13 +296,16 @@ export const Slider = React.memo(
 
         const content = props.range ? createRangeSlider() : createSingleSlider();
         const rootProps = mergeProps(
-            {
-                style: props.style,
-                className: cx('root', { vertical, horizontal }),
-                onClick: onBarClick
-            },
-            SliderBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    style: props.style,
+                    className: cx('root', { vertical, horizontal }),
+                    onClick: onBarClick
+                },
+                SliderBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/speeddial/SpeedDial.js
+++ b/components/lib/speeddial/SpeedDial.js
@@ -176,22 +176,28 @@ export const SpeedDial = React.memo(
             const contentClassName = classNames('p-speeddial-action', { 'p-disabled': disabled });
             const iconClassName = classNames('p-speeddial-action-icon', _icon);
             const actionIconProps = mergeProps(
-                {
-                    className: cx('actionIcon')
-                },
-                ptm('actionIcon')
+                [
+                    {
+                        className: cx('actionIcon')
+                    },
+                    ptm('actionIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const actionProps = mergeProps(
-                {
-                    href: url || '#',
-                    role: 'menuitem',
-                    className: classNames(_itemClassName, cx('action', { disabled })),
-                    style: _itemStyle,
-                    target: target,
-                    'data-pr-tooltip': label,
-                    onClick: (e) => onItemClick(e, item)
-                },
-                ptm('action')
+                [
+                    {
+                        href: url || '#',
+                        role: 'menuitem',
+                        className: classNames(_itemClassName, cx('action', { disabled })),
+                        style: _itemStyle,
+                        target: target,
+                        'data-pr-tooltip': label,
+                        onClick: (e) => onItemClick(e, item)
+                    },
+                    ptm('action')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = IconUtils.getJSXIcon(_icon, { ...actionIconProps }, { props });
             let content = (
@@ -215,13 +221,16 @@ export const SpeedDial = React.memo(
             }
 
             const menuItemProps = mergeProps(
-                {
-                    key: index,
-                    className: cx('menuitem'),
-                    style: getItemStyle(index),
-                    role: 'none'
-                },
-                ptm('menuitem')
+                [
+                    {
+                        key: index,
+                        className: cx('menuitem'),
+                        style: getItemStyle(index),
+                        role: 'none'
+                    },
+                    ptm('menuitem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuItemProps}>{content}</li>;
@@ -234,13 +243,16 @@ export const SpeedDial = React.memo(
         const createList = () => {
             const items = createItems();
             const menuProps = mergeProps(
-                {
-                    ref: listRef,
-                    className: cx('menu'),
-                    style: sx('menu'),
-                    role: 'menu'
-                },
-                ptm('menu')
+                [
+                    {
+                        ref: listRef,
+                        className: cx('menu'),
+                        style: sx('menu'),
+                        role: 'menu'
+                    },
+                    ptm('menu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <ul {...menuProps}>{items}</ul>;
@@ -262,20 +274,25 @@ export const SpeedDial = React.memo(
             });
             const icon = showIconVisible ? props.showIcon || <PlusIcon /> : hideIconVisible ? props.hideIcon || <MinusIcon /> : null;
             const toggleIcon = IconUtils.getJSXIcon(icon, undefined, { props, visible });
-            const buttonProps = mergeProps({
-                type: 'button',
-                style: props.buttonStyle,
-                className: classNames(props.buttonClassName, cx('button')),
-                icon: toggleIcon,
-                onClick: (e) => onClick(e),
-                disabled: props.disabled,
-                'aria-label': props['aria-label'],
-                pt: ptm('button'),
-                unstyled: props.unstyled,
-                __parentMetadata: {
-                    parent: metaData
-                }
-            });
+            const buttonProps = mergeProps(
+                [
+                    {
+                        type: 'button',
+                        style: props.buttonStyle,
+                        className: classNames(props.buttonClassName, cx('button')),
+                        icon: toggleIcon,
+                        onClick: (e) => onClick(e),
+                        disabled: props.disabled,
+                        'aria-label': props['aria-label'],
+                        pt: ptm('button'),
+                        unstyled: props.unstyled,
+                        __parentMetadata: {
+                            parent: metaData
+                        }
+                    }
+                ],
+                { useTailwind: context.useTailwind }
+            );
             const content = <Button {...buttonProps} />;
 
             if (props.buttonTemplate) {
@@ -297,11 +314,14 @@ export const SpeedDial = React.memo(
         const createMask = () => {
             if (props.mask) {
                 const maskProps = mergeProps(
-                    {
-                        className: classNames(props.maskClassName, cx('mask', { visible })),
-                        style: props.maskStyle
-                    },
-                    ptm('mask')
+                    [
+                        {
+                            className: classNames(props.maskClassName, cx('mask', { visible })),
+                            style: props.maskStyle
+                        },
+                        ptm('mask')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...maskProps}></div>;
@@ -314,12 +334,15 @@ export const SpeedDial = React.memo(
         const list = createList();
         const mask = createMask();
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root', { visible })),
-                style: { ...props.style, ...sx('root') }
-            },
-            SpeedDialBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root', { visible })),
+                    style: { ...props.style, ...sx('root') }
+                },
+                SpeedDialBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -134,10 +134,13 @@ export const SplitButton = React.memo(
 
         const dropdownIcon = () => {
             const iconProps = mergeProps(
-                {
-                    className: cx('icon')
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon')
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.dropdownIcon || <ChevronDownIcon {...iconProps} />;
@@ -147,14 +150,17 @@ export const SplitButton = React.memo(
         };
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: idState,
-                className: classNames(props.className, cx('root', { size })),
-                style: props.style
-            },
-            SplitButtonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: idState,
+                    className: classNames(props.className, cx('root', { size })),
+                    style: props.style
+                },
+                SplitButtonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/splitbutton/SplitButtonItem.js
+++ b/components/lib/splitbutton/SplitButtonItem.js
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const SplitButtonItem = React.memo((props) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -25,11 +27,14 @@ export const SplitButtonItem = React.memo((props) => {
 
     const createSeparator = () => {
         const separatorProps = mergeProps(
-            {
-                className: cx('separator'),
-                role: 'separator'
-            },
-            getPTOptions('separator')
+            [
+                {
+                    className: cx('separator'),
+                    role: 'separator'
+                },
+                getPTOptions('separator')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...separatorProps}></li>;
@@ -45,31 +50,40 @@ export const SplitButtonItem = React.memo((props) => {
         const iconClassName = classNames('p-menuitem-icon', _icon);
 
         const menuIconProps = mergeProps(
-            {
-                className: cx('menuIcon')
-            },
-            getPTOptions('menuIcon')
+            [
+                {
+                    className: cx('menuIcon')
+                },
+                getPTOptions('menuIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = IconUtils.getJSXIcon(_icon, { ...menuIconProps }, { props: props.splitButtonProps });
 
         const menuLabelProps = mergeProps(
-            {
-                className: cx('menuLabel')
-            },
-            getPTOptions('menuLabel')
+            [
+                {
+                    className: cx('menuLabel')
+                },
+                getPTOptions('menuLabel')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const label = _label && <span {...menuLabelProps}>{_label}</span>;
 
         const anchorProps = mergeProps(
-            {
-                href: url || '#',
-                role: 'menuitem',
-                className: cx('anchor'),
-                target: target,
-                onClick: onClick,
-                'aria-label': _label
-            },
-            getPTOptions('anchor')
+            [
+                {
+                    href: url || '#',
+                    role: 'menuitem',
+                    className: cx('anchor'),
+                    target: target,
+                    onClick: onClick,
+                    'aria-label': _label
+                },
+                getPTOptions('anchor')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -93,11 +107,14 @@ export const SplitButtonItem = React.memo((props) => {
         }
 
         const menuItemProps = mergeProps(
-            {
-                className: cx('menuItem'),
-                role: 'none'
-            },
-            getPTOptions('menuItem')
+            [
+                {
+                    className: cx('menuItem'),
+                    role: 'none'
+                },
+                getPTOptions('menuItem')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...menuItemProps}>{content}</li>;

--- a/components/lib/splitbutton/SplitButtonPanel.js
+++ b/components/lib/splitbutton/SplitButtonPanel.js
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { Portal } from '../portal/Portal';
+import { PrimeReactContext } from '../api/Api';
 import { mergeProps } from '../utils/Utils';
 
 export const SplitButtonPanel = React.forwardRef((props, ref) => {
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -15,37 +17,46 @@ export const SplitButtonPanel = React.forwardRef((props, ref) => {
 
     const createElement = () => {
         const menuProps = mergeProps(
-            {
-                ref: ref,
-                className: cx('menu', { subProps: props }),
-                style: props.menuStyle,
-                onClick: props.onClick
-            },
-            getPTOptions('menu')
+            [
+                {
+                    ref: ref,
+                    className: cx('menu', { subProps: props }),
+                    style: props.menuStyle,
+                    onClick: props.onClick
+                },
+                getPTOptions('menu')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const menuListProps = mergeProps(
-            {
-                id: props.menuId,
-                className: cx('menuList'),
-                role: 'menu'
-            },
-            getPTOptions('menuList')
+            [
+                {
+                    id: props.menuId,
+                    className: cx('menuList'),
+                    role: 'menu'
+                },
+                getPTOptions('menuList')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: props.in,
-                timeout: { enter: 120, exit: 100 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: props.onEnter,
-                onEntered: props.onEntered,
-                onExit: props.onExit,
-                onExited: props.onExited
-            },
-            getPTOptions('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: props.in,
+                    timeout: { enter: 120, exit: 100 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: props.onEnter,
+                    onEntered: props.onEntered,
+                    onExit: props.onExit,
+                    onExited: props.onExited
+                },
+                getPTOptions('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -242,24 +242,30 @@ export const Splitter = React.memo(
             const panelClassName = classNames(getPanelProp(panel, 'className'), cx('panel.root'));
 
             const gutterProps = mergeProps(
-                {
-                    ref: (el) => (gutterRefs.current[index] = el),
-                    className: cx('gutter'),
-                    style: props.layout === 'horizontal' ? { width: props.gutterSize + 'px' } : { height: props.gutterSize + 'px' },
-                    onMouseDown: (event) => onGutterMouseDown(event, index),
-                    onTouchStart: (event) => onGutterTouchStart(event, index),
-                    onTouchMove: (event) => onGutterTouchMove(event),
-                    onTouchEnd: (event) => onGutterTouchEnd(event),
-                    'data-p-splitter-gutter-resizing': false
-                },
-                ptm('gutter')
+                [
+                    {
+                        ref: (el) => (gutterRefs.current[index] = el),
+                        className: cx('gutter'),
+                        style: props.layout === 'horizontal' ? { width: props.gutterSize + 'px' } : { height: props.gutterSize + 'px' },
+                        onMouseDown: (event) => onGutterMouseDown(event, index),
+                        onTouchStart: (event) => onGutterTouchStart(event, index),
+                        onTouchMove: (event) => onGutterTouchMove(event),
+                        onTouchEnd: (event) => onGutterTouchEnd(event),
+                        'data-p-splitter-gutter-resizing': false
+                    },
+                    ptm('gutter')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const gutterHandlerProps = mergeProps(
-                {
-                    className: cx('gutterHandler')
-                },
-                ptm('gutterHandler')
+                [
+                    {
+                        className: cx('gutterHandler')
+                    },
+                    ptm('gutterHandler')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const gutter = index !== props.children.length - 1 && (
@@ -271,15 +277,18 @@ export const Splitter = React.memo(
             const flexBasis = 'calc(' + panelSize(panelSizes, index) + '% - ' + (childrenLength - 1) * props.gutterSize + 'px)';
 
             const rootProps = mergeProps(
-                {
-                    key: index,
-                    id: getPanelProp(panel, 'id'),
-                    className: panelClassName,
-                    style: { ...getPanelProp(panel, 'style'), flexBasis },
-                    role: 'presentation',
-                    'data-p-splitter-panel-nested': false
-                },
-                getPanelPT('splitterpanel.root')
+                [
+                    {
+                        key: index,
+                        id: getPanelProp(panel, 'id'),
+                        className: panelClassName,
+                        style: { ...getPanelProp(panel, 'style'), flexBasis },
+                        role: 'presentation',
+                        'data-p-splitter-panel-nested': false
+                    },
+                    getPanelPT('splitterpanel.root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -295,14 +304,17 @@ export const Splitter = React.memo(
         };
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                style: props.style,
-                className: classNames(props.className, cx('root')),
-                'data-p-splitter-resizing': false
-            },
-            SplitterBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    style: props.style,
+                    className: classNames(props.className, cx('root')),
+                    'data-p-splitter-resizing': false
+                },
+                SplitterBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const panels = createPanels();

--- a/components/lib/steps/Steps.js
+++ b/components/lib/steps/Steps.js
@@ -62,40 +62,52 @@ export const Steps = React.memo(
 
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(
-                {
-                    className: cx('icon', { item })
-                },
-                ptm('icon')
+                [
+                    {
+                        className: cx('icon', { item })
+                    },
+                    ptm('icon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props });
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label')
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const label = item.label && <span {...labelProps}>{item.label}</span>;
 
             const stepProps = mergeProps(
-                {
-                    className: cx('step')
-                },
-                ptm('step')
+                [
+                    {
+                        className: cx('step')
+                    },
+                    ptm('step')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const actionProps = mergeProps(
-                {
-                    href: item.url || '#',
-                    className: cx('action'),
-                    role: 'presentation',
-                    target: item.target,
-                    onClick: (event) => itemClick(event, item, index),
-                    tabIndex
-                },
-                ptm('action')
+                [
+                    {
+                        href: item.url || '#',
+                        className: cx('action'),
+                        role: 'presentation',
+                        target: item.target,
+                        onClick: (event) => itemClick(event, item, index),
+                        tabIndex
+                    },
+                    ptm('action')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -124,16 +136,19 @@ export const Steps = React.memo(
             }
 
             const menuItemProps = mergeProps(
-                {
-                    key,
-                    id: key,
-                    className: cx('menuitem', { active, disabled, item }),
-                    style: item.style,
-                    role: 'tab',
-                    'aria-selected': active,
-                    'aria-expanded': active
-                },
-                ptm('menuitem')
+                [
+                    {
+                        key,
+                        id: key,
+                        className: cx('menuitem', { active, disabled, item }),
+                        style: item.style,
+                        role: 'tab',
+                        'aria-selected': active,
+                        'aria-expanded': active
+                    },
+                    ptm('menuitem')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuItemProps}>{content}</li>;
@@ -141,10 +156,13 @@ export const Steps = React.memo(
 
         const createItems = () => {
             const menuProps = mergeProps(
-                {
-                    role: 'tablist'
-                },
-                ptm('menu')
+                [
+                    {
+                        role: 'tablist'
+                    },
+                    ptm('menu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (props.model) {
@@ -168,14 +186,17 @@ export const Steps = React.memo(
         }));
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: cx('root'),
-                style: props.style
-            },
-            StepsBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: cx('root'),
+                    style: props.style
+                },
+                StepsBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const items = createItems();

--- a/components/lib/tabmenu/TabMenu.js
+++ b/components/lib/tabmenu/TabMenu.js
@@ -105,32 +105,41 @@ export const TabMenu = React.memo(
             const active = isSelected(index);
             const iconClassName = classNames('p-menuitem-icon', _icon);
             const iconProps = mergeProps(
-                {
-                    className: cx('icon', { _icon })
-                },
-                getPTOptions('icon', item, index)
+                [
+                    {
+                        className: cx('icon', { _icon })
+                    },
+                    getPTOptions('icon', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = IconUtils.getJSXIcon(_icon, { ...iconProps }, { props });
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label')
-                },
-                getPTOptions('label', item, index)
+                [
+                    {
+                        className: cx('label')
+                    },
+                    getPTOptions('label', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const label = _label && <span {...labelProps}>{_label}</span>;
 
             const actionProps = mergeProps(
-                {
-                    href: url || '#',
-                    className: cx('action'),
-                    target: target,
-                    onClick: (event) => itemClick(event, item, index),
-                    role: 'presentation'
-                },
-                getPTOptions('action', item, index)
+                [
+                    {
+                        href: url || '#',
+                        className: cx('action'),
+                        target: target,
+                        onClick: (event) => itemClick(event, item, index),
+                        role: 'presentation'
+                    },
+                    getPTOptions('action', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = (
@@ -158,18 +167,21 @@ export const TabMenu = React.memo(
             }
 
             const menuItemProps = mergeProps(
-                {
-                    ref: tabsRef.current[`tab_${index}`],
-                    id: key,
-                    key,
-                    className: cx('menuitem', { _className, active, disabled }),
-                    style: style,
-                    role: 'tab',
-                    'aria-selected': active,
-                    'aria-expanded': active,
-                    'aria-disabled': disabled
-                },
-                getPTOptions('menuitem', item, index)
+                [
+                    {
+                        ref: tabsRef.current[`tab_${index}`],
+                        id: key,
+                        key,
+                        className: cx('menuitem', { _className, active, disabled }),
+                        style: style,
+                        role: 'tab',
+                        'aria-selected': active,
+                        'aria-expanded': active,
+                        'aria-disabled': disabled
+                    },
+                    getPTOptions('menuitem', item, index)
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...menuItemProps}>{content}</li>;
@@ -183,30 +195,39 @@ export const TabMenu = React.memo(
             const items = createItems();
 
             const inkbarProps = mergeProps(
-                {
-                    ref: inkbarRef,
-                    className: cx('inkbar')
-                },
-                ptm('inkbar')
+                [
+                    {
+                        ref: inkbarRef,
+                        className: cx('inkbar')
+                    },
+                    ptm('inkbar')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const menuProps = mergeProps(
-                {
-                    ref: navRef,
-                    className: cx('menu'),
-                    role: 'tablist'
-                },
-                ptm('menu')
+                [
+                    {
+                        ref: navRef,
+                        className: cx('menu'),
+                        role: 'tablist'
+                    },
+                    ptm('menu')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const rootProps = mergeProps(
-                {
-                    id: props.id,
-                    ref: elementRef,
-                    className: cx('root'),
-                    style: props.style
-                },
-                TabMenuBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        id: props.id,
+                        ref: elementRef,
+                        className: cx('root'),
+                        style: props.style
+                    },
+                    TabMenuBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -203,10 +203,13 @@ export const TabView = React.forwardRef((inProps, ref) => {
         const tabIndex = disabled ? null : 0;
         const leftIconElement = leftIcon && IconUtils.getJSXIcon(leftIcon, undefined, { props });
         const headerTitleProps = mergeProps(
-            {
-                className: cx('tab.headertitle')
-            },
-            getTabPT(tab, 'headertitle')
+            [
+                {
+                    className: cx('tab.headertitle')
+                },
+                getTabPT(tab, 'headertitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const titleElement = <span {...headerTitleProps}>{header}</span>;
         const rightIconElement = rightIcon && IconUtils.getJSXIcon(rightIcon, undefined, { props });
@@ -215,17 +218,20 @@ export const TabView = React.forwardRef((inProps, ref) => {
         const closableIconElement = closable ? IconUtils.getJSXIcon(icon, { className: iconClassName, onClick: (e) => onTabHeaderClose(e, index) }, { props }) : null;
 
         const headerActionProps = mergeProps(
-            {
-                id: headerId,
-                role: 'tab',
-                className: cx('tab.headeraction'),
-                tabIndex,
-                'aria-controls': ariaControls,
-                'aria-selected': selected,
-                onClick: (e) => onTabHeaderClick(e, tab, index),
-                onKeyDown: (e) => onKeyDown(e, tab, index)
-            },
-            getTabPT(tab, 'headeraction')
+            [
+                {
+                    id: headerId,
+                    role: 'tab',
+                    className: cx('tab.headeraction'),
+                    tabIndex,
+                    'aria-controls': ariaControls,
+                    'aria-selected': selected,
+                    onClick: (e) => onTabHeaderClick(e, tab, index),
+                    onKeyDown: (e) => onKeyDown(e, tab, index)
+                },
+                getTabPT(tab, 'headeraction')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -260,14 +266,17 @@ export const TabView = React.forwardRef((inProps, ref) => {
         }
 
         const headerProps = mergeProps(
-            {
-                ref: (el) => (tabsRef.current[`tab_${index}`] = el),
-                className: cx('tab.header', { selected, disabled, headerClassName, _className }),
-                style: sx('tab.header', { headerStyle, _style }),
-                role: 'presentation'
-            },
-            getTabPT(tab, 'root'),
-            getTabPT(tab, 'header')
+            [
+                {
+                    ref: (el) => (tabsRef.current[`tab_${index}`] = el),
+                    className: cx('tab.header', { selected, disabled, headerClassName, _className }),
+                    style: sx('tab.header', { headerStyle, _style }),
+                    role: 'presentation'
+                },
+                getTabPT(tab, 'root'),
+                getTabPT(tab, 'header')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...headerProps}>{content}</li>;
@@ -285,31 +294,40 @@ export const TabView = React.forwardRef((inProps, ref) => {
         const headers = createTabHeaders();
 
         const navContentProps = mergeProps(
-            {
-                id: idState,
-                ref: contentRef,
-                className: cx('navcontent'),
-                style: props.style,
-                onScroll
-            },
-            ptm('navcontent')
+            [
+                {
+                    id: idState,
+                    ref: contentRef,
+                    className: cx('navcontent'),
+                    style: props.style,
+                    onScroll
+                },
+                ptm('navcontent')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const navProps = mergeProps(
-            {
-                ref: navRef,
-                className: cx('nav'),
-                role: 'tablist'
-            },
-            ptm('nav')
+            [
+                {
+                    ref: navRef,
+                    className: cx('nav'),
+                    role: 'tablist'
+                },
+                ptm('nav')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const inkbarProps = mergeProps(
-            {
-                ref: inkbarRef,
-                className: cx('inkbar')
-            },
-            ptm('inkbar')
+            [
+                {
+                    ref: inkbarRef,
+                    className: cx('inkbar')
+                },
+                ptm('inkbar')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -324,11 +342,14 @@ export const TabView = React.forwardRef((inProps, ref) => {
 
     const createContent = () => {
         const panelContainerProps = mergeProps(
-            {
-                className: cx('panelcontainer'),
-                style: props.panelContainerStyle
-            },
-            ptm('panelcontainer')
+            [
+                {
+                    className: cx('panelcontainer'),
+                    style: props.panelContainerStyle
+                },
+                ptm('panelcontainer')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const contents = React.Children.map(props.children, (tab, index) => {
             if (shouldUseTab(tab, index) && (!props.renderActiveOnly || isSelected(index))) {
@@ -336,17 +357,20 @@ export const TabView = React.forwardRef((inProps, ref) => {
                 const contentId = idState + '_content_' + index;
                 const ariaLabelledBy = idState + '_header_' + index;
                 const contentProps = mergeProps(
-                    {
-                        id: contentId,
-                        className: cx('tab.content', { props, selected, getTabProp, tab, isSelected, shouldUseTab, index }),
-                        style: sx('tab.content', { props, getTabProp, tab, isSelected, shouldUseTab, index }),
-                        role: 'tabpanel',
-                        'aria-labelledby': ariaLabelledBy,
-                        'aria-hidden': !selected
-                    },
-                    TabPanelBase.getCOtherProps(tab),
-                    getTabPT(tab, 'root'),
-                    getTabPT(tab, 'content')
+                    [
+                        {
+                            id: contentId,
+                            className: cx('tab.content', { props, selected, getTabProp, tab, isSelected, shouldUseTab, index }),
+                            style: sx('tab.content', { props, getTabProp, tab, isSelected, shouldUseTab, index }),
+                            role: 'tabpanel',
+                            'aria-labelledby': ariaLabelledBy,
+                            'aria-hidden': !selected
+                        },
+                        TabPanelBase.getCOtherProps(tab),
+                        getTabPT(tab, 'root'),
+                        getTabPT(tab, 'content')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...contentProps}>{!props.renderActiveOnly ? getTabProp(tab, 'children') : selected && getTabProp(tab, 'children')}</div>;
@@ -357,18 +381,21 @@ export const TabView = React.forwardRef((inProps, ref) => {
     };
 
     const createPrevButton = () => {
-        const prevIconProps = mergeProps(ptm('previcon'));
+        const prevIconProps = mergeProps([ptm('previcon')], { useTailwind: context.useTailwind });
         const icon = props.prevButton || <ChevronLeftIcon {...prevIconProps} />;
         const leftIcon = IconUtils.getJSXIcon(icon, { ...prevIconProps }, { props });
         const prevButtonProps = mergeProps(
-            {
-                ref: prevBtnRef,
-                type: 'button',
-                className: cx('prevbutton'),
-                'aria-label': ariaLabel('previousPageLabel'),
-                onClick: (e) => navBackward(e)
-            },
-            ptm('prevbutton')
+            [
+                {
+                    ref: prevBtnRef,
+                    type: 'button',
+                    className: cx('prevbutton'),
+                    'aria-label': ariaLabel('previousPageLabel'),
+                    onClick: (e) => navBackward(e)
+                },
+                ptm('prevbutton')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.scrollable && !backwardIsDisabledState) {
@@ -385,22 +412,28 @@ export const TabView = React.forwardRef((inProps, ref) => {
 
     const createNextButton = () => {
         const nextIconProps = mergeProps(
-            {
-                'aria-hidden': 'true'
-            },
-            ptm('nexticon')
+            [
+                {
+                    'aria-hidden': 'true'
+                },
+                ptm('nexticon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = props.nextButton || <ChevronRightIcon {...nextIconProps} />;
         const rightIcon = IconUtils.getJSXIcon(icon, { ...nextIconProps }, { props });
         const nextButtonProps = mergeProps(
-            {
-                ref: nextBtnRef,
-                type: 'button',
-                className: cx('nextbutton'),
-                'aria-label': ariaLabel('nextPageLabel'),
-                onClick: (e) => navForward(e)
-            },
-            ptm('nextbutton')
+            [
+                {
+                    ref: nextBtnRef,
+                    type: 'button',
+                    className: cx('nextbutton'),
+                    'aria-label': ariaLabel('nextPageLabel'),
+                    onClick: (e) => navForward(e)
+                },
+                ptm('nextbutton')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (props.scrollable && !forwardIsDisabledState) {
@@ -414,21 +447,27 @@ export const TabView = React.forwardRef((inProps, ref) => {
     };
 
     const rootProps = mergeProps(
-        {
-            id: idState,
-            ref: elementRef,
-            style: props.style,
-            className: cx('root')
-        },
-        TabViewBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                id: idState,
+                ref: elementRef,
+                style: props.style,
+                className: cx('root')
+            },
+            TabViewBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const navContainerProps = mergeProps(
-        {
-            className: cx('navcontainer')
-        },
-        ptm('navcontainer')
+        [
+            {
+                className: cx('navcontainer')
+            },
+            ptm('navcontainer')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const navigator = createNavigator();
     const content = createContent();

--- a/components/lib/tag/Tag.js
+++ b/components/lib/tag/Tag.js
@@ -16,10 +16,13 @@ export const Tag = React.forwardRef((inProps, ref) => {
     const elementRef = React.useRef(null);
 
     const iconProps = mergeProps(
-        {
-            className: cx('icon')
-        },
-        ptm('icon')
+        [
+            {
+                className: cx('icon')
+            },
+            ptm('icon')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const icon = IconUtils.getJSXIcon(props.icon, { ...iconProps }, { props });
@@ -30,20 +33,26 @@ export const Tag = React.forwardRef((inProps, ref) => {
     }));
 
     const rootProps = mergeProps(
-        {
-            ref: elementRef,
-            className: classNames(props.className, cx('root')),
-            style: props.style
-        },
-        TagBase.getOtherProps(props),
-        ptm('root')
+        [
+            {
+                ref: elementRef,
+                className: classNames(props.className, cx('root')),
+                style: props.style
+            },
+            TagBase.getOtherProps(props),
+            ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const valueProps = mergeProps(
-        {
-            className: cx('value')
-        },
-        ptm('value')
+        [
+            {
+                className: cx('value')
+            },
+            ptm('value')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/terminal/Terminal.js
+++ b/components/lib/terminal/Terminal.js
@@ -28,10 +28,13 @@ export const Terminal = React.memo(
 
         useHandleStyle(TerminalBase.css.styles, isUnstyled, { name: 'terminal' });
         const promptProps = mergeProps(
-            {
-                className: cx('prompt')
-            },
-            ptm('prompt')
+            [
+                {
+                    className: cx('prompt')
+                },
+                ptm('prompt')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const onClick = () => {
@@ -121,7 +124,7 @@ export const Terminal = React.memo(
 
         const createWelcomeMessage = () => {
             if (props.welcomeMessage) {
-                const welcomeMessageProps = mergeProps(ptm('welcomeMessage'));
+                const welcomeMessageProps = mergeProps([ptm('welcomeMessage')], { useTailwind: context.useTailwind });
 
                 return <div {...welcomeMessageProps}>{props.welcomeMessage}</div>;
             }
@@ -132,18 +135,24 @@ export const Terminal = React.memo(
         const createCommand = (command, index) => {
             const { text, response } = command;
             const key = text + '_' + index;
-            const commandsProps = mergeProps({ key }, ptm('commands'));
+            const commandsProps = mergeProps([{ key }, ptm('commands')], { useTailwind: context.useTailwind });
             const commandProps = mergeProps(
-                {
-                    className: cx('command')
-                },
-                ptm('command')
+                [
+                    {
+                        className: cx('command')
+                    },
+                    ptm('command')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const responseProps = mergeProps(
-                {
-                    className: cx('response')
-                },
-                ptm('response')
+                [
+                    {
+                        className: cx('response')
+                    },
+                    ptm('response')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -158,10 +167,13 @@ export const Terminal = React.memo(
         const createContent = () => {
             const content = commandsState.map(createCommand);
             const contentProps = mergeProps(
-                {
-                    className: cx('content')
-                },
-                ptm('content')
+                [
+                    {
+                        className: cx('content')
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...contentProps}>{content}</div>;
@@ -169,23 +181,29 @@ export const Terminal = React.memo(
 
         const createPromptContainer = () => {
             const containerProps = mergeProps(
-                {
-                    className: cx('container')
-                },
-                ptm('container')
+                [
+                    {
+                        className: cx('container')
+                    },
+                    ptm('container')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const commandTextProps = mergeProps(
-                {
-                    ref: inputRef,
-                    value: commandTextState,
-                    type: 'text',
-                    className: cx('commandText'),
-                    autoComplete: 'off',
-                    onChange: (e) => onInputChange(e),
-                    onKeyDown: (e) => onInputKeyDown(e)
-                },
-                ptm('commandText')
+                [
+                    {
+                        ref: inputRef,
+                        value: commandTextState,
+                        type: 'text',
+                        className: cx('commandText'),
+                        autoComplete: 'off',
+                        onChange: (e) => onInputChange(e),
+                        onKeyDown: (e) => onInputKeyDown(e)
+                    },
+                    ptm('commandText')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -200,15 +218,18 @@ export const Terminal = React.memo(
         const content = createContent();
         const prompt = createPromptContainer();
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                className: classNames(props.className, cx('root')),
-                style: props.style,
-                onClick
-            },
-            TerminalBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root')),
+                    style: props.style,
+                    onClick
+                },
+                TerminalBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -183,30 +183,36 @@ export const TieredMenu = React.memo(
 
         const createElement = () => {
             const rootProps = mergeProps(
-                {
-                    ref: menuRef,
-                    id: props.id,
-                    className: cx('root'),
-                    style: props.style,
-                    onClick: onPanelClick
-                },
-                TieredMenuBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: menuRef,
+                        id: props.id,
+                        className: cx('root'),
+                        style: props.style,
+                        onClick: onPanelClick
+                    },
+                    TieredMenuBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: cx('transition'),
-                    in: visibleState,
-                    timeout: { enter: 120, exit: 100 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEnter,
-                    onEntered,
-                    onExit,
-                    onExited
-                },
-                ptm('transition')
+                [
+                    {
+                        classNames: cx('transition'),
+                        in: visibleState,
+                        timeout: { enter: 120, exit: 100 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEnter,
+                        onEntered,
+                        onExit,
+                        onExited
+                    },
+                    ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/tieredmenu/TieredMenuSub.js
+++ b/components/lib/tieredmenu/TieredMenuSub.js
@@ -2,11 +2,13 @@ import * as React from 'react';
 import { useEventListener, useMountEffect, useResizeListener, useUpdateEffect } from '../hooks/Hooks';
 import { AngleRightIcon } from '../icons/angleright';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const TieredMenuSub = React.memo((props) => {
     const [activeItemState, setActiveItemState] = React.useState(null);
     const elementRef = React.useRef(null);
+    const context = React.useContext(PrimeReactContext);
     const { ptm, cx, sx } = props;
 
     const getPTOptions = (item, key) => {
@@ -191,12 +193,15 @@ export const TieredMenuSub = React.memo((props) => {
         const key = 'separator_' + index;
 
         const separatorProps = mergeProps(
-            {
-                key,
-                className: cx('separator'),
-                role: 'separator'
-            },
-            ptm('separator', { hostName: props.hostName })
+            [
+                {
+                    key,
+                    className: cx('separator'),
+                    role: 'separator'
+                },
+                ptm('separator', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <li {...separatorProps}></li>;
@@ -237,40 +242,52 @@ export const TieredMenuSub = React.memo((props) => {
         const linkClassName = classNames('p-menuitem-link', { 'p-disabled': disabled });
         const iconClassName = classNames('p-menuitem-icon', _icon);
         const iconProps = mergeProps(
-            {
-                className: cx('icon', { _icon })
-            },
-            getPTOptions(item, 'icon')
+            [
+                {
+                    className: cx('icon', { _icon })
+                },
+                getPTOptions(item, 'icon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = IconUtils.getJSXIcon(_icon, { ...iconProps }, { props: props.menuProps });
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions(item, 'label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions(item, 'label')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const label = _label && <span {...labelProps}>{_label}</span>;
         const submenuIconClassName = 'p-submenu-icon';
         const submenuIconProps = mergeProps(
-            {
-                className: cx('submenuIcon')
-            },
-            getPTOptions(item, 'submenuIcon')
+            [
+                {
+                    className: cx('submenuIcon')
+                },
+                getPTOptions(item, 'submenuIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const submenuIcon = item.items && IconUtils.getJSXIcon(props.submenuIcon || <AngleRightIcon {...submenuIconProps} />, { ...submenuIconProps }, { props: props.menuProps });
         const submenu = createSubmenu(item, index);
         const actionProps = mergeProps(
-            {
-                href: url || '#',
-                className: cx('action', { disabled }),
-                target: target,
-                role: 'menuitem',
-                'aria-haspopup': items != null,
-                onClick: (event) => onItemClick(event, item),
-                onKeyDown: (event) => onItemKeyDown(event, item),
-                'aria-disabled': disabled
-            },
-            getPTOptions(item, 'action')
+            [
+                {
+                    href: url || '#',
+                    className: cx('action', { disabled }),
+                    target: target,
+                    role: 'menuitem',
+                    'aria-haspopup': items != null,
+                    onClick: (event) => onItemClick(event, item),
+                    onKeyDown: (event) => onItemKeyDown(event, item),
+                    'aria-disabled': disabled
+                },
+                getPTOptions(item, 'action')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -300,15 +317,18 @@ export const TieredMenuSub = React.memo((props) => {
         }
 
         const menuitemProps = mergeProps(
-            {
-                key,
-                id: key,
-                className: cx('menuitem', { _className, active }),
-                style: style,
-                onMouseEnter: (event) => onItemMouseEnter(event, item),
-                role: 'none'
-            },
-            getPTOptions(item, 'menuitem')
+            [
+                {
+                    key,
+                    id: key,
+                    className: cx('menuitem', { _className, active }),
+                    style: style,
+                    onMouseEnter: (event) => onItemMouseEnter(event, item),
+                    role: 'none'
+                },
+                getPTOptions(item, 'menuitem')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -330,14 +350,17 @@ export const TieredMenuSub = React.memo((props) => {
     const submenu = createMenu();
     const ptKey = props.root ? 'menu' : 'submenu';
     const menuProps = mergeProps(
-        {
-            ref: elementRef,
-            className: cx(ptKey, { subProps: props }),
-            style: sx(ptKey, { subProps: props }),
-            role: props.root ? 'menubar' : 'menu',
-            'aria-orientation': 'horizontal'
-        },
-        ptm(ptKey, { hostName: props.hostName })
+        [
+            {
+                ref: elementRef,
+                className: cx(ptKey, { subProps: props }),
+                style: sx(ptKey, { subProps: props }),
+                role: props.root ? 'menubar' : 'menu',
+                'aria-orientation': 'horizontal'
+            },
+            ptm(ptKey, { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <ul {...menuProps}>{submenu}</ul>;

--- a/components/lib/timeline/Timeline.js
+++ b/components/lib/timeline/Timeline.js
@@ -34,44 +34,62 @@ export const Timeline = React.memo(
                 props.value.map((item, index) => {
                     const opposite = ObjectUtils.getJSXElement(props.opposite, item, index);
                     const markerProps = mergeProps(
-                        {
-                            className: cx('marker')
-                        },
-                        getPTOptions('marker', index)
+                        [
+                            {
+                                className: cx('marker')
+                            },
+                            getPTOptions('marker', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const marker = ObjectUtils.getJSXElement(props.marker, item, index) || <div {...markerProps}></div>;
                     const connectorProps = mergeProps(
-                        {
-                            className: cx('connector')
-                        },
-                        getPTOptions('connector', index)
+                        [
+                            {
+                                className: cx('connector')
+                            },
+                            getPTOptions('connector', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const connector = index !== props.value.length - 1 && <div {...connectorProps}></div>;
                     const content = ObjectUtils.getJSXElement(props.content, item, index);
 
                     const eventProps = mergeProps(
-                        {
-                            className: cx('event')
-                        },
-                        getPTOptions('event', index)
+                        [
+                            {
+                                className: cx('event')
+                            },
+                            getPTOptions('event', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const oppositeProps = mergeProps(
-                        {
-                            className: cx('opposite')
-                        },
-                        getPTOptions('opposite', index)
+                        [
+                            {
+                                className: cx('opposite')
+                            },
+                            getPTOptions('opposite', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const separatorProps = mergeProps(
-                        {
-                            className: cx('separator')
-                        },
-                        getPTOptions('separator', index)
+                        [
+                            {
+                                className: cx('separator')
+                            },
+                            getPTOptions('separator', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
                     const contentProps = mergeProps(
-                        {
-                            className: cx('content')
-                        },
-                        getPTOptions('content', index)
+                        [
+                            {
+                                className: cx('content')
+                            },
+                            getPTOptions('content', index)
+                        ],
+                        { useTailwind: context.useTailwind }
                     );
 
                     return (
@@ -96,12 +114,15 @@ export const Timeline = React.memo(
         const events = createEvents();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: classNames(props.className, cx('root'))
-            },
-            TimelineBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root'))
+                },
+                TimelineBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <div {...rootProps}>{events}</div>;

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -115,26 +115,32 @@ export const Toast = React.memo(
 
         const createElement = () => {
             const rootProps = mergeProps(
-                {
-                    ref: containerRef,
-                    id: props.id,
-                    className: ptCallbacks.cx('root', { context }),
-                    style: ptCallbacks.sx('root')
-                },
-                ToastBase.getOtherProps(props),
-                ptCallbacks.ptm('root')
+                [
+                    {
+                        ref: containerRef,
+                        id: props.id,
+                        className: ptCallbacks.cx('root', { context }),
+                        style: ptCallbacks.sx('root')
+                    },
+                    ToastBase.getOtherProps(props),
+                    ptCallbacks.ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const transitionProps = mergeProps(
-                {
-                    classNames: ptCallbacks.cx('transition'),
-                    timeout: { enter: 300, exit: 300 },
-                    options: props.transitionOptions,
-                    unmountOnExit: true,
-                    onEntered,
-                    onExited
-                },
-                ptCallbacks.ptm('transition')
+                [
+                    {
+                        classNames: ptCallbacks.cx('transition'),
+                        timeout: { enter: 300, exit: 300 },
+                        options: props.transitionOptions,
+                        unmountOnExit: true,
+                        onEntered,
+                        onExited
+                    },
+                    ptCallbacks.ptm('transition')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/toast/ToastMessage.js
+++ b/components/lib/toast/ToastMessage.js
@@ -7,6 +7,7 @@ import { InfoCircleIcon } from '../icons/infocircle';
 import { TimesIcon } from '../icons/times';
 import { TimesCircleIcon } from '../icons/timescircle';
 import { Ripple } from '../ripple/Ripple';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, IconUtils, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const ToastMessage = React.memo(
@@ -28,6 +29,7 @@ export const ToastMessage = React.memo(
             life || 3000,
             !sticky && !focused
         );
+        const context = React.useContext(PrimeReactContext);
 
         const getPTOptions = (key, options) => {
             return ptm(key, {
@@ -78,11 +80,14 @@ export const ToastMessage = React.memo(
 
         const createCloseIcon = () => {
             const buttonIconProps = mergeProps(
-                {
-                    className: cx('message.buttonicon')
-                },
-                getPTOptions('buttonicon', parentParams),
-                ptmo(pt, 'buttonicon', { ...params, hostName: props.hostName })
+                [
+                    {
+                        className: cx('message.buttonicon')
+                    },
+                    getPTOptions('buttonicon', parentParams),
+                    ptmo(pt, 'buttonicon', { ...params, hostName: props.hostName })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = _closeIcon || <TimesIcon {...buttonIconProps} />;
@@ -90,14 +95,17 @@ export const ToastMessage = React.memo(
             const ariaLabel = props.ariaCloseLabel || localeOption('close');
 
             const closeButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('message.closeButton'),
-                    onClick: onClose,
-                    'aria-label': ariaLabel
-                },
-                getPTOptions('closeButton', parentParams),
-                ptmo(pt, 'closeButton', { ...params, hostName: props.hostName })
+                [
+                    {
+                        type: 'button',
+                        className: cx('message.closeButton'),
+                        onClick: onClose,
+                        'aria-label': ariaLabel
+                    },
+                    getPTOptions('closeButton', parentParams),
+                    ptmo(pt, 'closeButton', { ...params, hostName: props.hostName })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             if (closable !== false) {
@@ -118,11 +126,14 @@ export const ToastMessage = React.memo(
             if (messageInfo) {
                 const contentEl = ObjectUtils.getJSXElement(content, { message: messageInfo.message, onClick, onClose });
                 const iconProps = mergeProps(
-                    {
-                        className: cx('message.icon')
-                    },
-                    getPTOptions('icon', parentParams),
-                    ptmo(pt, 'icon', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('message.icon')
+                        },
+                        getPTOptions('icon', parentParams),
+                        ptmo(pt, 'icon', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 let icon = _icon;
@@ -149,27 +160,36 @@ export const ToastMessage = React.memo(
                 const messageIcon = IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
 
                 const textProps = mergeProps(
-                    {
-                        className: cx('message.text')
-                    },
-                    getPTOptions('text', parentParams),
-                    ptmo(pt, 'text', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('message.text')
+                        },
+                        getPTOptions('text', parentParams),
+                        ptmo(pt, 'text', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const summaryProps = mergeProps(
-                    {
-                        className: cx('message.summary')
-                    },
-                    getPTOptions('summary', parentParams),
-                    ptmo(pt, 'summary', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('message.summary')
+                        },
+                        getPTOptions('summary', parentParams),
+                        ptmo(pt, 'summary', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const detailProps = mergeProps(
-                    {
-                        className: cx('message.detail')
-                    },
-                    getPTOptions('detail', parentParams),
-                    ptmo(pt, 'detail', { ...params, hostName: props.hostName })
+                    [
+                        {
+                            className: cx('message.detail')
+                        },
+                        getPTOptions('detail', parentParams),
+                        ptmo(pt, 'detail', { ...params, hostName: props.hostName })
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return (
@@ -192,28 +212,34 @@ export const ToastMessage = React.memo(
         const closeIcon = createCloseIcon();
 
         const messageProps = mergeProps(
-            {
-                ref,
-                className: classNames(_className, cx('message.message', { severity })),
-                style,
-                role: 'alert',
-                'aria-live': 'assertive',
-                'aria-atomic': 'true',
-                onClick,
-                onMouseEnter: onMouseEnter,
-                onMouseLeave: onMouseLeave
-            },
-            getPTOptions('message', parentParams),
-            ptmo(pt, 'root', { ...params, hostName: props.hostName })
+            [
+                {
+                    ref,
+                    className: classNames(_className, cx('message.message', { severity })),
+                    style,
+                    role: 'alert',
+                    'aria-live': 'assertive',
+                    'aria-atomic': 'true',
+                    onClick,
+                    onMouseEnter: onMouseEnter,
+                    onMouseLeave: onMouseLeave
+                },
+                getPTOptions('message', parentParams),
+                ptmo(pt, 'root', { ...params, hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const contentProps = mergeProps(
-            {
-                className: classNames(_contentClassName, cx('message.content')),
-                style: contentStyle
-            },
-            getPTOptions('content', parentParams),
-            ptmo(pt, 'content', { ...params, hostName: props.hostName })
+            [
+                {
+                    className: classNames(_contentClassName, cx('message.content')),
+                    style: contentStyle
+                },
+                getPTOptions('content', parentParams),
+                ptmo(pt, 'content', { ...params, hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -53,10 +53,13 @@ export const ToggleButton = React.memo(
         const createIcon = () => {
             if (hasIcon) {
                 const iconProps = mergeProps(
-                    {
-                        className: cx('icon', { label })
-                    },
-                    ptm('icon')
+                    [
+                        {
+                            className: cx('icon', { label })
+                        },
+                        ptm('icon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return IconUtils.getJSXIcon(icon, { ...iconProps }, { props });
@@ -82,28 +85,34 @@ export const ToggleButton = React.memo(
         const iconElement = createIcon();
 
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            ptm('label')
+            [
+                {
+                    className: cx('label')
+                },
+                ptm('label')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                id: props.id,
-                className: cx('root', { hasIcon, hasLabel }),
-                style: props.style,
-                onClick: toggle,
-                onFocus: props.onFocus,
-                onBlur: props.onBlur,
-                onKeyDown: onKeyDown,
-                tabIndex: tabIndex,
-                role: 'button',
-                'aria-pressed': props.checked
-            },
-            ToggleButtonBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    id: props.id,
+                    className: cx('root', { hasIcon, hasLabel }),
+                    style: props.style,
+                    onClick: toggle,
+                    onFocus: props.onFocus,
+                    onBlur: props.onBlur,
+                    onKeyDown: onKeyDown,
+                    tabIndex: tabIndex,
+                    role: 'button',
+                    'aria-pressed': props.checked
+                },
+                ToggleButtonBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/toolbar/Toolbar.js
+++ b/components/lib/toolbar/Toolbar.js
@@ -24,36 +24,48 @@ export const Toolbar = React.memo(
         }));
 
         const startProps = mergeProps(
-            {
-                className: cx('start')
-            },
-            ptm('start')
+            [
+                {
+                    className: cx('start')
+                },
+                ptm('start')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const centerProps = mergeProps(
-            {
-                className: cx('center')
-            },
-            ptm('center')
+            [
+                {
+                    className: cx('center')
+                },
+                ptm('center')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const endProps = mergeProps(
-            {
-                className: cx('end')
-            },
-            ptm('end')
+            [
+                {
+                    className: cx('end')
+                },
+                ptm('end')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                id: props.id,
-                ref: elementRef,
-                style: props.style,
-                className: cx('root'),
-                role: 'toolbar'
-            },
-            ToolbarBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    id: props.id,
+                    ref: elementRef,
+                    style: props.style,
+                    className: cx('root'),
+                    role: 'toolbar'
+                },
+                ToolbarBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -483,32 +483,41 @@ export const Tooltip = React.memo(
         const createElement = () => {
             const empty = isTargetContentEmpty(currentTargetRef.current);
             const rootProps = mergeProps(
-                {
-                    id: props.id,
-                    className: classNames(props.className, cx('root', { positionState, classNameState })),
-                    style: props.style,
-                    role: 'tooltip',
-                    'aria-hidden': visibleState,
-                    onMouseEnter: (e) => onMouseEnter(e),
-                    onMouseLeave: (e) => onMouseLeave(e)
-                },
-                TooltipBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        id: props.id,
+                        className: classNames(props.className, cx('root', { positionState, classNameState })),
+                        style: props.style,
+                        role: 'tooltip',
+                        'aria-hidden': visibleState,
+                        onMouseEnter: (e) => onMouseEnter(e),
+                        onMouseLeave: (e) => onMouseLeave(e)
+                    },
+                    TooltipBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const arrowProps = mergeProps(
-                {
-                    className: cx('arrow'),
-                    style: sx('arrow', { ...metaData })
-                },
-                ptm('arrow')
+                [
+                    {
+                        className: cx('arrow'),
+                        style: sx('arrow', { ...metaData })
+                    },
+                    ptm('arrow')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const textProps = mergeProps(
-                {
-                    className: cx('text')
-                },
-                ptm('text')
+                [
+                    {
+                        className: cx('text')
+                    },
+                    ptm('text')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -395,13 +395,16 @@ export const Tree = React.memo(
             if (props.value) {
                 const rootNodes = createRootChildren();
                 const containerProps = mergeProps(
-                    {
-                        className: classNames(props.contentClassName, cx('container')),
-                        role: 'tree',
-                        style: props.contentStyle,
-                        ...ariaProps
-                    },
-                    ptm('container')
+                    [
+                        {
+                            className: classNames(props.contentClassName, cx('container')),
+                            role: 'tree',
+                            style: props.contentStyle,
+                            ...ariaProps
+                        },
+                        ptm('container')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <ul {...containerProps}>{rootNodes}</ul>;
@@ -413,19 +416,25 @@ export const Tree = React.memo(
         const createLoader = () => {
             if (props.loading) {
                 const loadingIconProps = mergeProps(
-                    {
-                        className: cx('loadingIcon')
-                    },
-                    ptm('loadingIcon')
+                    [
+                        {
+                            className: cx('loadingIcon')
+                        },
+                        ptm('loadingIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
                 const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
 
                 const loadingOverlayProps = mergeProps(
-                    {
-                        className: cx('loadingOverlay')
-                    },
-                    ptm('loadingOverlay')
+                    [
+                        {
+                            className: cx('loadingOverlay')
+                        },
+                        ptm('loadingOverlay')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...loadingOverlayProps}>{loadingIcon}</div>;
@@ -438,34 +447,43 @@ export const Tree = React.memo(
             if (props.filter) {
                 const value = ObjectUtils.isNotEmpty(filteredValue) ? filteredValue : '';
                 const searchIconProps = mergeProps(
-                    {
-                        className: cx('searchIcon')
-                    },
-                    ptm('searchIcon')
+                    [
+                        {
+                            className: cx('searchIcon')
+                        },
+                        ptm('searchIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.filterIcon || <SearchIcon {...searchIconProps} />;
                 const filterIcon = IconUtils.getJSXIcon(icon, { ...searchIconProps }, { props });
 
                 const filterContainerProps = mergeProps(
-                    {
-                        className: cx('filterContainer')
-                    },
-                    ptm('filterContainer')
+                    [
+                        {
+                            className: cx('filterContainer')
+                        },
+                        ptm('filterContainer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const inputProps = mergeProps(
-                    {
-                        type: 'text',
-                        value: value,
-                        autoComplete: 'off',
-                        className: cx('input'),
-                        placeholder: props.filterPlaceholder,
-                        'aria-label': props.filterPlaceholder,
-                        onKeyDown: onFilterInputKeyDown,
-                        onChange: onFilterInputChange,
-                        disabled: props.disabled
-                    },
-                    ptm('input')
+                    [
+                        {
+                            type: 'text',
+                            value: value,
+                            autoComplete: 'off',
+                            className: cx('input'),
+                            placeholder: props.filterPlaceholder,
+                            'aria-label': props.filterPlaceholder,
+                            onKeyDown: onFilterInputKeyDown,
+                            onChange: onFilterInputChange,
+                            disabled: props.disabled
+                        },
+                        ptm('input')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 let content = (
@@ -518,10 +536,13 @@ export const Tree = React.memo(
                 }
 
                 const headerProps = mergeProps(
-                    {
-                        className: cx('header')
-                    },
-                    ptm('header')
+                    [
+                        {
+                            className: cx('header')
+                        },
+                        ptm('header')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...headerProps}>{content}</div>;
@@ -534,10 +555,13 @@ export const Tree = React.memo(
             const content = ObjectUtils.getJSXElement(props.footer, props);
 
             const footerProps = mergeProps(
-                {
-                    className: cx('footer')
-                },
-                ptm('footer')
+                [
+                    {
+                        className: cx('footer')
+                    },
+                    ptm('footer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <div {...footerProps}>{content}</div>;
@@ -551,14 +575,17 @@ export const Tree = React.memo(
         const footer = createFooter();
 
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: classNames(props.className, cx('root')),
-                style: props.style,
-                id: props.id
-            },
-            TreeBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: classNames(props.className, cx('root')),
+                    style: props.style,
+                    id: props.id
+                },
+                TreeBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ariaLabel } from '../api/Api';
+import { ariaLabel, PrimeReactContext } from '../api/Api';
 import { CheckIcon } from '../icons/check';
 import { ChevronDownIcon } from '../icons/chevrondown';
 import { ChevronRightIcon } from '../icons/chevronright';
@@ -13,6 +13,7 @@ export const UITreeNode = React.memo((props) => {
     const isLeaf = props.isNodeLeaf(props.node);
     const expanded = (props.expandedKeys ? props.expandedKeys[props.node.key] !== undefined : false) || props.node.expanded;
     const { ptm, cx } = props;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key) => {
         return ptm(key, {
@@ -548,10 +549,13 @@ export const UITreeNode = React.memo((props) => {
 
     const createLabel = () => {
         const labelProps = mergeProps(
-            {
-                className: cx('label')
-            },
-            getPTOptions('label')
+            [
+                {
+                    className: cx('label')
+                },
+                getPTOptions('label')
+            ],
+            { useTailwind: context.useTailwind }
         );
         let content = <span {...labelProps}>{props.node.label}</span>;
 
@@ -575,26 +579,35 @@ export const UITreeNode = React.memo((props) => {
             const checked = isChecked();
             const partialChecked = isPartialChecked();
             const checkboxIconProps = mergeProps(
-                {
-                    className: cx('checkboxIcon')
-                },
-                getPTOptions('checkboxIcon')
+                [
+                    {
+                        className: cx('checkboxIcon')
+                    },
+                    getPTOptions('checkboxIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = checked ? props.checkboxIcon || <CheckIcon {...checkboxIconProps} /> : partialChecked ? props.checkboxIcon || <MinusIcon {...checkboxIconProps} /> : null;
             const checkboxIcon = IconUtils.getJSXIcon(icon, { ...checkboxIconProps }, props);
             const checkboxContainerProps = mergeProps(
-                {
-                    className: cx('checkboxContainer')
-                },
-                getPTOptions('checkboxContainer')
+                [
+                    {
+                        className: cx('checkboxContainer')
+                    },
+                    getPTOptions('checkboxContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const checkboxProps = mergeProps(
-                {
-                    className: cx('checkbox', { checked, partialChecked, nodeProps: props }),
-                    role: 'checkbox',
-                    'aria-checked': checked
-                },
-                getPTOptions('checkbox')
+                [
+                    {
+                        className: cx('checkbox', { checked, partialChecked, nodeProps: props }),
+                        role: 'checkbox',
+                        'aria-checked': checked
+                    },
+                    getPTOptions('checkbox')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -612,10 +625,13 @@ export const UITreeNode = React.memo((props) => {
 
         if (icon) {
             const nodeIconProps = mergeProps(
-                {
-                    className: classNames(icon, cx('nodeIcon'))
-                },
-                getPTOptions('nodeIcon')
+                [
+                    {
+                        className: classNames(icon, cx('nodeIcon'))
+                    },
+                    getPTOptions('nodeIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...nodeIconProps}></span>;
@@ -627,23 +643,29 @@ export const UITreeNode = React.memo((props) => {
     const createToggler = () => {
         const label = expanded ? ariaLabel('collapseLabel') : ariaLabel('expandLabel');
         const togglerIconProps = mergeProps(
-            {
-                className: cx('togglerIcon'),
-                'aria-hidden': true
-            },
-            getPTOptions('togglerIcon')
+            [
+                {
+                    className: cx('togglerIcon'),
+                    'aria-hidden': true
+                },
+                getPTOptions('togglerIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = expanded ? props.collapseIcon || <ChevronDownIcon {...togglerIconProps} /> : props.expandIcon || <ChevronRightIcon {...togglerIconProps} />;
         const togglerIcon = IconUtils.getJSXIcon(icon, { ...togglerIconProps }, { props, expanded });
         const togglerProps = mergeProps(
-            {
-                type: 'button',
-                className: cx('toggler'),
-                tabIndex: -1,
-                onClick: onTogglerClick,
-                'aria-label': label
-            },
-            getPTOptions('toggler')
+            [
+                {
+                    type: 'button',
+                    className: cx('toggler'),
+                    tabIndex: -1,
+                    onClick: onTogglerClick,
+                    'aria-label': label
+                },
+                getPTOptions('toggler')
+            ],
+            { useTailwind: context.useTailwind }
         );
         let content = (
             <button {...togglerProps}>
@@ -671,14 +693,17 @@ export const UITreeNode = React.memo((props) => {
     const createDropPoint = (position) => {
         if (props.dragdropScope) {
             const droppointProps = mergeProps(
-                {
-                    className: cx('droppoint'),
-                    onDrop: (event) => onDropPoint(event, position),
-                    onDragOver: onDropPointDragOver,
-                    onDragEnter: onDropPointDragEnter,
-                    onDragLeave: onDropPointDragLeave
-                },
-                getPTOptions('droppoint')
+                [
+                    {
+                        className: cx('droppoint'),
+                        onDrop: (event) => onDropPoint(event, position),
+                        onDragOver: onDropPointDragOver,
+                        onDragEnter: onDropPointDragEnter,
+                        onDragLeave: onDropPointDragLeave
+                    },
+                    getPTOptions('droppoint')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <li {...droppointProps}></li>;
@@ -696,24 +721,27 @@ export const UITreeNode = React.memo((props) => {
         const label = createLabel();
 
         const contentProps = mergeProps(
-            {
-                ref: contentRef,
-                className: classNames(props.node.className, cx('content', { checked, selected, nodeProps: props, isCheckboxSelectionMode })),
-                style: props.node.style,
-                onClick: onClick,
-                onDoubleClick: onDoubleClick,
-                onContextMenu: onRightClick,
-                onTouchEnd: onTouchEnd,
-                draggable: props.dragdropScope && props.node.draggable !== false && !props.disabled,
-                onDrop: onDrop,
-                onDragOver: onDragOver,
-                onDragEnter: onDragEnter,
-                onDragLeave: onDragLeave,
-                onDragStart: onDragStart,
-                onDragEnd: onDragEnd,
-                onKeyDown: onNodeKeyDown
-            },
-            getPTOptions('content')
+            [
+                {
+                    ref: contentRef,
+                    className: classNames(props.node.className, cx('content', { checked, selected, nodeProps: props, isCheckboxSelectionMode })),
+                    style: props.node.style,
+                    onClick: onClick,
+                    onDoubleClick: onDoubleClick,
+                    onContextMenu: onRightClick,
+                    onTouchEnd: onTouchEnd,
+                    draggable: props.dragdropScope && props.node.draggable !== false && !props.disabled,
+                    onDrop: onDrop,
+                    onDragOver: onDragOver,
+                    onDragEnter: onDragEnter,
+                    onDragLeave: onDragLeave,
+                    onDragStart: onDragStart,
+                    onDragEnd: onDragEnd,
+                    onKeyDown: onNodeKeyDown
+                },
+                getPTOptions('content')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -728,11 +756,14 @@ export const UITreeNode = React.memo((props) => {
 
     const createChildren = () => {
         const subgroupProps = mergeProps(
-            {
-                className: cx('subgroup'),
-                role: 'group'
-            },
-            getPTOptions('subgroup')
+            [
+                {
+                    className: cx('subgroup'),
+                    role: 'group'
+                },
+                getPTOptions('subgroup')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         if (ObjectUtils.isNotEmpty(props.node.children) && expanded) {
@@ -796,16 +827,19 @@ export const UITreeNode = React.memo((props) => {
         const children = createChildren();
 
         const nodeProps = mergeProps(
-            {
-                className: classNames(props.node.className, cx('node', { isLeaf })),
-                style: props.node.style,
-                tabIndex,
-                role: 'treeitem',
-                'aria-posinset': props.index + 1,
-                'aria-expanded': expanded,
-                'aria-selected': checked || selected
-            },
-            getPTOptions('node')
+            [
+                {
+                    className: classNames(props.node.className, cx('node', { isLeaf })),
+                    style: props.node.style,
+                    tabIndex,
+                    role: 'treeitem',
+                    'aria-posinset': props.index + 1,
+                    'aria-expanded': expanded,
+                    'aria-selected': checked || selected
+                },
+                getPTOptions('node')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -397,27 +397,33 @@ export const TreeSelect = React.memo(
 
         const createKeyboardHelper = () => {
             const hiddenInputWrapperProps = mergeProps(
-                {
-                    className: 'p-hidden-accessible'
-                },
-                ptm('hiddenInputWrapper')
+                [
+                    {
+                        className: 'p-hidden-accessible'
+                    },
+                    ptm('hiddenInputWrapper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const hiddenInputProps = mergeProps(
-                {
-                    ref: focusInputRef,
-                    role: 'listbox',
-                    id: props.inputId,
-                    type: 'text',
-                    'aria-expanded': overlayVisibleState,
-                    onFocus: onInputFocus,
-                    onBlur: onInputBlur,
-                    onKeyDown: onInputKeyDown,
-                    disabled: props.disabled,
-                    tabIndex: props.tabIndex,
-                    ...ariaProps
-                },
-                ptm('hiddenInput')
+                [
+                    {
+                        ref: focusInputRef,
+                        role: 'listbox',
+                        id: props.inputId,
+                        type: 'text',
+                        'aria-expanded': overlayVisibleState,
+                        onFocus: onInputFocus,
+                        onBlur: onInputBlur,
+                        onKeyDown: onInputKeyDown,
+                        disabled: props.disabled,
+                        tabIndex: props.tabIndex,
+                        ...ariaProps
+                    },
+                    ptm('hiddenInput')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -429,30 +435,42 @@ export const TreeSelect = React.memo(
 
         const createLabel = () => {
             const tokenProps = mergeProps(
-                {
-                    className: cx('token')
-                },
-                ptm('token')
+                [
+                    {
+                        className: cx('token')
+                    },
+                    ptm('token')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const tokenLabelProps = mergeProps(
-                {
-                    className: cx('tokenLabel')
-                },
-                ptm('tokenLabel')
+                [
+                    {
+                        className: cx('tokenLabel')
+                    },
+                    ptm('tokenLabel')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const labelContainerProps = mergeProps(
-                {
-                    className: cx('labelContainer')
-                },
-                ptm('labelContainer')
+                [
+                    {
+                        className: cx('labelContainer')
+                    },
+                    ptm('labelContainer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const labelProps = mergeProps(
-                {
-                    className: cx('label', { isValueEmpty, getLabel })
-                },
-                ptm('label')
+                [
+                    {
+                        className: cx('label', { isValueEmpty, getLabel })
+                    },
+                    ptm('label')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             let content = null;
@@ -489,20 +507,26 @@ export const TreeSelect = React.memo(
 
         const createDropdownIcon = () => {
             const triggerProps = mergeProps(
-                {
-                    ref: triggerRef,
-                    className: cx('trigger'),
-                    role: 'button',
-                    'aria-haspopup': 'listbox',
-                    'aria-expanded': overlayVisibleState
-                },
-                ptm('trigger')
+                [
+                    {
+                        ref: triggerRef,
+                        className: cx('trigger'),
+                        role: 'button',
+                        'aria-haspopup': 'listbox',
+                        'aria-expanded': overlayVisibleState
+                    },
+                    ptm('trigger')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const triggerIconProps = mergeProps(
-                {
-                    className: cx('triggerIcon')
-                },
-                ptm('triggerIcon')
+                [
+                    {
+                        className: cx('triggerIcon')
+                    },
+                    ptm('triggerIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const icon = props.dropdownIcon || <ChevronDownIcon {...triggerIconProps} />;
@@ -514,11 +538,14 @@ export const TreeSelect = React.memo(
         const createClearIcon = () => {
             if (props.value != null && props.showClear && !props.disabled) {
                 const clearIconProps = mergeProps(
-                    {
-                        className: cx('clearIcon'),
-                        onPointerUp: clear
-                    },
-                    ptm('clearIcon')
+                    [
+                        {
+                            className: cx('clearIcon'),
+                            onPointerUp: clear
+                        },
+                        ptm('clearIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.clearIcon || <TimesIcon {...clearIconProps} />;
 
@@ -530,10 +557,13 @@ export const TreeSelect = React.memo(
 
         const createContent = () => {
             const emptyMessageProps = mergeProps(
-                {
-                    className: cx('emptyMessage')
-                },
-                ptm('emptyMessage')
+                [
+                    {
+                        className: cx('emptyMessage')
+                    },
+                    ptm('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -573,31 +603,40 @@ export const TreeSelect = React.memo(
             if (props.filter) {
                 const filterValue = ObjectUtils.isNotEmpty(filteredValue) ? filteredValue : '';
                 const filterContainerProps = mergeProps(
-                    {
-                        className: cx('filterContainer')
-                    },
-                    ptm('filterContainer')
+                    [
+                        {
+                            className: cx('filterContainer')
+                        },
+                        ptm('filterContainer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const filterProps = mergeProps(
-                    {
-                        ref: filterInputRef,
-                        type: 'text',
-                        value: filterValue,
-                        autoComplete: 'off',
-                        className: cx('filter'),
-                        placeholder: props.filterPlaceholder,
-                        onKeyDown: onFilterInputKeyDown,
-                        onChange: onFilterInputChange,
-                        disabled: props.disabled
-                    },
-                    ptm('filter')
+                    [
+                        {
+                            ref: filterInputRef,
+                            type: 'text',
+                            value: filterValue,
+                            autoComplete: 'off',
+                            className: cx('filter'),
+                            placeholder: props.filterPlaceholder,
+                            onKeyDown: onFilterInputKeyDown,
+                            onChange: onFilterInputChange,
+                            disabled: props.disabled
+                        },
+                        ptm('filter')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 const filterIconProps = mergeProps(
-                    {
-                        className: cx('filterIcon')
-                    },
-                    ptm('filterIcon')
+                    [
+                        {
+                            className: cx('filterIcon')
+                        },
+                        ptm('filterIcon')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
                 const icon = props.filterIcon || <SearchIcon {...filterIconProps} />;
                 const filterIcon = IconUtils.getJSXIcon(icon, { ...filterIconProps }, { props });
@@ -630,30 +669,39 @@ export const TreeSelect = React.memo(
         const createHeader = () => {
             const filterElement = createFilterElement();
             const closeIconProps = mergeProps(
-                {
-                    className: cx('closeIcon'),
-                    'aria-hidden': true
-                },
-                ptm('closeIcon')
+                [
+                    {
+                        className: cx('closeIcon'),
+                        'aria-hidden': true
+                    },
+                    ptm('closeIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.closeIcon || <TimesIcon {...closeIconProps} />;
             const closeIcon = IconUtils.getJSXIcon(icon, { ...closeIconProps }, { props });
 
             const closeButtonProps = mergeProps(
-                {
-                    type: 'button',
-                    className: cx('closeButton'),
-                    onClick: hide,
-                    'aria-label': localeOption('close')
-                },
-                ptm('closeButton')
+                [
+                    {
+                        type: 'button',
+                        className: cx('closeButton'),
+                        onClick: hide,
+                        'aria-label': localeOption('close')
+                    },
+                    ptm('closeButton')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const headerProps = mergeProps(
-                {
-                    className: cx('header')
-                },
-                ptm('header')
+                [
+                    {
+                        className: cx('header')
+                    },
+                    ptm('header')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const closeElement = (
@@ -696,14 +744,17 @@ export const TreeSelect = React.memo(
         const otherProps = TreeSelectBase.getOtherProps(props);
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const rootProps = mergeProps(
-            {
-                ref: elementRef,
-                className: cx('root', { focusedState, overlayVisibleState, isValueEmpty }),
-                style: props.style,
-                onClick: onClick
-            },
-            TreeSelectBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    ref: elementRef,
+                    className: cx('root', { focusedState, overlayVisibleState, isValueEmpty }),
+                    style: props.style,
+                    onClick: onClick
+                },
+                TreeSelectBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const keyboardHelper = createKeyboardHelper();

--- a/components/lib/treeselect/TreeSelectPanel.js
+++ b/components/lib/treeselect/TreeSelectPanel.js
@@ -19,35 +19,44 @@ export const TreeSelectPanel = React.forwardRef((props, ref) => {
         const wrapperStyle = { maxHeight: props.scrollHeight || 'auto' };
 
         const panelProps = mergeProps(
-            {
-                className: cx('panel', { panelProps: props, context }),
-                style: props.panelStyle,
-                onClick: props.onClick
-            },
-            getPTOptions('panel')
+            [
+                {
+                    className: cx('panel', { panelProps: props, context }),
+                    style: props.panelStyle,
+                    onClick: props.onClick
+                },
+                getPTOptions('panel')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const wrapperProps = mergeProps(
-            {
-                className: cx('wrapper'),
-                style: wrapperStyle
-            },
-            getPTOptions('wrapper')
+            [
+                {
+                    className: cx('wrapper'),
+                    style: wrapperStyle
+                },
+                getPTOptions('wrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const transitionProps = mergeProps(
-            {
-                classNames: cx('transition'),
-                in: props.in,
-                timeout: { enter: 120, exit: 100 },
-                options: props.transitionOptions,
-                unmountOnExit: true,
-                onEnter: props.onEnter,
-                onEntered: props.onEntered,
-                onExit: props.onExit,
-                onExited: props.onExited
-            },
-            getPTOptions('transition')
+            [
+                {
+                    classNames: cx('transition'),
+                    in: props.in,
+                    timeout: { enter: 120, exit: 100 },
+                    options: props.transitionOptions,
+                    unmountOnExit: true,
+                    onEnter: props.onEnter,
+                    onEntered: props.onEntered,
+                    onExit: props.onExit,
+                    onExited: props.onExited
+                },
+                getPTOptions('transition')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -996,10 +996,13 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
         scrollableView = createScrollableView(value, scrollableColumns, false, props.headerColumnGroup, props.footerColumnGroup);
         const scrollableWrapperProps = mergeProps(
-            {
-                className: ptCallbacks.cx('scrollableWrapper')
-            },
-            ptCallbacks.ptm('scrollableWrapper')
+            [
+                {
+                    className: ptCallbacks.cx('scrollableWrapper')
+                },
+                ptCallbacks.ptm('scrollableWrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -1017,18 +1020,24 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         const body = createTableBody(value, columns);
 
         const wrapperProps = mergeProps(
-            {
-                className: ptCallbacks.cx('wrapper')
-            },
-            ptCallbacks.ptm('wrapper')
+            [
+                {
+                    className: ptCallbacks.cx('wrapper')
+                },
+                ptCallbacks.ptm('wrapper')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const tableProps = mergeProps(
-            {
-                style: props.tableStyle,
-                className: classNames(props.tableClassName, ptCallbacks.cx('table'))
-            },
-            ptCallbacks.ptm('table')
+            [
+                {
+                    style: props.tableStyle,
+                    className: classNames(props.tableClassName, ptCallbacks.cx('table'))
+                },
+                ptCallbacks.ptm('table')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (
@@ -1049,25 +1058,34 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     const createLoader = () => {
         if (props.loading) {
             const loadingIconProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('loadingIcon')
-                },
-                ptCallbacks.ptm('loadingIcon')
+                [
+                    {
+                        className: ptCallbacks.cx('loadingIcon')
+                    },
+                    ptCallbacks.ptm('loadingIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
             const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
             const loadingWrapperProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('loadingWrapper')
-                },
-                ptCallbacks.ptm('loadingWrapper')
+                [
+                    {
+                        className: ptCallbacks.cx('loadingWrapper')
+                    },
+                    ptCallbacks.ptm('loadingWrapper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const loadingOverlayProps = mergeProps(
-                {
-                    className: ptCallbacks.cx('loadingOverlay')
-                },
-                ptCallbacks.ptm('loadingOverlay')
+                [
+                    {
+                        className: ptCallbacks.cx('loadingOverlay')
+                    },
+                    ptCallbacks.ptm('loadingOverlay')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -1085,23 +1103,32 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     const table = createTable(data);
     const totalRecords = getTotalRecords(data);
     const headerProps = mergeProps(
-        {
-            className: ptCallbacks.cx('header')
-        },
-        ptCallbacks.ptm('header')
+        [
+            {
+                className: ptCallbacks.cx('header')
+            },
+            ptCallbacks.ptm('header')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const footerProps = mergeProps(
-        {
-            className: ptCallbacks.cx('footer')
-        },
-        ptCallbacks.ptm('footer')
+        [
+            {
+                className: ptCallbacks.cx('footer')
+            },
+            ptCallbacks.ptm('footer')
+        ],
+        { useTailwind: context.useTailwind }
     );
     const resizeHelperProps = mergeProps(
-        {
-            className: ptCallbacks.cx('resizeHelper'),
-            style: { display: 'none' }
-        },
-        ptCallbacks.ptm('resizeHelper')
+        [
+            {
+                className: ptCallbacks.cx('resizeHelper'),
+                style: { display: 'none' }
+            },
+            ptCallbacks.ptm('resizeHelper')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const headerFacet = props.header && <div {...headerProps}>{props.header}</div>;
@@ -1111,13 +1138,16 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     const loader = createLoader();
     const resizeHelper = props.resizableColumns && <div ref={resizerHelperRef} {...resizeHelperProps}></div>;
     const reorderIndicatorUpProps = mergeProps(
-        {
-            className: ptCallbacks.cx('reorderIndicatorUp'),
-            style: { position: 'absolute', display: 'none' }
-        },
-        ptCallbacks.ptm('reorderIndicatorUp')
+        [
+            {
+                className: ptCallbacks.cx('reorderIndicatorUp'),
+                style: { position: 'absolute', display: 'none' }
+            },
+            ptCallbacks.ptm('reorderIndicatorUp')
+        ],
+        { useTailwind: context.useTailwind }
     );
-    const reorderIndicatorUpIconProps = mergeProps(ptCallbacks.ptm('reorderIndicatorUpIcon'));
+    const reorderIndicatorUpIconProps = mergeProps([ptCallbacks.ptm('reorderIndicatorUpIcon')], { useTailwind: context.useTailwind });
     const reorderIndicatorUpIcon = props.reorderableColumns && IconUtils.getJSXIcon(props.reorderIndicatorUpIcon || <ArrowDownIcon {...reorderIndicatorUpIconProps} />, { ...reorderIndicatorUpIconProps }, { props });
     const reorderIndicatorUp = props.reorderableColumns && (
         <span ref={reorderIndicatorUpRef} {...reorderIndicatorUpProps}>
@@ -1125,7 +1155,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         </span>
     );
     const reorderIndicatorDownProps = { className: ptCallbacks.sx('reorderIndicatorDown'), style: { position: 'absolute', display: 'none' } };
-    const reorderIndicatorDownIconProps = mergeProps(ptCallbacks.ptm('reorderIndicatorDownIcon'));
+    const reorderIndicatorDownIconProps = mergeProps([ptCallbacks.ptm('reorderIndicatorDownIcon')], { useTailwind: context.useTailwind });
     const reorderIndicatorDownIcon = IconUtils.getJSXIcon(props.reorderIndicatorDownIcon || <ArrowUpIcon {...reorderIndicatorDownIconProps} />, { ...reorderIndicatorDownIconProps }, { props });
     const reorderIndicatorDown = props.reorderableColumns && (
         <span ref={reorderIndicatorDownRef} {...reorderIndicatorDownProps}>
@@ -1134,14 +1164,17 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
     );
 
     const rootProps = mergeProps(
-        {
-            id: props.id,
-            className: classNames(props.className, ptCallbacks.cx('root', { isRowSelectionMode })),
-            style: props.style,
-            'data-scrollselectors': '.p-treetable-wrapper'
-        },
-        ObjectUtils.findDiffKeys(props, TreeTable.defaultProps),
-        ptCallbacks.ptm('root')
+        [
+            {
+                id: props.id,
+                className: classNames(props.className, ptCallbacks.cx('root', { isRowSelectionMode })),
+                style: props.style,
+                'data-scrollselectors': '.p-treetable-wrapper'
+            },
+            ObjectUtils.findDiffKeys(props, TreeTable.defaultProps),
+            ptCallbacks.ptm('root')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/treetable/TreeTableBody.js
+++ b/components/lib/treetable/TreeTableBody.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { localeOption } from '../api/Api';
+import { localeOption, PrimeReactContext } from '../api/Api';
 import { DomHandler, mergeProps } from '../utils/Utils';
 import { TreeTableRow } from './TreeTableRow';
 
@@ -7,6 +7,7 @@ export const TreeTableBody = React.memo((props) => {
     const isSingleSelectionMode = props.selectionMode === 'single';
     const isMultipleSelectionMode = props.selectionMode === 'multiple';
     const { ptm, cx } = props.ptCallbacks;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -232,16 +233,22 @@ export const TreeTableBody = React.memo((props) => {
             const colSpan = props.columns ? props.columns.length : null;
             const content = props.emptyMessage || localeOption('emptyMessage');
             const emptyMessageProps = mergeProps(
-                {
-                    className: cx('emptyMessage')
-                },
-                getPTOptions('emptyMessage')
+                [
+                    {
+                        className: cx('emptyMessage')
+                    },
+                    getPTOptions('emptyMessage')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const emptyMessageCellProps = mergeProps(
-                {
-                    colSpan
-                },
-                getPTOptions('emptyMessageCell')
+                [
+                    {
+                        colSpan
+                    },
+                    getPTOptions('emptyMessageCell')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -254,10 +261,13 @@ export const TreeTableBody = React.memo((props) => {
 
     const content = props.value && props.value.length ? createRows() : createEmptyMessage();
     const tbodyProps = mergeProps(
-        {
-            className: cx('tbody')
-        },
-        getPTOptions('tbody')
+        [
+            {
+                className: cx('tbody')
+            },
+            getPTOptions('tbody')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <tbody {...tbodyProps}>{content}</tbody>;

--- a/components/lib/treetable/TreeTableBodyCell.js
+++ b/components/lib/treetable/TreeTableBodyCell.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
 import { useEventListener, useUnmountEffect } from '../hooks/Hooks';
 import { OverlayService } from '../overlayservice/OverlayService';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, ObjectUtils, classNames, mergeProps } from '../utils/Utils';
 
 export const TreeTableBodyCell = (props) => {
@@ -13,6 +14,7 @@ export const TreeTableBodyCell = (props) => {
     const tabIndexTimeout = React.useRef(null);
     const getColumnProp = (name) => ColumnBase.getCProp(props.column, name);
     const getColumnProps = (column) => ColumnBase.getCProps(column);
+    const context = React.useContext(PrimeReactContext);
     const { ptm, ptmo, cx } = props.ptCallbacks;
 
     const getColumnPTOptions = (key) => {
@@ -36,7 +38,7 @@ export const TreeTableBodyCell = (props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const field = getColumnProp('field') || `field_${props.index}`;
@@ -210,16 +212,19 @@ export const TreeTableBodyCell = (props) => {
     }
 
     const editorKeyHelperProps = mergeProps(
-        {
-            tabIndex: 0,
-            ref: keyHelperRef,
-            className: 'p-cell-editor-key-helper p-hidden-accessible',
-            onFocus: (e) => onEditorFocus(e)
-        },
-        getColumnPTOptions('editorKeyHelperLabel')
+        [
+            {
+                tabIndex: 0,
+                ref: keyHelperRef,
+                className: 'p-cell-editor-key-helper p-hidden-accessible',
+                onFocus: (e) => onEditorFocus(e)
+            },
+            getColumnPTOptions('editorKeyHelperLabel')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
-    const editorKeyHelperLabelProps = mergeProps(getColumnPTOptions('editorKeyHelper'));
+    const editorKeyHelperLabelProps = mergeProps([getColumnPTOptions('editorKeyHelper')], { useTailwind: context.useTailwind });
     /* eslint-disable */
     const editorKeyHelper = props.editor && (
         <a {...editorKeyHelperProps}>
@@ -228,14 +233,17 @@ export const TreeTableBodyCell = (props) => {
     );
     /* eslint-enable */
     const bodyCellProps = mergeProps(
-        {
-            className: classNames(bodyClassName || props.className, cx('bodyCell', { bodyProps: props, editingState })),
-            style,
-            onClick: (e) => onClick(e),
-            onKeyDown: (e) => onKeyDown(e)
-        },
-        getColumnPTOptions('root'),
-        getColumnPTOptions('bodyCell')
+        [
+            {
+                className: classNames(bodyClassName || props.className, cx('bodyCell', { bodyProps: props, editingState })),
+                style,
+                onClick: (e) => onClick(e),
+                onKeyDown: (e) => onKeyDown(e)
+            },
+            getColumnPTOptions('root'),
+            getColumnPTOptions('bodyCell')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/treetable/TreeTableFooter.js
+++ b/components/lib/treetable/TreeTableFooter.js
@@ -2,10 +2,12 @@ import * as React from 'react';
 import { ColumnBase } from '../column/ColumnBase';
 import { ColumnGroupBase } from '../columngroup/ColumnGroupBase';
 import { RowBase } from '../row/RowBase';
+import { PrimeReactContext } from '../api/Api';
 import { mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const TreeTableFooter = React.memo((props) => {
     const { ptm, ptmo, cx } = props.ptCallbacks;
+    const context = React.useContext(PrimeReactContext);
 
     const getColumnProp = (column, name) => {
         return ColumnBase.getCProp(column, name);
@@ -23,19 +25,22 @@ export const TreeTableFooter = React.memo((props) => {
             hostName: props.hostName
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const createFooterCell = (column, index) => {
         const footerCellProps = mergeProps(
-            {
-                key: column.field || index,
-                className: getColumnProp(column, 'footerClassName') || getColumnProp(column, 'className'),
-                style: getColumnProp(column, 'footerStyle') || getColumnProp(column, 'style'),
-                rowSpan: getColumnProp(column, 'rowSpan'),
-                colSpan: getColumnProp(column, 'colSpan')
-            },
-            getColumnPTOptions(column, 'footerCell')
+            [
+                {
+                    key: column.field || index,
+                    className: getColumnProp(column, 'footerClassName') || getColumnProp(column, 'className'),
+                    style: getColumnProp(column, 'footerStyle') || getColumnProp(column, 'style'),
+                    rowSpan: getColumnProp(column, 'rowSpan'),
+                    colSpan: getColumnProp(column, 'colSpan')
+                },
+                getColumnPTOptions(column, 'footerCell')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const content = ObjectUtils.getJSXElement(getColumnProp(column, 'footer'), { props: getColumnProps(column) });
@@ -46,7 +51,7 @@ export const TreeTableFooter = React.memo((props) => {
     const createFooterRow = (row, index) => {
         const rowColumns = React.Children.toArray(RowBase.getCProp(row, 'children'));
         const rowFooterCells = rowColumns.map(createFooterCell);
-        const footerRowProps = mergeProps(ptm('footerRow', { hostName: props.hostName }));
+        const footerRowProps = mergeProps([ptm('footerRow', { hostName: props.hostName })], { useTailwind: context.useTailwind });
 
         return (
             <tr {...footerRowProps} key={index}>
@@ -64,7 +69,7 @@ export const TreeTableFooter = React.memo((props) => {
     const createColumns = (columns) => {
         if (columns) {
             const headerCells = columns.map(createFooterCell);
-            const footerRowProps = mergeProps(ptm('footerRow', { hostName: props.hostName }));
+            const footerRowProps = mergeProps([ptm('footerRow', { hostName: props.hostName })], { useTailwind: context.useTailwind });
 
             return <tr {...footerRowProps}>{headerCells}</tr>;
         } else {
@@ -80,10 +85,13 @@ export const TreeTableFooter = React.memo((props) => {
 
     if (hasFooter()) {
         const tfootProps = mergeProps(
-            {
-                className: cx('tfoot')
-            },
-            ptm('tfoot', { hostName: props.hostName })
+            [
+                {
+                    className: cx('tfoot')
+                },
+                ptm('tfoot', { hostName: props.hostName })
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <tfoot {...tfootProps}>{content}</tfoot>;

--- a/components/lib/treetable/TreeTableHeader.js
+++ b/components/lib/treetable/TreeTableHeader.js
@@ -7,11 +7,13 @@ import { SortAmountUpAltIcon } from '../icons/sortamountupalt';
 import { InputText } from '../inputtext/InputText';
 import { RowBase } from '../row/RowBase';
 import { Tooltip } from '../tooltip/Tooltip';
+import { PrimeReactContext } from '../api/Api';
 import { classNames, DomHandler, IconUtils, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const TreeTableHeader = React.memo((props) => {
     const { ptm, ptmo, cx } = props.ptCallbacks;
     const filterTimeout = React.useRef(null);
+    const context = React.useContext(PrimeReactContext);
 
     const getColumnProp = (column, ...args) => {
         return column ? (typeof args[0] === 'string' ? ColumnBase.getCProp(column, args[0]) : ColumnBase.getCProp(args[0] || column, args[1])) : null;
@@ -28,7 +30,7 @@ export const TreeTableHeader = React.memo((props) => {
             ...params
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const onHeaderClick = (event, column) => {
@@ -169,14 +171,17 @@ export const TreeTableHeader = React.memo((props) => {
     const createSortIcon = (column, sorted, sortOrder) => {
         if (getColumnProp(column, 'sortable')) {
             const sortIconProps = mergeProps(
-                {
-                    className: cx('sortIcon')
-                },
-                getColumnPTOptions(column, 'sortIcon', {
-                    context: {
-                        sorted
-                    }
-                })
+                [
+                    {
+                        className: cx('sortIcon')
+                    },
+                    getColumnPTOptions(column, 'sortIcon', {
+                        context: {
+                            sorted
+                        }
+                    })
+                ],
+                { useTailwind: context.useTailwind }
             );
             let icon = sorted ? sortOrder < 0 ? <SortAmountDownIcon {...sortIconProps} /> : <SortAmountUpAltIcon {...sortIconProps} /> : <SortAltIcon {...sortIconProps} />;
             let sortIcon = IconUtils.getJSXIcon(props.sortIcon || icon, { ...sortIconProps }, { props, sorted, sortOrder });
@@ -190,11 +195,14 @@ export const TreeTableHeader = React.memo((props) => {
     const createResizer = (column) => {
         if (props.resizableColumns) {
             const columnResizerProps = mergeProps(
-                {
-                    className: cx('columnResizer'),
-                    onMouseDown: (e) => onResizerMouseDown(e, column)
-                },
-                getColumnPTOptions(column, 'columnResizer')
+                [
+                    {
+                        className: cx('columnResizer'),
+                        onMouseDown: (e) => onResizerMouseDown(e, column)
+                    },
+                    getColumnPTOptions(column, 'columnResizer')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...columnResizerProps} />;
@@ -206,10 +214,13 @@ export const TreeTableHeader = React.memo((props) => {
     const createSortBadge = (column, sortMetaDataIndex) => {
         if (sortMetaDataIndex !== -1 && props.multiSortMeta && props.multiSortMeta.length > 1) {
             const sortBadgeProps = mergeProps(
-                {
-                    className: cx('sortBadge')
-                },
-                getColumnPTOptions(column, 'sortBadge')
+                [
+                    {
+                        className: cx('sortBadge')
+                    },
+                    getColumnPTOptions(column, 'sortBadge')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <span {...sortBadgeProps}>{sortMetaDataIndex + 1}</span>;
@@ -221,10 +232,13 @@ export const TreeTableHeader = React.memo((props) => {
     const createTitle = (column, options) => {
         const title = ObjectUtils.getJSXElement(getColumnProp(column, 'header'), { props: options });
         const headerTitleProps = mergeProps(
-            {
-                className: cx('headerTitle')
-            },
-            getColumnPTOptions(column, 'headerTitle')
+            [
+                {
+                    className: cx('headerTitle')
+                },
+                getColumnPTOptions(column, 'headerTitle')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return <span {...headerTitleProps}>{title}</span>;
@@ -251,22 +265,25 @@ export const TreeTableHeader = React.memo((props) => {
 
         if (options.filterOnly) {
             const headerCellProps = mergeProps(
-                {
-                    key: getColumnProp(column, 'columnKey') || getColumnProp(column, 'field') || options.index,
-                    className: classNames(cx('headerCell', { options }), getColumnProp(column, 'filterHeaderClassName')),
-                    style: getColumnProp(column, 'filterHeaderStyle') || getColumnProp(column, 'style'),
-                    rowSpan: getColumnProp(column, 'rowSpan'),
-                    colSpan: getColumnProp(column, 'colSpan'),
-                    'data-p-sortable-column': getColumnProp(column, 'sortable'),
-                    'data-p-resizable-column': props.resizableColumns,
-                    'data-p-frozen-column': getColumnProp(column, 'frozen')
-                },
-                getColumnPTOptions(column, 'root'),
-                getColumnPTOptions(column, 'headerCell', {
-                    context: {
-                        frozen: getColumnProp(column, 'frozen')
-                    }
-                })
+                [
+                    {
+                        key: getColumnProp(column, 'columnKey') || getColumnProp(column, 'field') || options.index,
+                        className: classNames(cx('headerCell', { options }), getColumnProp(column, 'filterHeaderClassName')),
+                        style: getColumnProp(column, 'filterHeaderStyle') || getColumnProp(column, 'style'),
+                        rowSpan: getColumnProp(column, 'rowSpan'),
+                        colSpan: getColumnProp(column, 'colSpan'),
+                        'data-p-sortable-column': getColumnProp(column, 'sortable'),
+                        'data-p-resizable-column': props.resizableColumns,
+                        'data-p-frozen-column': getColumnProp(column, 'frozen')
+                    },
+                    getColumnPTOptions(column, 'root'),
+                    getColumnPTOptions(column, 'headerCell', {
+                        context: {
+                            frozen: getColumnProp(column, 'frozen')
+                        }
+                    })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <th {...headerCellProps}>{filterElement}</th>;
@@ -292,33 +309,36 @@ export const TreeTableHeader = React.memo((props) => {
             const title = createTitle(column, options);
             const resizer = createResizer(column);
             const headerCellProps = mergeProps(
-                {
-                    className: classNames(getColumnProp(column, 'headerClassName') || getColumnProp(column, 'className'), cx('headerCell', { headerProps: props, column, options, getColumnProp, sorted, frozen })),
-                    style: getColumnProp(column, 'headerStyle') || getColumnProp(column, 'style'),
-                    tabIndex: getColumnProp(column, 'sortable') ? props.tabIndex : null,
-                    onClick: (e) => onHeaderClick(e, column),
-                    onMouseDown: (e) => onHeaderMouseDown(e, column),
-                    onKeyDown: (e) => onHeaderKeyDown(e, column),
-                    rowSpan: getColumnProp(column, 'rowSpan'),
-                    colSpan: getColumnProp(column, 'colSpan'),
-                    'aria-sort': ariaSortData,
-                    onDragStart: (e) => onDragStart(e, column),
-                    onDragOver: (e) => onDragOver(e, column),
-                    onDragLeave: (e) => onDragLeave(e, column),
-                    onDrop: (e) => onDrop(e, column),
-                    'data-p-sortable-column': getColumnProp(column, 'sortable'),
-                    'data-p-resizable-column': props.resizableColumns,
-                    'data-p-highlight': sorted,
-                    'data-p-frozen-column': getColumnProp(column, 'frozen')
-                },
-                getColumnPTOptions(column, 'root'),
-                getColumnPTOptions(column, 'headerCell', {
-                    context: {
-                        sorted,
-                        frozen,
-                        resizable: props.resizableColumns
-                    }
-                })
+                [
+                    {
+                        className: classNames(getColumnProp(column, 'headerClassName') || getColumnProp(column, 'className'), cx('headerCell', { headerProps: props, column, options, getColumnProp, sorted, frozen })),
+                        style: getColumnProp(column, 'headerStyle') || getColumnProp(column, 'style'),
+                        tabIndex: getColumnProp(column, 'sortable') ? props.tabIndex : null,
+                        onClick: (e) => onHeaderClick(e, column),
+                        onMouseDown: (e) => onHeaderMouseDown(e, column),
+                        onKeyDown: (e) => onHeaderKeyDown(e, column),
+                        rowSpan: getColumnProp(column, 'rowSpan'),
+                        colSpan: getColumnProp(column, 'colSpan'),
+                        'aria-sort': ariaSortData,
+                        onDragStart: (e) => onDragStart(e, column),
+                        onDragOver: (e) => onDragOver(e, column),
+                        onDragLeave: (e) => onDragLeave(e, column),
+                        onDrop: (e) => onDrop(e, column),
+                        'data-p-sortable-column': getColumnProp(column, 'sortable'),
+                        'data-p-resizable-column': props.resizableColumns,
+                        'data-p-highlight': sorted,
+                        'data-p-frozen-column': getColumnProp(column, 'frozen')
+                    },
+                    getColumnPTOptions(column, 'root'),
+                    getColumnPTOptions(column, 'headerCell', {
+                        context: {
+                            sorted,
+                            frozen,
+                            resizable: props.resizableColumns
+                        }
+                    })
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -339,7 +359,7 @@ export const TreeTableHeader = React.memo((props) => {
     const createHeaderRow = (row, index) => {
         const rowColumns = React.Children.toArray(RowBase.getCProp(row, 'children'));
         const rowHeaderCells = rowColumns.map((col, i) => createHeaderCell(col, { index: i, filterOnly: false, renderFilter: true }));
-        const headerRowProps = mergeProps(ptm('headerRow', { hostName: props.hostName }));
+        const headerRowProps = mergeProps([ptm('headerRow', { hostName: props.hostName })], { useTailwind: context.useTailwind });
 
         return (
             <tr {...headerRowProps} key={index}>
@@ -356,7 +376,7 @@ export const TreeTableHeader = React.memo((props) => {
 
     const createColumns = (columns) => {
         if (columns) {
-            const headerRowProps = mergeProps(ptm('headerRow', { hostName: props.hostName }));
+            const headerRowProps = mergeProps([ptm('headerRow', { hostName: props.hostName })], { useTailwind: context.useTailwind });
 
             if (hasColumnFilter(columns)) {
                 return (
@@ -375,10 +395,13 @@ export const TreeTableHeader = React.memo((props) => {
 
     const content = props.columnGroup ? createColumnGroup() : createColumns(props.columns);
     const theadProps = mergeProps(
-        {
-            className: cx('thead')
-        },
-        ptm('thead', { hostName: props.hostName })
+        [
+            {
+                className: cx('thead')
+            },
+            ptm('thead', { hostName: props.hostName })
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return <thead {...theadProps}>{content}</thead>;

--- a/components/lib/treetable/TreeTableRow.js
+++ b/components/lib/treetable/TreeTableRow.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ariaLabel } from '../api/Api';
+import { ariaLabel, PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { CheckIcon } from '../icons/check';
 import { ChevronDownIcon } from '../icons/chevrondown';
@@ -15,6 +15,7 @@ export const TreeTableRow = React.memo((props) => {
     const checkboxBoxRef = React.useRef(null);
     const nodeTouched = React.useRef(false);
     const expanded = props.expandedKeys ? props.expandedKeys[props.node.key] !== undefined : false;
+    const context = React.useContext(PrimeReactContext);
 
     const getColumnProp = (column, name) => {
         return ColumnBase.getCProp(column, name);
@@ -38,7 +39,7 @@ export const TreeTableRow = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const getColumnCheckboxPTOptions = (column, key) => {
@@ -54,7 +55,7 @@ export const TreeTableRow = React.memo((props) => {
             }
         };
 
-        return mergeProps(ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata));
+        return mergeProps([ptm(`column.${key}`, { column: columnMetadata }), ptm(`column.${key}`, columnMetadata), ptmo(cProps, key, columnMetadata)], { useTailwind: context.useTailwind });
     };
 
     const getRowPTOptions = (key) => {
@@ -347,24 +348,30 @@ export const TreeTableRow = React.memo((props) => {
     const createToggler = (column) => {
         const label = expanded ? ariaLabel('collapseLabel') : ariaLabel('expandLabel');
         const rowTogglerIconProps = mergeProps(
-            {
-                className: cx('rowTogglerIcon'),
-                'aria-hidden': true
-            },
-            getColumnPTOptions(column, 'rowTogglerIcon')
+            [
+                {
+                    className: cx('rowTogglerIcon'),
+                    'aria-hidden': true
+                },
+                getColumnPTOptions(column, 'rowTogglerIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const icon = expanded ? <ChevronDownIcon {...rowTogglerIconProps} /> : <ChevronRightIcon {...rowTogglerIconProps} />;
         const togglerIcon = IconUtils.getJSXIcon(props.togglerIcon || icon, { ...rowTogglerIconProps }, { props });
         const rowTogglerProps = mergeProps(
-            {
-                type: 'button',
-                className: cx('rowToggler'),
-                onClick: (e) => onTogglerClick(e),
-                tabIndex: -1,
-                style: { marginLeft: props.level * 16 + 'px', visibility: props.node.leaf === false || (props.node.children && props.node.children.length) ? 'visible' : 'hidden' },
-                'aria-label': label
-            },
-            getColumnPTOptions(column, 'rowToggler')
+            [
+                {
+                    type: 'button',
+                    className: cx('rowToggler'),
+                    onClick: (e) => onTogglerClick(e),
+                    tabIndex: -1,
+                    style: { marginLeft: props.level * 16 + 'px', visibility: props.node.leaf === false || (props.node.children && props.node.children.length) ? 'visible' : 'hidden' },
+                    'aria-label': label
+                },
+                getColumnPTOptions(column, 'rowToggler')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let content = (
@@ -396,43 +403,58 @@ export const TreeTableRow = React.memo((props) => {
             const checked = isChecked();
             const partialChecked = isPartialChecked();
             const checboxIconProps = mergeProps(
-                {
-                    className: cx('checkboxIcon')
-                },
-                getColumnCheckboxPTOptions(column, 'checkboxIcon')
+                [
+                    {
+                        className: cx('checkboxIcon')
+                    },
+                    getColumnCheckboxPTOptions(column, 'checkboxIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = checked ? props.checkboxIcon || <CheckIcon {...checboxIconProps} /> : partialChecked ? props.checkboxIcon || <MinusIcon {...checboxIconProps} /> : null;
             const checkIcon = IconUtils.getJSXIcon(icon, { ...checboxIconProps }, { props, checked, partialChecked });
             const hiddenInputProps = mergeProps(
-                {
-                    type: 'checkbox',
-                    onFocus: (e) => onCheckboxFocus(e),
-                    onBlur: (e) => onCheckboxBlur(e)
-                },
-                getColumnCheckboxPTOptions(column, 'hiddenInput')
+                [
+                    {
+                        type: 'checkbox',
+                        onFocus: (e) => onCheckboxFocus(e),
+                        onBlur: (e) => onCheckboxBlur(e)
+                    },
+                    getColumnCheckboxPTOptions(column, 'hiddenInput')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const checkboxWrapperProps = mergeProps(
-                {
-                    className: cx('checkboxWrapper'),
-                    onClick: (e) => onCheckboxChange(e),
-                    role: 'checkbox',
-                    'aria-checked': checked
-                },
-                getColumnCheckboxPTOptions(column, 'checkboxWrapper')
+                [
+                    {
+                        className: cx('checkboxWrapper'),
+                        onClick: (e) => onCheckboxChange(e),
+                        role: 'checkbox',
+                        'aria-checked': checked
+                    },
+                    getColumnCheckboxPTOptions(column, 'checkboxWrapper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const hiddenInputWrapperProps = mergeProps(
-                {
-                    className: 'p-hidden-accessible'
-                },
-                getColumnCheckboxPTOptions(column, 'hiddenInputWrapper')
+                [
+                    {
+                        className: 'p-hidden-accessible'
+                    },
+                    getColumnCheckboxPTOptions(column, 'hiddenInputWrapper')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             const checkboxProps = mergeProps(
-                {
-                    className: cx('checkbox', { checked, partialChecked })
-                },
-                getColumnCheckboxPTOptions(column, 'checkbox')
+                [
+                    {
+                        className: cx('checkbox', { checked, partialChecked })
+                    },
+                    getColumnCheckboxPTOptions(column, 'checkbox')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (
@@ -536,19 +558,22 @@ export const TreeTableRow = React.memo((props) => {
 
     className = classNames(className, props.node.className);
     const rowProps = mergeProps(
-        {
-            tabIndex: 0,
-            className,
-            style: props.node.style,
-            onClick: (e) => onClick(e),
-            onTouchEnd: (e) => onTouchEnd(e),
-            onContextMenu: (e) => onRightClick(e),
-            onKeyDown: (e) => onKeyDown(e),
-            onMouseEnter: (e) => onMouseEnter(e),
-            onMouseLeave: (e) => onMouseLeave(e),
-            'data-p-highlight': isSelected()
-        },
-        getRowPTOptions('row')
+        [
+            {
+                tabIndex: 0,
+                className,
+                style: props.node.style,
+                onClick: (e) => onClick(e),
+                onTouchEnd: (e) => onTouchEnd(e),
+                onContextMenu: (e) => onRightClick(e),
+                onKeyDown: (e) => onKeyDown(e),
+                onMouseEnter: (e) => onMouseEnter(e),
+                onMouseLeave: (e) => onMouseLeave(e),
+                'data-p-highlight': isSelected()
+            },
+            getRowPTOptions('row')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/treetable/TreeTableScrollableView.js
+++ b/components/lib/treetable/TreeTableScrollableView.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useMountEffect } from '../hooks/Hooks';
+import { PrimeReactContext } from '../api/Api';
 import { DomHandler, mergeProps, ObjectUtils } from '../utils/Utils';
 
 export const TreeTableScrollableView = React.memo((props) => {
@@ -11,6 +12,7 @@ export const TreeTableScrollableView = React.memo((props) => {
     const scrollFooterRef = React.useRef(null);
     const scrollFooterBoxRef = React.useRef(null);
     const { ptm, cx, sx } = props.ptCallbacks;
+    const context = React.useContext(PrimeReactContext);
 
     const getPTOptions = (key, options) => {
         return ptm(key, {
@@ -99,10 +101,13 @@ export const TreeTableScrollableView = React.memo((props) => {
         if (ObjectUtils.isNotEmpty(props.columns)) {
             const cols = props.columns.map((col, i) => <col key={col.field + '_' + i} />);
             const scrollableColgroupProps = mergeProps(
-                {
-                    className: cx('scrollableColgroup')
-                },
-                getPTOptions('scrollableColgroup')
+                [
+                    {
+                        className: cx('scrollableColgroup')
+                    },
+                    getPTOptions('scrollableColgroup')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return <colgroup {...scrollableColgroupProps}>{cols}</colgroup>;
@@ -115,71 +120,98 @@ export const TreeTableScrollableView = React.memo((props) => {
     const left = props.frozen ? null : props.frozenWidth;
     const colGroup = createColGroup();
     const scrollableProps = mergeProps(
-        {
-            className: cx('scrollable', { scrolaableProps: props }),
-            style: { width, left }
-        },
-        getPTOptions('scrollable')
+        [
+            {
+                className: cx('scrollable', { scrolaableProps: props }),
+                style: { width, left }
+            },
+            getPTOptions('scrollable')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableHeaderProps = mergeProps(
-        {
-            className: cx('scrollableHeader'),
-            onScroll: (e) => onHeaderScroll(e)
-        },
-        getPTOptions('scrollableHeader')
+        [
+            {
+                className: cx('scrollableHeader'),
+                onScroll: (e) => onHeaderScroll(e)
+            },
+            getPTOptions('scrollableHeader')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableHeaderBoxProps = mergeProps(
-        {
-            className: cx('scrollableHeaderBox')
-        },
-        getPTOptions('scrollableHeaderBox')
+        [
+            {
+                className: cx('scrollableHeaderBox')
+            },
+            getPTOptions('scrollableHeaderBox')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableHeaderTableProps = mergeProps(
-        {
-            className: cx('scrollableHeaderTable')
-        },
-        getPTOptions('scrollableHeaderTable')
+        [
+            {
+                className: cx('scrollableHeaderTable')
+            },
+            getPTOptions('scrollableHeaderTable')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableBodyProps = mergeProps(
-        {
-            className: cx('scrollableBody'),
-            style: !props.frozen && props.scrollHeight ? { overflowY: 'scroll' } : undefined,
-            onScroll: (e) => onBodyScroll(e)
-        },
-        getPTOptions('scrollableBody')
+        [
+            {
+                className: cx('scrollableBody'),
+                style: !props.frozen && props.scrollHeight ? { overflowY: 'scroll' } : undefined,
+                onScroll: (e) => onBodyScroll(e)
+            },
+            getPTOptions('scrollableBody')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableBodyTableProps = mergeProps(
-        {
-            style: { top: '0' },
-            className: cx('scrollableBodyTable')
-        },
-        getPTOptions('scrollableBodyTable')
+        [
+            {
+                style: { top: '0' },
+                className: cx('scrollableBodyTable')
+            },
+            getPTOptions('scrollableBodyTable')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableFooterProps = mergeProps(
-        {
-            className: cx('scrollableFooter')
-        },
-        getPTOptions('scrollableFooter')
+        [
+            {
+                className: cx('scrollableFooter')
+            },
+            getPTOptions('scrollableFooter')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableFooterBoxProps = mergeProps(
-        {
-            className: sx('scrollableFooterBox')
-        },
-        getPTOptions('scrollableFooterBox')
+        [
+            {
+                className: sx('scrollableFooterBox')
+            },
+            getPTOptions('scrollableFooterBox')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     const scrollableFooterTableProps = mergeProps(
-        {
-            className: cx('scrollableFooterTable')
-        },
-        getPTOptions('scrollableFooterTable')
+        [
+            {
+                className: cx('scrollableFooterTable')
+            },
+            getPTOptions('scrollableFooterTable')
+        ],
+        { useTailwind: context.useTailwind }
     );
 
     return (

--- a/components/lib/tristatecheckbox/TriStateCheckbox.js
+++ b/components/lib/tristatecheckbox/TriStateCheckbox.js
@@ -88,16 +88,22 @@ export const TriStateCheckbox = React.memo(
         const otherProps = TriStateCheckboxBase.getOtherProps(props);
         const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
         const checkIconProps = mergeProps(
-            {
-                className: cx('checkIcon')
-            },
-            ptm('checkIcon')
+            [
+                {
+                    className: cx('checkIcon')
+                },
+                ptm('checkIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
         const uncheckIconProps = mergeProps(
-            {
-                className: cx('checkIcon')
-            },
-            ptm('uncheckIcon')
+            [
+                {
+                    className: cx('checkIcon')
+                },
+                ptm('uncheckIcon')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         let icon;
@@ -114,35 +120,44 @@ export const TriStateCheckbox = React.memo(
         const ariaChecked = props.value ? 'true' : 'false';
 
         const checkboxProps = mergeProps(
-            {
-                className: cx('checkbox', { focusedState }),
-                tabIndex: props.tabIndex,
-                onFocus: onFocus,
-                onBlur: onBlur,
-                onKeyDown: onKeyDown,
-                role: 'checkbox',
-                'aria-checked': ariaChecked,
-                ...ariaProps
-            },
-            ptm('checkbox')
+            [
+                {
+                    className: cx('checkbox', { focusedState }),
+                    tabIndex: props.tabIndex,
+                    onFocus: onFocus,
+                    onBlur: onBlur,
+                    onKeyDown: onKeyDown,
+                    role: 'checkbox',
+                    'aria-checked': ariaChecked,
+                    ...ariaProps
+                },
+                ptm('checkbox')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const srOnlyAriaProps = mergeProps(
-            {
-                className: 'p-sr-only p-hidden-accessible',
-                'aria-live': 'polite'
-            },
-            ptm('srOnlyAria')
+            [
+                {
+                    className: 'p-sr-only p-hidden-accessible',
+                    'aria-live': 'polite'
+                },
+                ptm('srOnlyAria')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         const rootProps = mergeProps(
-            {
-                className: classNames(props.className, cx('root')),
-                style: props.style,
-                onClick: onClick
-            },
-            TriStateCheckboxBase.getOtherProps(props),
-            ptm('root')
+            [
+                {
+                    className: classNames(props.className, cx('root')),
+                    style: props.style,
+                    onClick: onClick
+                },
+                TriStateCheckboxBase.getOtherProps(props),
+                ptm('root')
+            ],
+            { useTailwind: context.useTailwind }
         );
 
         return (

--- a/components/lib/utils/MergeProps.js
+++ b/components/lib/utils/MergeProps.js
@@ -1,4 +1,8 @@
-export function mergeProps(...props) {
+import { twMerge } from 'tailwind-merge';
+
+export function mergeProps(props, options = {}) {
+    const { useTailwind } = options;
+
     if (props) {
         const isFn = (o) => !!(o && o.constructor && o.call && o.apply);
 
@@ -9,7 +13,14 @@ export function mergeProps(...props) {
                 if (key === 'style') {
                     merged['style'] = { ...merged['style'], ...ps['style'] };
                 } else if (key === 'className') {
-                    let newClassname = [merged['className'], ps['className']].join(' ').trim();
+                    let newClassname = '';
+
+                    if (useTailwind) {
+                        newClassname = twMerge(merged['className'], ps['className']);
+                    } else {
+                        newClassname = [merged['className'], ps['className']].join(' ').trim();
+                    }
+
                     const isEmpty = newClassname === null || newClassname === undefined || newClassname === '';
 
                     merged['className'] = isEmpty ? undefined : newClassname;

--- a/components/lib/utils/utils.d.ts
+++ b/components/lib/utils/utils.d.ts
@@ -9,7 +9,7 @@ import * as React from 'react';
 
 export declare function classNames(...args: any[]): string | undefined;
 
-export declare function mergeProps(...args: object[]): object | undefined;
+export declare function mergeProps(props: object[], options: { useTailwind: boolean | undefined }): object | undefined;
 
 export declare class DomHandler {
     static innerWidth(el: HTMLElement): number;

--- a/components/lib/virtualscroller/VirtualScroller.js
+++ b/components/lib/virtualscroller/VirtualScroller.js
@@ -601,10 +601,13 @@ export const VirtualScroller = React.memo(
         const createLoader = () => {
             const iconClassName = 'p-virtualscroller-loading-icon';
             const loadingIconProps = mergeProps(
-                {
-                    className: iconClassName
-                },
-                ptm('loadingIcon')
+                [
+                    {
+                        className: iconClassName
+                    },
+                    ptm('loadingIcon')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
             const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
@@ -631,10 +634,13 @@ export const VirtualScroller = React.memo(
                 }
 
                 const loaderProps = mergeProps(
-                    {
-                        className
-                    },
-                    ptm('loader')
+                    [
+                        {
+                            className
+                        },
+                        ptm('loader')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...loaderProps}>{content}</div>;
@@ -646,12 +652,15 @@ export const VirtualScroller = React.memo(
         const createSpacer = () => {
             if (props.showSpacer) {
                 const spacerProps = mergeProps(
-                    {
-                        ref: spacerRef,
-                        style: spacerStyle.current,
-                        className: 'p-virtualscroller-spacer'
-                    },
-                    ptm('spacer')
+                    [
+                        {
+                            ref: spacerRef,
+                            style: spacerStyle.current,
+                            className: 'p-virtualscroller-spacer'
+                        },
+                        ptm('spacer')
+                    ],
+                    { useTailwind: context.useTailwind }
                 );
 
                 return <div {...spacerProps}></div>;
@@ -677,12 +686,15 @@ export const VirtualScroller = React.memo(
             const items = createItems();
             const className = classNames('p-virtualscroller-content', { 'p-virtualscroller-loading': loadingState });
             const contentProps = mergeProps(
-                {
-                    ref: contentRef,
-                    style: contentStyle.current,
-                    className
-                },
-                ptm('content')
+                [
+                    {
+                        ref: contentRef,
+                        style: contentStyle.current,
+                        className
+                    },
+                    ptm('content')
+                ],
+                { useTailwind: context.useTailwind }
             );
             const content = <div {...contentProps}>{items}</div>;
 
@@ -740,15 +752,18 @@ export const VirtualScroller = React.memo(
             const content = createContent();
             const spacer = createSpacer();
             const rootProps = mergeProps(
-                {
-                    ref: elementRef,
-                    className,
-                    tabIndex: props.tabIndex,
-                    style: props.style,
-                    onScroll: (e) => onScroll(e)
-                },
-                VirtualScrollerBase.getOtherProps(props),
-                ptm('root')
+                [
+                    {
+                        ref: elementRef,
+                        className,
+                        tabIndex: props.tabIndex,
+                        style: props.style,
+                        onScroll: (e) => onScroll(e)
+                    },
+                    VirtualScrollerBase.getOtherProps(props),
+                    ptm('root')
+                ],
+                { useTailwind: context.useTailwind }
             );
 
             return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "react-final-form": "^6.5.9",
                 "react-hook-form": "^7.45.2",
                 "react-transition-group": "^4.4.5",
+                "tailwind-merge": "^2.0.0",
                 "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
             },
             "devDependencies": {
@@ -17544,6 +17545,18 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "node_modules/tailwind-merge": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.0.0.tgz",
+            "integrity": "sha512-WO8qghn9yhsldLSg80au+3/gY9E4hFxIvQ3qOmlpXnqpDKoMruKfi/56BbbMg6fHTQJ9QD3cc79PoWqlaQE4rw==",
+            "dependencies": {
+                "@babel/runtime": "^7.23.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/dcastil"
+            }
         },
         "node_modules/tapable": {
             "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "react-final-form": "^6.5.9",
         "react-hook-form": "^7.45.2",
         "react-transition-group": "^4.4.5",
+        "tailwind-merge": "^2.0.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.19.3/xlsx-0.19.3.tgz"
     },
     "devDependencies": {


### PR DESCRIPTION
###
Previously, when attempting to override a tailwind class, the class merging algorithm would not take into account the priority of the tailwind base classes.  A utility called tailwind-merge does this for you, along with maintaining the merging of standard classes that might be defined.

This has been brought up in a few other discussions. (See: #5144 and similar) Since it seems that there has been a big push to support tailwind, we decided to just hack away at this. 

Obviously it would be very nice to not have to drill context into every component like that, however I decided to go that way since the president was set and I didn't want to influence design decisions as a first time contributer.  In the event that you would like to avoid prop drilling, we could create a wrapped hook such as `useMergeProps(props...)` that returns a wrapped around the existing `mergeProps()` function. Ultimately, every file that was touched would still need to be touched.

### Note
 It works 100% if you rebase it on the tip of 10.0.7.  Currently some styling issues exist on the top of master that seem to break components such as `Editor.js`.
 
### Important changes
- `components/lib/utils/MergeProps.js` now checks for the useTailwind context flag to determine what merging strategy to use.
- The usePassthrough hook has also been updated to use the new merge functionality when the Provider has been enabled to do so.  This works independently of the per component overrides.
```javascript
const CustomTailwind = usePassThrough(
  {
    dropdown: {
      root: { className: 'w-36 md:w-36 bg-red-500 md:w-64' },
    },
  },
  {
    mergeSections: true,
    mergeProps: true,
    useTailwind: true,
  },
);
```
```javascript
<PrimeReactProvider value={{ unstyled: true, pt: CustomTailwind, useTailwind: true }}>
  <AppRouter />
</PrimeReactProvider>
```

- Documentation has been updated as have the types associated with the change.


### Automated CodeMod
Just as an FYI, incase you want to change the shape of the API, I automated the code change with the following regex:
FInd `\bmergeProps\(((?:[^;]+)|(?:\n))\);` ->  Replace `mergeProps([$1], { useTailwind: context.useTailwind });`
