### PR TITLE
Fix #5447: TreeSelect don't close panel on unselect

### DIFF
--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -140,6 +140,7 @@ export const TreeSelect = React.memo(
 
         const onNodeUnselect = (node) => {
             props.onNodeUnselect && props.onNodeUnselect(node);
+            isCheckboxSelectionMode && node.originalEvent.stopPropagation();
         };
 
         const onNodeToggle = (e) => {


### PR DESCRIPTION
Fix #5447: TreeSelect don't close panel on unselect