### PR TITLE
Fix #2666: Fix overlay components in cell editor

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -58,7 +58,10 @@ export const BodyCell = React.memo((props) => {
         type: 'click',
         listener: (e) => {
             if (!selfClick.current && isOutsideClicked(e.target)) {
-                switchCellToViewMode(e, true);
+                // #2666 for overlay components and outside is clicked
+                setTimeout(() => {
+                    switchCellToViewMode(e, true);
+                }, 0);
             }
 
             selfClick.current = false;


### PR DESCRIPTION
Fix #2666: Fix overlay components in cell editor

Fix #5320 DataTable support Dropdown in cell edit mode
Fix #3079
Fix #2097

What is happening:

1. Item in dropdown is clicked
2. cellEditValidator fires
3. onCellEditComplete fires
4. `onChange` on dropdown component fires

So the dropdown `editorCallback` doesn't get called until the end and its too late.  By using setTimeout(0) it changes the order to this...

1. Item in dropdown is clicked
2. `onChange` on dropdown component fires
3. cellEditValidator fires
4. onCellEditComplete fires