### PR TITLE
Fix #5523: BlockUI return activeElement focus

### DIFF
--- a/components/lib/blockui/BlockUI.js
+++ b/components/lib/blockui/BlockUI.js
@@ -13,6 +13,7 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
     const [visibleState, setVisibleState] = React.useState(props.blocked);
     const elementRef = React.useRef(null);
     const maskRef = React.useRef(null);
+    const activeElementRef = React.useRef(null);
 
     const { ptm, cx, isUnstyled } = BlockUIBase.setMetaData({
         props
@@ -22,13 +23,18 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
 
     const block = () => {
         setVisibleState(true);
+        activeElementRef.current = document.activeElement;
     };
 
     const unblock = () => {
         const callback = () => {
             setVisibleState(false);
 
-            props.fullScreen && DomHandler.unblockBodyScroll();
+            if (props.fullScreen) {
+                DomHandler.unblockBodyScroll();
+                activeElementRef.current && activeElementRef.current.focus();
+            }
+
             props.onUnblocked && props.onUnblocked();
         };
 
@@ -46,7 +52,7 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
     const onPortalMounted = () => {
         if (props.fullScreen) {
             DomHandler.blockBodyScroll();
-            document.activeElement.blur();
+            activeElementRef.current && activeElementRef.current.blur();
         }
 
         if (props.autoZIndex) {
@@ -67,9 +73,7 @@ export const BlockUI = React.forwardRef((inProps, ref) => {
     }, [props.blocked]);
 
     useUnmountEffect(() => {
-        if (props.fullScreen) {
-            DomHandler.unblockBodyScroll();
-        }
+        props.fullScreen && DomHandler.unblockBodyScroll();
 
         ZIndexUtils.clear(maskRef.current);
     });


### PR DESCRIPTION
Fix #5523: BlockUI return activeElement focus