### PR TITLE
Fix #5340: MutliSelect emptyMessage don't add to DOM

### DIFF
--- a/components/lib/multiselect/MultiSelectBase.js
+++ b/components/lib/multiselect/MultiSelectBase.js
@@ -214,6 +214,7 @@ export const MultiSelectBase = ComponentBase.extend({
         disabled: false,
         display: 'comma',
         dropdownIcon: null,
+        emptyMessage: null,
         emptyFilterMessage: null,
         filter: false,
         filterBy: null,


### PR DESCRIPTION
Fix #5340: MutliSelect emptyMessage don't add to DOM