### PR TITLE
Support `roundingMode` for InputNumber

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -59,7 +59,7 @@ export const InputNumber = React.memo(
                 useGrouping: props.useGrouping,
                 minimumFractionDigits: props.minFractionDigits,
                 maximumFractionDigits: props.maxFractionDigits,
-                roundingMode: props.roundingMode,
+                roundingMode: props.roundingMode
             };
         };
 
@@ -110,7 +110,7 @@ export const InputNumber = React.memo(
                     currencyDisplay: props.currencyDisplay,
                     minimumFractionDigits: 0,
                     maximumFractionDigits: 0,
-                    roundingMode: props.roundingMode,
+                    roundingMode: props.roundingMode
                 });
 
                 return new RegExp(`[${formatter.format(1).replace(/\s/g, '').replace(_numeral.current, '').replace(_group.current, '')}]`, 'g');
@@ -141,7 +141,7 @@ export const InputNumber = React.memo(
                     currencyDisplay: props.currencyDisplay,
                     minimumFractionDigits: 0,
                     maximumFractionDigits: 0,
-                    roundingMode: props.roundingMode,
+                    roundingMode: props.roundingMode
                 });
 
                 suffixChar.current = formatter.format(1).split('1')[1];

--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -58,7 +58,8 @@ export const InputNumber = React.memo(
                 currencyDisplay: props.currencyDisplay,
                 useGrouping: props.useGrouping,
                 minimumFractionDigits: props.minFractionDigits,
-                maximumFractionDigits: props.maxFractionDigits
+                maximumFractionDigits: props.maxFractionDigits,
+                roundingMode: props.roundingMode,
             };
         };
 
@@ -108,7 +109,8 @@ export const InputNumber = React.memo(
                     currency: props.currency,
                     currencyDisplay: props.currencyDisplay,
                     minimumFractionDigits: 0,
-                    maximumFractionDigits: 0
+                    maximumFractionDigits: 0,
+                    roundingMode: props.roundingMode,
                 });
 
                 return new RegExp(`[${formatter.format(1).replace(/\s/g, '').replace(_numeral.current, '').replace(_group.current, '')}]`, 'g');
@@ -138,7 +140,8 @@ export const InputNumber = React.memo(
                     currency: props.currency,
                     currencyDisplay: props.currencyDisplay,
                     minimumFractionDigits: 0,
-                    maximumFractionDigits: 0
+                    maximumFractionDigits: 0,
+                    roundingMode: props.roundingMode,
                 });
 
                 suffixChar.current = formatter.format(1).split('1')[1];

--- a/components/lib/inputnumber/InputNumberBase.js
+++ b/components/lib/inputnumber/InputNumberBase.js
@@ -171,6 +171,7 @@ export const InputNumberBase = ComponentBase.extend({
         prefix: null,
         readOnly: false,
         required: false,
+        roundingMode: undefined,
         showButtons: false,
         size: null,
         step: 1,

--- a/components/lib/inputnumber/inputnumber.d.ts
+++ b/components/lib/inputnumber/inputnumber.d.ts
@@ -16,16 +16,7 @@ import { TooltipOptions } from '../tooltip/tooltipoptions';
 import { FormEvent } from '../ts-helpers';
 import { IconType, PassThroughType } from '../utils/utils';
 
-export declare type RoundingMode = 
-    | 'ceil' 
-    | 'floor' 
-    | 'expand' 
-    | 'trunc' 
-    | 'halfCeil' 
-    | 'halfFloor' 
-    | 'halfExpand' 
-    | 'halfTrunc' 
-    | 'halfEven';
+export declare type RoundingMode = 'ceil' | 'floor' | 'expand' | 'trunc' | 'halfCeil' | 'halfFloor' | 'halfExpand' | 'halfTrunc' | 'halfEven';
 
 export declare type InputNumberPassThroughType<T> = PassThroughType<T, InputNumberPassThroughMethodOptions>;
 

--- a/components/lib/inputnumber/inputnumber.d.ts
+++ b/components/lib/inputnumber/inputnumber.d.ts
@@ -16,6 +16,17 @@ import { TooltipOptions } from '../tooltip/tooltipoptions';
 import { FormEvent } from '../ts-helpers';
 import { IconType, PassThroughType } from '../utils/utils';
 
+export declare type RoundingMode = 
+    | 'ceil' 
+    | 'floor' 
+    | 'expand' 
+    | 'trunc' 
+    | 'halfCeil' 
+    | 'halfFloor' 
+    | 'halfExpand' 
+    | 'halfTrunc' 
+    | 'halfEven';
+
 export declare type InputNumberPassThroughType<T> = PassThroughType<T, InputNumberPassThroughMethodOptions>;
 
 /**
@@ -190,6 +201,11 @@ export interface InputNumberProps extends Omit<React.DetailedHTMLProps<React.HTM
      * the default for currency formatting is the larger of minimumFractionDigits and the number of minor unit digits provided by the [ISO 4217 currency code list](https://www.six-group.com/en/products-services/financial-information/data-standards.html#scrollTo=maintenance-agency) (2 if the list doesn't provide that information).
      */
     maxFractionDigits?: number | undefined;
+    /**
+     * How decimals should be rounded.
+     * The default value is `"halfExpand"`, [further information](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode).
+     */
+    roundingMode?: RoundingMode;
     /**
      * Name of the input element.
      */


### PR DESCRIPTION
### Feature Requests
Support [`roundingMode`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode) for the `InputNumber` component.

https://github.com/orgs/primefaces/discussions/611

Fix #5528