### PR TITLE
Fix #5210: Multiselect align overlay after filtering

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -617,10 +617,10 @@ export const MultiSelect = React.memo(
         }, [props.overlayVisible]);
 
         useUpdateEffect(() => {
-            if (overlayVisibleState && hasFilter) {
+            if (overlayVisibleState && filterState && hasFilter) {
                 alignOverlay();
             }
-        }, [overlayVisibleState, hasFilter]);
+        }, [overlayVisibleState, filterState, hasFilter]);
 
         useUnmountEffect(() => {
             ZIndexUtils.clear(overlayRef.current);


### PR DESCRIPTION
Fix #5210: Multiselect align overlay after filtering