### PR TITLE
Fix #5370: TreeTable highlight selection in Checkbox mode

### DIFF
--- a/components/lib/treetable/TreeTableRow.js
+++ b/components/lib/treetable/TreeTableRow.js
@@ -332,8 +332,11 @@ export const TreeTableRow = React.memo((props) => {
     };
 
     const isSelected = () => {
-        if ((props.selectionMode === 'single' || props.selectionMode === 'multiple') && props.selectionKeys) return props.selectionMode === 'single' ? props.selectionKeys === props.node.key : props.selectionKeys[props.node.key] !== undefined;
-        else return false;
+        if (props.selectionMode === 'single' || ((props.selectionMode === 'multiple' || props.selectionMode === 'checkbox') && props.selectionKeys)) {
+            return props.selectionMode === 'single' ? props.selectionKeys === props.node.key : props.selectionKeys[props.node.key] !== undefined;
+        }
+
+        return false;
     };
 
     const isChecked = () => {


### PR DESCRIPTION
Fix #5370: TreeTable highlight selection in Checkbox mode

Similar to how PrimeNG TreeTable does highlight for checkbox mode: https://primeng.org/treetable#checkbox