### PR TITLE
Fix #4675: Improved bundler support for ESM/SSR

### DIFF
--- a/components/lib/accordion/package.json
+++ b/components/lib/accordion/package.json
@@ -3,5 +3,15 @@
     "module": "./accordion.esm.js",
     "unpkg": "./accordion.min.js",
     "types": "./accordion.d.ts",
+    "exports": {
+        ".": {
+            "types": "./accordion.d.ts",
+            "module": "./accordion.esm.js",
+            "import": "./accordion.esm.js",
+            "require": "./accordion.cjs.js",
+            "default": "./accordion.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/autocomplete/package.json
+++ b/components/lib/autocomplete/package.json
@@ -3,5 +3,15 @@
     "module": "./autocomplete.esm.js",
     "unpkg": "./autocomplete.min.js",
     "types": "./autocomplete.d.ts",
+    "exports": {
+        ".": {
+            "types": "./autocomplete.d.ts",
+            "module": "./autocomplete.esm.js",
+            "import": "./autocomplete.esm.js",
+            "require": "./autocomplete.cjs.js",
+            "default": "./autocomplete.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/avatar/package.json
+++ b/components/lib/avatar/package.json
@@ -3,5 +3,15 @@
     "module": "./avatar.esm.js",
     "unpkg": "./avatar.min.js",
     "types": "./avatar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./avatar.d.ts",
+            "module": "./avatar.esm.js",
+            "import": "./avatar.esm.js",
+            "require": "./avatar.cjs.js",
+            "default": "./avatar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/avatargroup/package.json
+++ b/components/lib/avatargroup/package.json
@@ -3,5 +3,15 @@
     "module": "./avatargroup.esm.js",
     "unpkg": "./avatargroup.min.js",
     "types": "./avatargroup.d.ts",
+    "exports": {
+        ".": {
+            "types": "./avatargroup.d.ts",
+            "module": "./avatargroup.esm.js",
+            "import": "./avatargroup.esm.js",
+            "require": "./avatargroup.cjs.js",
+            "default": "./avatargroup.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/badge/package.json
+++ b/components/lib/badge/package.json
@@ -3,5 +3,15 @@
     "module": "./badge.esm.js",
     "unpkg": "./badge.min.js",
     "types": "./badge.d.ts",
+    "exports": {
+        ".": {
+            "types": "./badge.d.ts",
+            "module": "./badge.esm.js",
+            "import": "./badge.esm.js",
+            "require": "./badge.cjs.js",
+            "default": "./badge.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/blockui/package.json
+++ b/components/lib/blockui/package.json
@@ -3,5 +3,15 @@
     "module": "./blockui.esm.js",
     "unpkg": "./blockui.min.js",
     "types": "./blockui.d.ts",
+    "exports": {
+        ".": {
+            "types": "./blockui.d.ts",
+            "module": "./blockui.esm.js",
+            "import": "./blockui.esm.js",
+            "require": "./blockui.cjs.js",
+            "default": "./blockui.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/breadcrumb/package.json
+++ b/components/lib/breadcrumb/package.json
@@ -3,5 +3,15 @@
     "module": "./breadcrumb.esm.js",
     "unpkg": "./breadcrumb.min.js",
     "types": "./breadcrumb.d.ts",
+    "exports": {
+        ".": {
+            "types": "./breadcrumb.d.ts",
+            "module": "./breadcrumb.esm.js",
+            "import": "./breadcrumb.esm.js",
+            "require": "./breadcrumb.cjs.js",
+            "default": "./breadcrumb.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/button/package.json
+++ b/components/lib/button/package.json
@@ -3,5 +3,15 @@
     "module": "./button.esm.js",
     "unpkg": "./button.min.js",
     "types": "./button.d.ts",
+    "exports": {
+        ".": {
+            "types": "./button.d.ts",
+            "module": "./button.esm.js",
+            "import": "./button.esm.js",
+            "require": "./button.cjs.js",
+            "default": "./button.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/calendar/package.json
+++ b/components/lib/calendar/package.json
@@ -3,5 +3,15 @@
     "module": "./calendar.esm.js",
     "unpkg": "./calendar.min.js",
     "types": "./calendar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./calendar.d.ts",
+            "module": "./calendar.esm.js",
+            "import": "./calendar.esm.js",
+            "require": "./calendar.cjs.js",
+            "default": "./calendar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/card/package.json
+++ b/components/lib/card/package.json
@@ -3,5 +3,15 @@
     "module": "./card.esm.js",
     "unpkg": "./card.min.js",
     "types": "./card.d.ts",
+    "exports": {
+        ".": {
+            "types": "./card.d.ts",
+            "module": "./card.esm.js",
+            "import": "./card.esm.js",
+            "require": "./card.cjs.js",
+            "default": "./card.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/carousel/package.json
+++ b/components/lib/carousel/package.json
@@ -3,5 +3,15 @@
     "module": "./carousel.esm.js",
     "unpkg": "./carousel.min.js",
     "types": "./carousel.d.ts",
+    "exports": {
+        ".": {
+            "types": "./carousel.d.ts",
+            "module": "./carousel.esm.js",
+            "import": "./carousel.esm.js",
+            "require": "./carousel.cjs.js",
+            "default": "./carousel.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/cascadeselect/package.json
+++ b/components/lib/cascadeselect/package.json
@@ -3,5 +3,15 @@
     "module": "./cascadeselect.esm.js",
     "unpkg": "./cascadeselect.min.js",
     "types": "./cascadeselect.d.ts",
+    "exports": {
+        ".": {
+            "types": "./cascadeselect.d.ts",
+            "module": "./cascadeselect.esm.js",
+            "import": "./cascadeselect.esm.js",
+            "require": "./cascadeselect.cjs.js",
+            "default": "./cascadeselect.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/chart/package.json
+++ b/components/lib/chart/package.json
@@ -3,5 +3,15 @@
     "module": "./chart.esm.js",
     "unpkg": "./chart.min.js",
     "types": "./chart.d.ts",
+    "exports": {
+        ".": {
+            "types": "./chart.d.ts",
+            "module": "./chart.esm.js",
+            "import": "./chart.esm.js",
+            "require": "./chart.cjs.js",
+            "default": "./chart.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/checkbox/package.json
+++ b/components/lib/checkbox/package.json
@@ -3,5 +3,15 @@
     "module": "./checkbox.esm.js",
     "unpkg": "./checkbox.min.js",
     "types": "./checkbox.d.ts",
+    "exports": {
+        ".": {
+            "types": "./checkbox.d.ts",
+            "module": "./checkbox.esm.js",
+            "import": "./checkbox.esm.js",
+            "require": "./checkbox.cjs.js",
+            "default": "./checkbox.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/chip/package.json
+++ b/components/lib/chip/package.json
@@ -3,5 +3,15 @@
     "module": "./chip.esm.js",
     "unpkg": "./chip.min.js",
     "types": "./chip.d.ts",
+    "exports": {
+        ".": {
+            "types": "./chip.d.ts",
+            "module": "./chip.esm.js",
+            "import": "./chip.esm.js",
+            "require": "./chip.cjs.js",
+            "default": "./chip.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/chips/package.json
+++ b/components/lib/chips/package.json
@@ -3,5 +3,15 @@
     "module": "./chips.esm.js",
     "unpkg": "./chips.min.js",
     "types": "./chips.d.ts",
+    "exports": {
+        ".": {
+            "types": "./chips.d.ts",
+            "module": "./chips.esm.js",
+            "import": "./chips.esm.js",
+            "require": "./chips.cjs.js",
+            "default": "./chips.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/colorpicker/package.json
+++ b/components/lib/colorpicker/package.json
@@ -3,5 +3,15 @@
     "module": "./colorpicker.esm.js",
     "unpkg": "./colorpicker.min.js",
     "types": "./colorpicker.d.ts",
+    "exports": {
+        ".": {
+            "types": "./colorpicker.d.ts",
+            "module": "./colorpicker.esm.js",
+            "import": "./colorpicker.esm.js",
+            "require": "./colorpicker.cjs.js",
+            "default": "./colorpicker.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/column/package.json
+++ b/components/lib/column/package.json
@@ -3,5 +3,15 @@
     "module": "./column.esm.js",
     "unpkg": "./column.min.js",
     "types": "./column.d.ts",
+    "exports": {
+        ".": {
+            "types": "./column.d.ts",
+            "module": "./column.esm.js",
+            "import": "./column.esm.js",
+            "require": "./column.cjs.js",
+            "default": "./column.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/columngroup/package.json
+++ b/components/lib/columngroup/package.json
@@ -3,5 +3,15 @@
     "module": "./columngroup.esm.js",
     "unpkg": "./columngroup.min.js",
     "types": "./columngroup.d.ts",
+    "exports": {
+        ".": {
+            "types": "./columngroup.d.ts",
+            "module": "./columngroup.esm.js",
+            "import": "./columngroup.esm.js",
+            "require": "./columngroup.cjs.js",
+            "default": "./columngroup.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/componentbase/package.json
+++ b/components/lib/componentbase/package.json
@@ -3,5 +3,15 @@
     "module": "./componentbase.esm.js",
     "unpkg": "./componentbase.min.js",
     "types": "./componentbase.d.ts",
+    "exports": {
+        ".": {
+            "types": "./componentbase.d.ts",
+            "module": "./componentbase.esm.js",
+            "import": "./componentbase.esm.js",
+            "require": "./componentbase.cjs.js",
+            "default": "./componentbase.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/confirmdialog/package.json
+++ b/components/lib/confirmdialog/package.json
@@ -3,5 +3,15 @@
     "module": "./confirmdialog.esm.js",
     "unpkg": "./confirmdialog.min.js",
     "types": "./confirmdialog.d.ts",
+    "exports": {
+        ".": {
+            "types": "./confirmdialog.d.ts",
+            "module": "./confirmdialog.esm.js",
+            "import": "./confirmdialog.esm.js",
+            "require": "./confirmdialog.cjs.js",
+            "default": "./confirmdialog.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/confirmpopup/package.json
+++ b/components/lib/confirmpopup/package.json
@@ -3,5 +3,15 @@
     "module": "./confirmpopup.esm.js",
     "unpkg": "./confirmpopup.min.js",
     "types": "./confirmpopup.d.ts",
+    "exports": {
+        ".": {
+            "types": "./confirmpopup.d.ts",
+            "module": "./confirmpopup.esm.js",
+            "import": "./confirmpopup.esm.js",
+            "require": "./confirmpopup.cjs.js",
+            "default": "./confirmpopup.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/contextmenu/package.json
+++ b/components/lib/contextmenu/package.json
@@ -3,5 +3,15 @@
     "module": "./contextmenu.esm.js",
     "unpkg": "./contextmenu.min.js",
     "types": "./contextmenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./contextmenu.d.ts",
+            "module": "./contextmenu.esm.js",
+            "import": "./contextmenu.esm.js",
+            "require": "./contextmenu.cjs.js",
+            "default": "./contextmenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/csstransition/package.json
+++ b/components/lib/csstransition/package.json
@@ -3,5 +3,15 @@
     "module": "./csstransition.esm.js",
     "unpkg": "./csstransition.min.js",
     "types": "./csstransition.d.ts",
+    "exports": {
+        ".": {
+            "types": "./csstransition.d.ts",
+            "module": "./csstransition.esm.js",
+            "import": "./csstransition.esm.js",
+            "require": "./csstransition.cjs.js",
+            "default": "./csstransition.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/datascroller/package.json
+++ b/components/lib/datascroller/package.json
@@ -3,5 +3,15 @@
     "module": "./datascroller.esm.js",
     "unpkg": "./datascroller.min.js",
     "types": "./datascroller.d.ts",
+    "exports": {
+        ".": {
+            "types": "./datascroller.d.ts",
+            "module": "./datascroller.esm.js",
+            "import": "./datascroller.esm.js",
+            "require": "./datascroller.cjs.js",
+            "default": "./datascroller.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/datatable/package.json
+++ b/components/lib/datatable/package.json
@@ -3,5 +3,15 @@
     "module": "./datatable.esm.js",
     "unpkg": "./datatable.min.js",
     "types": "./datatable.d.ts",
+    "exports": {
+        ".": {
+            "types": "./datatable.d.ts",
+            "module": "./datatable.esm.js",
+            "import": "./datatable.esm.js",
+            "require": "./datatable.cjs.js",
+            "default": "./datatable.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/dataview/package.json
+++ b/components/lib/dataview/package.json
@@ -3,5 +3,15 @@
     "module": "./dataview.esm.js",
     "unpkg": "./dataview.min.js",
     "types": "./dataview.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dataview.d.ts",
+            "module": "./dataview.esm.js",
+            "import": "./dataview.esm.js",
+            "require": "./dataview.cjs.js",
+            "default": "./dataview.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/deferredcontent/package.json
+++ b/components/lib/deferredcontent/package.json
@@ -3,5 +3,15 @@
     "module": "./deferredcontent.esm.js",
     "unpkg": "./deferredcontent.min.js",
     "types": "./deferredcontent.d.ts",
+    "exports": {
+        ".": {
+            "types": "./deferredcontent.d.ts",
+            "module": "./deferredcontent.esm.js",
+            "import": "./deferredcontent.esm.js",
+            "require": "./deferredcontent.cjs.js",
+            "default": "./deferredcontent.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/dialog/package.json
+++ b/components/lib/dialog/package.json
@@ -3,5 +3,15 @@
     "module": "./dialog.esm.js",
     "unpkg": "./dialog.min.js",
     "types": "./dialog.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dialog.d.ts",
+            "module": "./dialog.esm.js",
+            "import": "./dialog.esm.js",
+            "require": "./dialog.cjs.js",
+            "default": "./dialog.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/divider/package.json
+++ b/components/lib/divider/package.json
@@ -3,5 +3,15 @@
     "module": "./divider.esm.js",
     "unpkg": "./divider.min.js",
     "types": "./divider.d.ts",
+    "exports": {
+        ".": {
+            "types": "./divider.d.ts",
+            "module": "./divider.esm.js",
+            "import": "./divider.esm.js",
+            "require": "./divider.cjs.js",
+            "default": "./divider.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/dock/package.json
+++ b/components/lib/dock/package.json
@@ -3,5 +3,15 @@
     "module": "./dock.esm.js",
     "unpkg": "./dock.min.js",
     "types": "./dock.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dock.d.ts",
+            "module": "./dock.esm.js",
+            "import": "./dock.esm.js",
+            "require": "./dock.cjs.js",
+            "default": "./dock.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/dropdown/package.json
+++ b/components/lib/dropdown/package.json
@@ -3,5 +3,15 @@
     "module": "./dropdown.esm.js",
     "unpkg": "./dropdown.min.js",
     "types": "./dropdown.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dropdown.d.ts",
+            "module": "./dropdown.esm.js",
+            "import": "./dropdown.esm.js",
+            "require": "./dropdown.cjs.js",
+            "default": "./dropdown.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/editor/package.json
+++ b/components/lib/editor/package.json
@@ -3,5 +3,15 @@
     "module": "./editor.esm.js",
     "unpkg": "./editor.min.js",
     "types": "./editor.d.ts",
+    "exports": {
+        ".": {
+            "types": "./editor.d.ts",
+            "module": "./editor.esm.js",
+            "import": "./editor.esm.js",
+            "require": "./editor.cjs.js",
+            "default": "./editor.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/fieldset/package.json
+++ b/components/lib/fieldset/package.json
@@ -3,5 +3,15 @@
     "module": "./fieldset.esm.js",
     "unpkg": "./fieldset.min.js",
     "types": "./fieldset.d.ts",
+    "exports": {
+        ".": {
+            "types": "./fieldset.d.ts",
+            "module": "./fieldset.esm.js",
+            "import": "./fieldset.esm.js",
+            "require": "./fieldset.cjs.js",
+            "default": "./fieldset.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/fileupload/package.json
+++ b/components/lib/fileupload/package.json
@@ -3,5 +3,15 @@
     "module": "./fileupload.esm.js",
     "unpkg": "./fileupload.min.js",
     "types": "./fileupload.d.ts",
+    "exports": {
+        ".": {
+            "types": "./fileupload.d.ts",
+            "module": "./fileupload.esm.js",
+            "import": "./fileupload.esm.js",
+            "require": "./fileupload.cjs.js",
+            "default": "./fileupload.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/galleria/package.json
+++ b/components/lib/galleria/package.json
@@ -3,5 +3,15 @@
     "module": "./galleria.esm.js",
     "unpkg": "./galleria.min.js",
     "types": "./galleria.d.ts",
+    "exports": {
+        ".": {
+            "types": "./galleria.d.ts",
+            "module": "./galleria.esm.js",
+            "import": "./galleria.esm.js",
+            "require": "./galleria.cjs.js",
+            "default": "./galleria.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/hooks/package.json
+++ b/components/lib/hooks/package.json
@@ -3,5 +3,15 @@
     "module": "./hooks.esm.js",
     "unpkg": "./hooks.min.js",
     "types": "./hooks.d.ts",
+    "exports": {
+        ".": {
+            "types": "./hooks.d.ts",
+            "module": "./hooks.esm.js",
+            "import": "./hooks.esm.js",
+            "require": "./hooks.cjs.js",
+            "default": "./hooks.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/iconbase/package.json
+++ b/components/lib/iconbase/package.json
@@ -3,5 +3,15 @@
     "module": "./iconbase.esm.js",
     "unpkg": "./iconbase.min.js",
     "types": "./iconbase.d.ts",
+    "exports": {
+        ".": {
+            "types": "./iconbase.d.ts",
+            "module": "./iconbase.esm.js",
+            "import": "./iconbase.esm.js",
+            "require": "./iconbase.cjs.js",
+            "default": "./iconbase.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angledoubledown/package.json
+++ b/components/lib/icons/angledoubledown/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angledoubleleft/package.json
+++ b/components/lib/icons/angledoubleleft/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angledoubleright/package.json
+++ b/components/lib/icons/angledoubleright/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angledoubleup/package.json
+++ b/components/lib/icons/angledoubleup/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angledown/package.json
+++ b/components/lib/icons/angledown/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angleleft/package.json
+++ b/components/lib/icons/angleleft/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angleright/package.json
+++ b/components/lib/icons/angleright/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/angleup/package.json
+++ b/components/lib/icons/angleup/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/arrowdown/package.json
+++ b/components/lib/icons/arrowdown/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/arrowup/package.json
+++ b/components/lib/icons/arrowup/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/ban/package.json
+++ b/components/lib/icons/ban/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/bars/package.json
+++ b/components/lib/icons/bars/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/calendar/package.json
+++ b/components/lib/icons/calendar/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/check/package.json
+++ b/components/lib/icons/check/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/chevrondown/package.json
+++ b/components/lib/icons/chevrondown/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/chevronleft/package.json
+++ b/components/lib/icons/chevronleft/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/chevronright/package.json
+++ b/components/lib/icons/chevronright/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/chevronup/package.json
+++ b/components/lib/icons/chevronup/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/download/package.json
+++ b/components/lib/icons/download/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/exclamationtriangle/package.json
+++ b/components/lib/icons/exclamationtriangle/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/eye/package.json
+++ b/components/lib/icons/eye/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/eyeslash/package.json
+++ b/components/lib/icons/eyeslash/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/filter/package.json
+++ b/components/lib/icons/filter/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/filterslash/package.json
+++ b/components/lib/icons/filterslash/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/infocircle/package.json
+++ b/components/lib/icons/infocircle/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/minus/package.json
+++ b/components/lib/icons/minus/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/pencil/package.json
+++ b/components/lib/icons/pencil/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/plus/package.json
+++ b/components/lib/icons/plus/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/refresh/package.json
+++ b/components/lib/icons/refresh/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/search/package.json
+++ b/components/lib/icons/search/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/searchminus/package.json
+++ b/components/lib/icons/searchminus/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/searchplus/package.json
+++ b/components/lib/icons/searchplus/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/sortalt/package.json
+++ b/components/lib/icons/sortalt/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/sortamountdown/package.json
+++ b/components/lib/icons/sortamountdown/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/sortamountupalt/package.json
+++ b/components/lib/icons/sortamountupalt/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/spinner/package.json
+++ b/components/lib/icons/spinner/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/star/package.json
+++ b/components/lib/icons/star/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/starfill/package.json
+++ b/components/lib/icons/starfill/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/thlarge/package.json
+++ b/components/lib/icons/thlarge/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/times/package.json
+++ b/components/lib/icons/times/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/timescircle/package.json
+++ b/components/lib/icons/timescircle/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/trash/package.json
+++ b/components/lib/icons/trash/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/undo/package.json
+++ b/components/lib/icons/undo/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/upload/package.json
+++ b/components/lib/icons/upload/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/windowmaximize/package.json
+++ b/components/lib/icons/windowmaximize/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/icons/windowminimize/package.json
+++ b/components/lib/icons/windowminimize/package.json
@@ -3,5 +3,15 @@
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
     "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/image/package.json
+++ b/components/lib/image/package.json
@@ -3,5 +3,15 @@
     "module": "./image.esm.js",
     "unpkg": "./image.min.js",
     "types": "./image.d.ts",
+    "exports": {
+        ".": {
+            "types": "./image.d.ts",
+            "module": "./image.esm.js",
+            "import": "./image.esm.js",
+            "require": "./image.cjs.js",
+            "default": "./image.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inplace/package.json
+++ b/components/lib/inplace/package.json
@@ -3,5 +3,15 @@
     "module": "./inplace.esm.js",
     "unpkg": "./inplace.min.js",
     "types": "./inplace.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inplace.d.ts",
+            "module": "./inplace.esm.js",
+            "import": "./inplace.esm.js",
+            "require": "./inplace.cjs.js",
+            "default": "./inplace.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inputmask/package.json
+++ b/components/lib/inputmask/package.json
@@ -3,5 +3,15 @@
     "module": "./inputmask.esm.js",
     "unpkg": "./inputmask.min.js",
     "types": "./inputmask.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inputmask.d.ts",
+            "module": "./inputmask.esm.js",
+            "import": "./inputmask.esm.js",
+            "require": "./inputmask.cjs.js",
+            "default": "./inputmask.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inputnumber/package.json
+++ b/components/lib/inputnumber/package.json
@@ -3,5 +3,15 @@
     "module": "./inputnumber.esm.js",
     "unpkg": "./inputnumber.min.js",
     "types": "./inputnumber.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inputnumber.d.ts",
+            "module": "./inputnumber.esm.js",
+            "import": "./inputnumber.esm.js",
+            "require": "./inputnumber.cjs.js",
+            "default": "./inputnumber.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inputswitch/package.json
+++ b/components/lib/inputswitch/package.json
@@ -3,5 +3,15 @@
     "module": "./inputswitch.esm.js",
     "unpkg": "./inputswitch.min.js",
     "types": "./inputswitch.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inputswitch.d.ts",
+            "module": "./inputswitch.esm.js",
+            "import": "./inputswitch.esm.js",
+            "require": "./inputswitch.cjs.js",
+            "default": "./inputswitch.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inputtext/package.json
+++ b/components/lib/inputtext/package.json
@@ -3,5 +3,15 @@
     "module": "./inputtext.esm.js",
     "unpkg": "./inputtext.min.js",
     "types": "./inputtext.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inputtext.d.ts",
+            "module": "./inputtext.esm.js",
+            "import": "./inputtext.esm.js",
+            "require": "./inputtext.cjs.js",
+            "default": "./inputtext.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/inputtextarea/package.json
+++ b/components/lib/inputtextarea/package.json
@@ -3,5 +3,15 @@
     "module": "./inputtextarea.esm.js",
     "unpkg": "./inputtextarea.min.js",
     "types": "./inputtextarea.d.ts",
+    "exports": {
+        ".": {
+            "types": "./inputtextarea.d.ts",
+            "module": "./inputtextarea.esm.js",
+            "import": "./inputtextarea.esm.js",
+            "require": "./inputtextarea.cjs.js",
+            "default": "./inputtextarea.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/keyfilter/package.json
+++ b/components/lib/keyfilter/package.json
@@ -3,5 +3,15 @@
     "module": "./keyfilter.esm.js",
     "unpkg": "./keyfilter.min.js",
     "types": "./keyfilteroptions.d.ts",
+    "exports": {
+        ".": {
+            "types": "./keyfilteroptions.d.ts",
+            "module": "./keyfilter.esm.js",
+            "import": "./keyfilter.esm.js",
+            "require": "./keyfilter.cjs.js",
+            "default": "./keyfilter.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/knob/package.json
+++ b/components/lib/knob/package.json
@@ -3,5 +3,15 @@
     "module": "./knob.esm.js",
     "unpkg": "./knob.min.js",
     "types": "./knob.d.ts",
+    "exports": {
+        ".": {
+            "types": "./knob.d.ts",
+            "module": "./knob.esm.js",
+            "import": "./knob.esm.js",
+            "require": "./knob.cjs.js",
+            "default": "./knob.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/listbox/package.json
+++ b/components/lib/listbox/package.json
@@ -3,5 +3,15 @@
     "module": "./listbox.esm.js",
     "unpkg": "./listbox.min.js",
     "types": "./listbox.d.ts",
+    "exports": {
+        ".": {
+            "types": "./listbox.d.ts",
+            "module": "./listbox.esm.js",
+            "import": "./listbox.esm.js",
+            "require": "./listbox.cjs.js",
+            "default": "./listbox.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/megamenu/package.json
+++ b/components/lib/megamenu/package.json
@@ -3,5 +3,15 @@
     "module": "./megamenu.esm.js",
     "unpkg": "./megamenu.min.js",
     "types": "./megamenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./megamenu.d.ts",
+            "module": "./megamenu.esm.js",
+            "import": "./megamenu.esm.js",
+            "require": "./megamenu.cjs.js",
+            "default": "./megamenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/mention/package.json
+++ b/components/lib/mention/package.json
@@ -3,5 +3,15 @@
     "module": "./mention.esm.js",
     "unpkg": "./mention.min.js",
     "types": "./mention.d.ts",
+    "exports": {
+        ".": {
+            "types": "./mention.d.ts",
+            "module": "./mention.esm.js",
+            "import": "./mention.esm.js",
+            "require": "./mention.cjs.js",
+            "default": "./mention.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/menu/package.json
+++ b/components/lib/menu/package.json
@@ -3,5 +3,15 @@
     "module": "./menu.esm.js",
     "unpkg": "./menu.min.js",
     "types": "./menu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./menu.d.ts",
+            "module": "./menu.esm.js",
+            "import": "./menu.esm.js",
+            "require": "./menu.cjs.js",
+            "default": "./menu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/menubar/package.json
+++ b/components/lib/menubar/package.json
@@ -3,5 +3,15 @@
     "module": "./menubar.esm.js",
     "unpkg": "./menubar.min.js",
     "types": "./menubar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./menubar.d.ts",
+            "module": "./menubar.esm.js",
+            "import": "./menubar.esm.js",
+            "require": "./menubar.cjs.js",
+            "default": "./menubar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/menuitem/package.json
+++ b/components/lib/menuitem/package.json
@@ -1,4 +1,10 @@
 {
     "types": "./menuitem.d.ts",
+    "exports": {
+        ".": {
+            "types": "./menuitem.d.ts"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/message/package.json
+++ b/components/lib/message/package.json
@@ -3,5 +3,15 @@
     "module": "./message.esm.js",
     "unpkg": "./message.min.js",
     "types": "./message.d.ts",
+    "exports": {
+        ".": {
+            "types": "./message.d.ts",
+            "module": "./message.esm.js",
+            "import": "./message.esm.js",
+            "require": "./message.cjs.js",
+            "default": "./message.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/messages/package.json
+++ b/components/lib/messages/package.json
@@ -3,5 +3,15 @@
     "module": "./messages.esm.js",
     "unpkg": "./messages.min.js",
     "types": "./messages.d.ts",
+    "exports": {
+        ".": {
+            "types": "./messages.d.ts",
+            "module": "./messages.esm.js",
+            "import": "./messages.esm.js",
+            "require": "./messages.cjs.js",
+            "default": "./messages.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/multiselect/package.json
+++ b/components/lib/multiselect/package.json
@@ -3,5 +3,15 @@
     "module": "./multiselect.esm.js",
     "unpkg": "./multiselect.min.js",
     "types": "./multiselect.d.ts",
+    "exports": {
+        ".": {
+            "types": "./multiselect.d.ts",
+            "module": "./multiselect.esm.js",
+            "import": "./multiselect.esm.js",
+            "require": "./multiselect.cjs.js",
+            "default": "./multiselect.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/multistatecheckbox/package.json
+++ b/components/lib/multistatecheckbox/package.json
@@ -3,5 +3,15 @@
     "module": "./multistatecheckbox.esm.js",
     "unpkg": "./multistatecheckbox.min.js",
     "types": "./multistatecheckbox.d.ts",
+    "exports": {
+        ".": {
+            "types": "./multistatecheckbox.d.ts",
+            "module": "./multistatecheckbox.esm.js",
+            "import": "./multistatecheckbox.esm.js",
+            "require": "./multistatecheckbox.cjs.js",
+            "default": "./multistatecheckbox.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/orderlist/package.json
+++ b/components/lib/orderlist/package.json
@@ -3,5 +3,15 @@
     "module": "./orderlist.esm.js",
     "unpkg": "./orderlist.min.js",
     "types": "./orderlist.d.ts",
+    "exports": {
+        ".": {
+            "types": "./orderlist.d.ts",
+            "module": "./orderlist.esm.js",
+            "import": "./orderlist.esm.js",
+            "require": "./orderlist.cjs.js",
+            "default": "./orderlist.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/organizationchart/package.json
+++ b/components/lib/organizationchart/package.json
@@ -3,5 +3,15 @@
     "module": "./organizationchart.esm.js",
     "unpkg": "./organizationchart.min.js",
     "types": "./organizationchart.d.ts",
+    "exports": {
+        ".": {
+            "types": "./organizationchart.d.ts",
+            "module": "./organizationchart.esm.js",
+            "import": "./organizationchart.esm.js",
+            "require": "./organizationchart.cjs.js",
+            "default": "./organizationchart.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/overlaypanel/package.json
+++ b/components/lib/overlaypanel/package.json
@@ -3,5 +3,15 @@
     "module": "./overlaypanel.esm.js",
     "unpkg": "./overlaypanel.min.js",
     "types": "./overlaypanel.d.ts",
+    "exports": {
+        ".": {
+            "types": "./overlaypanel.d.ts",
+            "module": "./overlaypanel.esm.js",
+            "import": "./overlaypanel.esm.js",
+            "require": "./overlaypanel.cjs.js",
+            "default": "./overlaypanel.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/overlayservice/package.json
+++ b/components/lib/overlayservice/package.json
@@ -3,5 +3,15 @@
     "module": "./overlayservice.esm.js",
     "unpkg": "./overlayservice.min.js",
     "types": "./overlayservice.d.ts",
+    "exports": {
+        ".": {
+            "types": "./overlayservice.d.ts",
+            "module": "./overlayservice.esm.js",
+            "import": "./overlayservice.esm.js",
+            "require": "./overlayservice.cjs.js",
+            "default": "./overlayservice.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/paginator/package.json
+++ b/components/lib/paginator/package.json
@@ -3,5 +3,15 @@
     "module": "./paginator.esm.js",
     "unpkg": "./paginator.min.js",
     "types": "./paginator.d.ts",
+    "exports": {
+        ".": {
+            "types": "./paginator.d.ts",
+            "module": "./paginator.esm.js",
+            "import": "./paginator.esm.js",
+            "require": "./paginator.cjs.js",
+            "default": "./paginator.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/panel/package.json
+++ b/components/lib/panel/package.json
@@ -3,5 +3,15 @@
     "module": "./panel.esm.js",
     "unpkg": "./panel.min.js",
     "types": "./panel.d.ts",
+    "exports": {
+        ".": {
+            "types": "./panel.d.ts",
+            "module": "./panel.esm.js",
+            "import": "./panel.esm.js",
+            "require": "./panel.cjs.js",
+            "default": "./panel.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/panelmenu/package.json
+++ b/components/lib/panelmenu/package.json
@@ -3,5 +3,15 @@
     "module": "./panelmenu.esm.js",
     "unpkg": "./panelmenu.min.js",
     "types": "./panelmenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./panelmenu.d.ts",
+            "module": "./panelmenu.esm.js",
+            "import": "./panelmenu.esm.js",
+            "require": "./panelmenu.cjs.js",
+            "default": "./panelmenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/passthrough/package.json
+++ b/components/lib/passthrough/package.json
@@ -2,5 +2,15 @@
     "main": "./index.cjs.js",
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
-    "types": "./index.d.ts"
+    "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    }
 }

--- a/components/lib/passthrough/tailwind/package.json
+++ b/components/lib/passthrough/tailwind/package.json
@@ -2,5 +2,15 @@
     "main": "./index.cjs.js",
     "module": "./index.esm.js",
     "unpkg": "./index.min.js",
-    "types": "./index.d.ts"
+    "types": "./index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "module": "./index.esm.js",
+            "import": "./index.esm.js",
+            "require": "./index.cjs.js",
+            "default": "./index.min.js"
+        },
+        "./package.json": "./package.json"
+    }
 }

--- a/components/lib/password/package.json
+++ b/components/lib/password/package.json
@@ -3,5 +3,15 @@
     "module": "./password.esm.js",
     "unpkg": "./password.min.js",
     "types": "./password.d.ts",
+    "exports": {
+        ".": {
+            "types": "./password.d.ts",
+            "module": "./password.esm.js",
+            "import": "./password.esm.js",
+            "require": "./password.cjs.js",
+            "default": "./password.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/picklist/package.json
+++ b/components/lib/picklist/package.json
@@ -3,5 +3,15 @@
     "module": "./picklist.esm.js",
     "unpkg": "./picklist.min.js",
     "types": "./picklist.d.ts",
+    "exports": {
+        ".": {
+            "types": "./picklist.d.ts",
+            "module": "./picklist.esm.js",
+            "import": "./picklist.esm.js",
+            "require": "./picklist.cjs.js",
+            "default": "./picklist.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/portal/package.json
+++ b/components/lib/portal/package.json
@@ -2,5 +2,14 @@
     "main": "./portal.cjs.js",
     "module": "./portal.esm.js",
     "unpkg": "./portal.min.js",
+    "exports": {
+        ".": {
+            "module": "./portal.esm.js",
+            "import": "./portal.esm.js",
+            "require": "./portal.cjs.js",
+            "default": "./portal.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/progressbar/package.json
+++ b/components/lib/progressbar/package.json
@@ -3,5 +3,15 @@
     "module": "./progressbar.esm.js",
     "unpkg": "./progressbar.min.js",
     "types": "./progressbar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./progressbar.d.ts",
+            "module": "./progressbar.esm.js",
+            "import": "./progressbar.esm.js",
+            "require": "./progressbar.cjs.js",
+            "default": "./progressbar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/progressspinner/package.json
+++ b/components/lib/progressspinner/package.json
@@ -3,5 +3,15 @@
     "module": "./progressspinner.esm.js",
     "unpkg": "./progressspinner.min.js",
     "types": "./progressspinner.d.ts",
+    "exports": {
+        ".": {
+            "types": "./progressspinner.d.ts",
+            "module": "./progressspinner.esm.js",
+            "import": "./progressspinner.esm.js",
+            "require": "./progressspinner.cjs.js",
+            "default": "./progressspinner.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/radiobutton/package.json
+++ b/components/lib/radiobutton/package.json
@@ -3,5 +3,15 @@
     "module": "./radiobutton.esm.js",
     "unpkg": "./radiobutton.min.js",
     "types": "./radiobutton.d.ts",
+    "exports": {
+        ".": {
+            "types": "./radiobutton.d.ts",
+            "module": "./radiobutton.esm.js",
+            "import": "./radiobutton.esm.js",
+            "require": "./radiobutton.cjs.js",
+            "default": "./radiobutton.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/rating/package.json
+++ b/components/lib/rating/package.json
@@ -3,5 +3,15 @@
     "module": "./rating.esm.js",
     "unpkg": "./rating.min.js",
     "types": "./rating.d.ts",
+    "exports": {
+        ".": {
+            "types": "./rating.d.ts",
+            "module": "./rating.esm.js",
+            "import": "./rating.esm.js",
+            "require": "./rating.cjs.js",
+            "default": "./rating.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/ripple/package.json
+++ b/components/lib/ripple/package.json
@@ -3,5 +3,15 @@
     "module": "./ripple.esm.js",
     "unpkg": "./ripple.min.js",
     "types": "./ripple.d.ts",
+    "exports": {
+        ".": {
+            "types": "./ripple.d.ts",
+            "module": "./ripple.esm.js",
+            "import": "./ripple.esm.js",
+            "require": "./ripple.cjs.js",
+            "default": "./ripple.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/row/package.json
+++ b/components/lib/row/package.json
@@ -3,5 +3,15 @@
     "module": "./row.esm.js",
     "unpkg": "./row.min.js",
     "types": "./row.d.ts",
+    "exports": {
+        ".": {
+            "types": "./row.d.ts",
+            "module": "./row.esm.js",
+            "import": "./row.esm.js",
+            "require": "./row.cjs.js",
+            "default": "./row.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/scrollpanel/package.json
+++ b/components/lib/scrollpanel/package.json
@@ -3,5 +3,15 @@
     "module": "./scrollpanel.esm.js",
     "unpkg": "./scrollpanel.min.js",
     "types": "./scrollpanel.d.ts",
+    "exports": {
+        ".": {
+            "types": "./scrollpanel.d.ts",
+            "module": "./scrollpanel.esm.js",
+            "import": "./scrollpanel.esm.js",
+            "require": "./scrollpanel.cjs.js",
+            "default": "./scrollpanel.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/scrolltop/package.json
+++ b/components/lib/scrolltop/package.json
@@ -3,5 +3,15 @@
     "module": "./scrolltop.esm.js",
     "unpkg": "./scrolltop.min.js",
     "types": "./scrolltop.d.ts",
+    "exports": {
+        ".": {
+            "types": "./scrolltop.d.ts",
+            "module": "./scrolltop.esm.js",
+            "import": "./scrolltop.esm.js",
+            "require": "./scrolltop.cjs.js",
+            "default": "./scrolltop.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/selectbutton/package.json
+++ b/components/lib/selectbutton/package.json
@@ -3,5 +3,15 @@
     "module": "./selectbutton.esm.js",
     "unpkg": "./selectbutton.min.js",
     "types": "./selectbutton.d.ts",
+    "exports": {
+        ".": {
+            "types": "./selectbutton.d.ts",
+            "module": "./selectbutton.esm.js",
+            "import": "./selectbutton.esm.js",
+            "require": "./selectbutton.cjs.js",
+            "default": "./selectbutton.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/selectitem/package.json
+++ b/components/lib/selectitem/package.json
@@ -1,4 +1,10 @@
 {
     "types": "./selectitem.d.ts",
+    "exports": {
+        ".": {
+            "types": "./selectitem.d.ts"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/sidebar/package.json
+++ b/components/lib/sidebar/package.json
@@ -3,5 +3,15 @@
     "module": "./sidebar.esm.js",
     "unpkg": "./sidebar.min.js",
     "types": "./sidebar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./sidebar.d.ts",
+            "module": "./sidebar.esm.js",
+            "import": "./sidebar.esm.js",
+            "require": "./sidebar.cjs.js",
+            "default": "./sidebar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/skeleton/package.json
+++ b/components/lib/skeleton/package.json
@@ -3,5 +3,15 @@
     "module": "./skeleton.esm.js",
     "unpkg": "./skeleton.min.js",
     "types": "./skeleton.d.ts",
+    "exports": {
+        ".": {
+            "types": "./skeleton.d.ts",
+            "module": "./skeleton.esm.js",
+            "import": "./skeleton.esm.js",
+            "require": "./skeleton.cjs.js",
+            "default": "./skeleton.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/slidemenu/package.json
+++ b/components/lib/slidemenu/package.json
@@ -3,5 +3,15 @@
     "module": "./slidemenu.esm.js",
     "unpkg": "./slidemenu.min.js",
     "types": "./slidemenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./slidemenu.d.ts",
+            "module": "./slidemenu.esm.js",
+            "import": "./slidemenu.esm.js",
+            "require": "./slidemenu.cjs.js",
+            "default": "./slidemenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/slider/package.json
+++ b/components/lib/slider/package.json
@@ -3,5 +3,15 @@
     "module": "./slider.esm.js",
     "unpkg": "./slider.min.js",
     "types": "./slider.d.ts",
+    "exports": {
+        ".": {
+            "types": "./slider.d.ts",
+            "module": "./slider.esm.js",
+            "import": "./slider.esm.js",
+            "require": "./slider.cjs.js",
+            "default": "./slider.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/speeddial/package.json
+++ b/components/lib/speeddial/package.json
@@ -3,5 +3,15 @@
     "module": "./speeddial.esm.js",
     "unpkg": "./speeddial.min.js",
     "types": "./speeddial.d.ts",
+    "exports": {
+        ".": {
+            "types": "./speeddial.d.ts",
+            "module": "./speeddial.esm.js",
+            "import": "./speeddial.esm.js",
+            "require": "./speeddial.cjs.js",
+            "default": "./speeddial.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/splitbutton/package.json
+++ b/components/lib/splitbutton/package.json
@@ -3,5 +3,15 @@
     "module": "./splitbutton.esm.js",
     "unpkg": "./splitbutton.min.js",
     "types": "./splitbutton.d.ts",
+    "exports": {
+        ".": {
+            "types": "./splitbutton.d.ts",
+            "module": "./splitbutton.esm.js",
+            "import": "./splitbutton.esm.js",
+            "require": "./splitbutton.cjs.js",
+            "default": "./splitbutton.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/splitter/package.json
+++ b/components/lib/splitter/package.json
@@ -3,5 +3,15 @@
     "module": "./splitter.esm.js",
     "unpkg": "./splitter.min.js",
     "types": "./splitter.d.ts",
+    "exports": {
+        ".": {
+            "types": "./splitter.d.ts",
+            "module": "./splitter.esm.js",
+            "import": "./splitter.esm.js",
+            "require": "./splitter.cjs.js",
+            "default": "./splitter.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/steps/package.json
+++ b/components/lib/steps/package.json
@@ -3,5 +3,15 @@
     "module": "./steps.esm.js",
     "unpkg": "./steps.min.js",
     "types": "./steps.d.ts",
+    "exports": {
+        ".": {
+            "types": "./steps.d.ts",
+            "module": "./steps.esm.js",
+            "import": "./steps.esm.js",
+            "require": "./steps.cjs.js",
+            "default": "./steps.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/styleclass/package.json
+++ b/components/lib/styleclass/package.json
@@ -3,5 +3,15 @@
     "module": "./styleclass.esm.js",
     "unpkg": "./styleclass.min.js",
     "types": "./styleclass.d.ts",
+    "exports": {
+        ".": {
+            "types": "./styleclass.d.ts",
+            "module": "./styleclass.esm.js",
+            "import": "./styleclass.esm.js",
+            "require": "./styleclass.cjs.js",
+            "default": "./styleclass.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tabmenu/package.json
+++ b/components/lib/tabmenu/package.json
@@ -3,5 +3,15 @@
     "module": "./tabmenu.esm.js",
     "unpkg": "./tabmenu.min.js",
     "types": "./tabmenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tabmenu.d.ts",
+            "module": "./tabmenu.esm.js",
+            "import": "./tabmenu.esm.js",
+            "require": "./tabmenu.cjs.js",
+            "default": "./tabmenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tabview/package.json
+++ b/components/lib/tabview/package.json
@@ -3,5 +3,15 @@
     "module": "./tabview.esm.js",
     "unpkg": "./tabview.min.js",
     "types": "./tabview.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tabview.d.ts",
+            "module": "./tabview.esm.js",
+            "import": "./tabview.esm.js",
+            "require": "./tabview.cjs.js",
+            "default": "./tabview.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tag/package.json
+++ b/components/lib/tag/package.json
@@ -3,5 +3,15 @@
     "module": "./tag.esm.js",
     "unpkg": "./tag.min.js",
     "types": "./tag.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tag.d.ts",
+            "module": "./tag.esm.js",
+            "import": "./tag.esm.js",
+            "require": "./tag.cjs.js",
+            "default": "./tag.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/terminal/package.json
+++ b/components/lib/terminal/package.json
@@ -1,7 +1,17 @@
 {
-  "main": "./terminal.cjs.js",
-  "module": "./terminal.esm.js",
-  "unpkg": "./terminal.min.js",
-  "types": "./terminal.d.ts",
+    "main": "./terminal.cjs.js",
+    "module": "./terminal.esm.js",
+    "unpkg": "./terminal.min.js",
+    "types": "./terminal.d.ts",
+    "exports": {
+        ".": {
+            "types": "./terminal.d.ts",
+            "module": "./terminal.esm.js",
+            "import": "./terminal.esm.js",
+            "require": "./terminal.cjs.js",
+            "default": "./terminal.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/terminalservice/package.json
+++ b/components/lib/terminalservice/package.json
@@ -1,7 +1,17 @@
 {
-  "main": "./terminalservice.cjs.js",
-  "module": "./terminalservice.esm.js",
-  "unpkg": "./terminalservice.min.js",
-  "types": "./terminalservice.d.ts",
+    "main": "./terminalservice.cjs.js",
+    "module": "./terminalservice.esm.js",
+    "unpkg": "./terminalservice.min.js",
+    "types": "./terminalservice.d.ts",
+    "exports": {
+        ".": {
+            "types": "./terminalservice.d.ts",
+            "module": "./terminalservice.esm.js",
+            "import": "./terminalservice.esm.js",
+            "require": "./terminalservice.cjs.js",
+            "default": "./terminalservice.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tieredmenu/package.json
+++ b/components/lib/tieredmenu/package.json
@@ -3,5 +3,15 @@
     "module": "./tieredmenu.esm.js",
     "unpkg": "./tieredmenu.min.js",
     "types": "./tieredmenu.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tieredmenu.d.ts",
+            "module": "./tieredmenu.esm.js",
+            "import": "./tieredmenu.esm.js",
+            "require": "./tieredmenu.cjs.js",
+            "default": "./tieredmenu.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/timeline/package.json
+++ b/components/lib/timeline/package.json
@@ -3,5 +3,15 @@
     "module": "./timeline.esm.js",
     "unpkg": "./timeline.min.js",
     "types": "./timeline.d.ts",
+    "exports": {
+        ".": {
+            "types": "./timeline.d.ts",
+            "module": "./timeline.esm.js",
+            "import": "./timeline.esm.js",
+            "require": "./timeline.cjs.js",
+            "default": "./timeline.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/toast/package.json
+++ b/components/lib/toast/package.json
@@ -3,5 +3,15 @@
     "module": "./toast.esm.js",
     "unpkg": "./toast.min.js",
     "types": "./toast.d.ts",
+    "exports": {
+        ".": {
+            "types": "./toast.d.ts",
+            "module": "./toast.esm.js",
+            "import": "./toast.esm.js",
+            "require": "./toast.cjs.js",
+            "default": "./toast.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/togglebutton/package.json
+++ b/components/lib/togglebutton/package.json
@@ -3,5 +3,15 @@
     "module": "./togglebutton.esm.js",
     "unpkg": "./togglebutton.min.js",
     "types": "./togglebutton.d.ts",
+    "exports": {
+        ".": {
+            "types": "./togglebutton.d.ts",
+            "module": "./togglebutton.esm.js",
+            "import": "./togglebutton.esm.js",
+            "require": "./togglebutton.cjs.js",
+            "default": "./togglebutton.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/toolbar/package.json
+++ b/components/lib/toolbar/package.json
@@ -3,5 +3,15 @@
     "module": "./toolbar.esm.js",
     "unpkg": "./toolbar.min.js",
     "types": "./toolbar.d.ts",
+    "exports": {
+        ".": {
+            "types": "./toolbar.d.ts",
+            "module": "./toolbar.esm.js",
+            "import": "./toolbar.esm.js",
+            "require": "./toolbar.cjs.js",
+            "default": "./toolbar.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tooltip/package.json
+++ b/components/lib/tooltip/package.json
@@ -3,5 +3,15 @@
     "module": "./tooltip.esm.js",
     "unpkg": "./tooltip.min.js",
     "types": "./tooltip.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tooltip.d.ts",
+            "module": "./tooltip.esm.js",
+            "import": "./tooltip.esm.js",
+            "require": "./tooltip.cjs.js",
+            "default": "./tooltip.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tree/package.json
+++ b/components/lib/tree/package.json
@@ -3,5 +3,15 @@
     "module": "./tree.esm.js",
     "unpkg": "./tree.min.js",
     "types": "./tree.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tree.d.ts",
+            "module": "./tree.esm.js",
+            "import": "./tree.esm.js",
+            "require": "./tree.cjs.js",
+            "default": "./tree.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/treenode/package.json
+++ b/components/lib/treenode/package.json
@@ -1,4 +1,10 @@
 {
     "types": "./treenode.d.ts",
+    "exports": {
+        ".": {
+            "types": "./treenode.d.ts"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/treeselect/package.json
+++ b/components/lib/treeselect/package.json
@@ -3,5 +3,15 @@
     "module": "./treeselect.esm.js",
     "unpkg": "./treeselect.min.js",
     "types": "./treeselect.d.ts",
+    "exports": {
+        ".": {
+            "types": "./treeselect.d.ts",
+            "module": "./treeselect.esm.js",
+            "import": "./treeselect.esm.js",
+            "require": "./treeselect.cjs.js",
+            "default": "./treeselect.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/treetable/package.json
+++ b/components/lib/treetable/package.json
@@ -3,5 +3,15 @@
     "module": "./treetable.esm.js",
     "unpkg": "./treetable.min.js",
     "types": "./treetable.d.ts",
+    "exports": {
+        ".": {
+            "types": "./treetable.d.ts",
+            "module": "./treetable.esm.js",
+            "import": "./treetable.esm.js",
+            "require": "./treetable.cjs.js",
+            "default": "./treetable.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/tristatecheckbox/package.json
+++ b/components/lib/tristatecheckbox/package.json
@@ -3,5 +3,15 @@
     "module": "./tristatecheckbox.esm.js",
     "unpkg": "./tristatecheckbox.min.js",
     "types": "./tristatecheckbox.d.ts",
+    "exports": {
+        ".": {
+            "types": "./tristatecheckbox.d.ts",
+            "module": "./tristatecheckbox.esm.js",
+            "import": "./tristatecheckbox.esm.js",
+            "require": "./tristatecheckbox.cjs.js",
+            "default": "./tristatecheckbox.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/utils/package.json
+++ b/components/lib/utils/package.json
@@ -3,5 +3,15 @@
     "module": "./utils.esm.js",
     "unpkg": "./utils.min.js",
     "types": "./utils.d.ts",
+    "exports": {
+        ".": {
+            "types": "./utils.d.ts",
+            "module": "./utils.esm.js",
+            "import": "./utils.esm.js",
+            "require": "./utils.cjs.js",
+            "default": "./utils.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/components/lib/virtualscroller/package.json
+++ b/components/lib/virtualscroller/package.json
@@ -3,5 +3,15 @@
     "module": "./virtualscroller.esm.js",
     "unpkg": "./virtualscroller.min.js",
     "types": "./virtualscroller.d.ts",
+    "exports": {
+        ".": {
+            "types": "./virtualscroller.d.ts",
+            "module": "./virtualscroller.esm.js",
+            "import": "./virtualscroller.esm.js",
+            "require": "./virtualscroller.cjs.js",
+            "default": "./virtualscroller.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "sideEffects": false
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -223,6 +223,7 @@ function addEntry(name, input, output, isComponent = true) {
     };
 
     entries.push(get_CJS_ESM());
+
     if (!NPM_LINK) {
         entries.push(get_IIFE());
 
@@ -369,6 +370,15 @@ function addPackageJson() {
     "main": "primereact.all.min.js",
     "module": "primereact.all.esm.min.js",
     "web-types": "web-types.json",
+    "exports": {
+        ".": {
+            "module": "./primereact.all.esm.min.js",
+            "import": "./primereact.all.esm.min.js",
+            "require": "./primereact.all.min.js",
+            "default": "./primereact.all.min.js"
+        },
+        "./package.json": "./package.json"
+    },
     "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",


### PR DESCRIPTION
Fix #4675: Improved bundler support for ESM/SSR
Fix #4253: Better IDE understanding of components

After reading this guide: https://github.com/frehner/modern-guide-to-packaging-js-library

And following what the Redux team decided to support the most amount of bundlers properly.
