### PR TITLE
Fix #5427: TreeTable invalid DOM props

### DIFF
--- a/components/lib/treetable/TreeTableHeader.js
+++ b/components/lib/treetable/TreeTableHeader.js
@@ -331,7 +331,7 @@ export const TreeTableHeader = React.memo((props) => {
                 {
                     className: cx('headerContent')
                 },
-                getColumnPTOptions('headerContent')
+                getColumnPTOptions(column, 'headerContent')
             );
 
             const header = (


### PR DESCRIPTION
Fix #5427: TreeTable invalid DOM props