### PR TITLE
fix(InputMask): Paste at Cursor Selection

### DIFF
--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -411,32 +411,19 @@ export const InputMask = React.memo(
             androidChrome.current ? handleAndroidInput(event) : handleInputChange(event);
         };
 
-        const handleInputChange = (e) => {
+        const handleInputChange = (e, isOnPaste = false) => {
             if (props.readOnly) {
                 return;
             }
-
-            let pos = checkVal(true);
-
-            caret(pos);
-            updateModel(e);
-
-            if (props.onComplete && isCompleted()) {
-                props.onComplete({
-                    originalEvent: e,
-                    value: getValue()
-                });
+        
+            if (!isOnPaste) {
+                let pos = checkVal(true);
+        
+                caret(pos);
             }
-        };
-
-        const handlePaste = (e) => {
-            if (props.readOnly) {
-                return;
-            }
-
-            caret();
+        
             updateModel(e);
-
+        
             if (props.onComplete && isCompleted()) {
                 props.onComplete({
                     originalEvent: e,
@@ -623,7 +610,7 @@ export const InputMask = React.memo(
                 onKeyDown={onKeyDown}
                 onKeyPress={onKeyPress}
                 onInput={onInput}
-                onPaste={handlePaste}
+                onPaste={(e) => handleInputChange(e, true)}
                 required={props.required}
                 tooltip={props.tooltip}
                 tooltipOptions={props.tooltipOptions}

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -408,7 +408,7 @@ export const InputMask = React.memo(
         };
 
         const onInput = (event) => {
-            androidChrome.current ? handleAndroidInput(event) : (event);
+            androidChrome.current ? handleAndroidInput(event) : handleInputChange(event);
         };
 
         const handleInputChange = (e, isOnPaste = false) => {

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -423,7 +423,7 @@ export const InputMask = React.memo(
             }
         
             updateModel(e);
-        
+
             if (props.onComplete && isCompleted()) {
                 props.onComplete({
                     originalEvent: e,

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -408,20 +408,20 @@ export const InputMask = React.memo(
         };
 
         const onInput = (event) => {
-            androidChrome.current ? handleAndroidInput(event) : handleInputChange(event);
+            androidChrome.current ? handleAndroidInput(event) : (event);
         };
 
         const handleInputChange = (e, isOnPaste = false) => {
             if (props.readOnly) {
                 return;
             }
-        
+
             if (!isOnPaste) {
                 let pos = checkVal(true);
-        
+
                 caret(pos);
             }
-        
+
             updateModel(e);
 
             if (props.onComplete && isCompleted()) {

--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -429,6 +429,22 @@ export const InputMask = React.memo(
             }
         };
 
+        const handlePaste = (e) => {
+            if (props.readOnly) {
+                return;
+            }
+
+            caret();
+            updateModel(e);
+
+            if (props.onComplete && isCompleted()) {
+                props.onComplete({
+                    originalEvent: e,
+                    value: getValue()
+                });
+            }
+        };
+
         const getUnmaskedValue = React.useCallback(() => {
             let unmaskedBuffer = [];
 
@@ -607,7 +623,7 @@ export const InputMask = React.memo(
                 onKeyDown={onKeyDown}
                 onKeyPress={onKeyPress}
                 onInput={onInput}
-                onPaste={handleInputChange}
+                onPaste={handlePaste}
                 required={props.required}
                 tooltip={props.tooltip}
                 tooltipOptions={props.tooltipOptions}


### PR DESCRIPTION
The input mask component currently pastes contents at the first empty value position instead of the cursor selection. Providing an undefined position to the caret function *mostly* fixes this issue because after the paste happens, the cursor is returned to the last empty value position instead of at the end of the newly pasted value.

### Defect Fixes
Fix #5285
