### PR TITLE
Fix #5273: Button plain prop for unstyled

### DIFF
--- a/components/lib/button/ButtonBase.js
+++ b/components/lib/button/ButtonBase.js
@@ -45,6 +45,7 @@ export const ButtonBase = ComponentBase.extend({
         loading: false,
         loadingIcon: null,
         outlined: false,
+        plain: false,
         raised: false,
         rounded: false,
         severity: null,

--- a/components/lib/button/button.d.ts
+++ b/components/lib/button/button.d.ts
@@ -151,6 +151,11 @@ export interface ButtonProps extends Omit<React.DetailedHTMLProps<React.ButtonHT
      */
     loadingIcon?: IconType<ButtonProps> | undefined;
     /**
+     * Add a plain textual class to the button without a background initially.
+     * @defaultValue false
+     */
+    plain?: boolean | undefined;
+    /**
      * Content of the tooltip.
      */
     tooltip?: string | undefined;


### PR DESCRIPTION
Fix #5273: Button plain prop for unstyled