### PR TITLE
Fix #5312: Tooltip left behind on slow machine

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -469,9 +469,7 @@ export const Tooltip = React.memo(
         }, [props.content]);
 
         useUnmountEffect(() => {
-            clearTimeouts();
-            unloadTargetEvents();
-
+            hide();
             ZIndexUtils.clear(elementRef.current);
         });
 


### PR DESCRIPTION
Fix #3965
Fix #5312: Tooltip left behind on slow machine

I tested this with my Google Chrome set to 6x slow and it seems to be working
