### PR TITLE
fix: #5349, PanelMenu: Menu items with no sub-items toggling border

### DIFF
--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -209,7 +209,7 @@ export const PanelMenu = React.memo(
 
             const menuContentProps = mergeProps(
                 {
-                    className: cx('menuContent')
+                    className: cx('menuContent', { item })
                 },
                 getPTOptions(item, 'menuContent')
             );

--- a/components/lib/panelmenu/PanelMenuBase.js
+++ b/components/lib/panelmenu/PanelMenuBase.js
@@ -8,7 +8,7 @@ const classes = {
     headerAction: 'p-panelmenu-header-link',
     panel: ({ item }) => classNames('p-panelmenu-panel', item.className),
     header: ({ active, item }) => classNames('p-component p-panelmenu-header', { 'p-highlight': active, 'p-disabled': item.disabled }),
-    menuContent: 'p-panelmenu-content',
+    menuContent: ({ item }) => classNames({'p-panelmenu-content': item && item.items && item.items.length}),
     root: ({ props }) => classNames('p-panelmenu p-component', props.className),
     separator: 'p-menu-separator',
     toggleableContent: ({ active }) =>

--- a/components/lib/panelmenu/PanelMenuBase.js
+++ b/components/lib/panelmenu/PanelMenuBase.js
@@ -8,7 +8,7 @@ const classes = {
     headerAction: 'p-panelmenu-header-link',
     panel: ({ item }) => classNames('p-panelmenu-panel', item.className),
     header: ({ active, item }) => classNames('p-component p-panelmenu-header', { 'p-highlight': active, 'p-disabled': item.disabled }),
-    menuContent: ({ item }) => classNames({'p-panelmenu-content': item && item.items && item.items.length}),
+    menuContent: ({ item }) => classNames({ 'p-panelmenu-content': item && item.items && item.items.length }),
     root: ({ props }) => classNames('p-panelmenu p-component', props.className),
     separator: 'p-menu-separator',
     toggleableContent: ({ active }) =>


### PR DESCRIPTION
### Defect Fixes
fix: #5349, PanelMenu: Menu items with no sub-items toggling border
