### PR TITLE
Fix #5234: IconProps better SVG typescript support

### DIFF
--- a/components/lib/utils/utils.d.ts
+++ b/components/lib/utils/utils.d.ts
@@ -174,7 +174,7 @@ export type IconOptions<ComponentProps, AdditionalProps> = AdditionalProps & {
     /**
      * Icon specific properties.
      */
-    iconProps: React.HTMLProps<HTMLElement | SVGElement>;
+    iconProps: React.HTMLProps<HTMLElement> | React.SVGProps<SVGSVGElement>;
     /**
      * The element representing the icon.
      */


### PR DESCRIPTION
Fix #5234: IconProps better SVG typescript support