### PR TITLE
Fix #5414: p-disabled for svg icons

### DIFF
--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -265,7 +265,8 @@ svg.p-icon {
     pointer-events: auto;
 }
 
-svg.p-icon g {
+svg.p-icon g,
+.p-disabled svg.p-icon {
     pointer-events: none;
 }
 


### PR DESCRIPTION
Fix #5414: p-disabled for svg icons