### PR TITLE
Fix #5572: Multselect selectAllLabel was being added to DOM

### DIFF
--- a/components/lib/multiselect/MultiSelectBase.js
+++ b/components/lib/multiselect/MultiSelectBase.js
@@ -260,6 +260,7 @@ export const MultiSelectBase = ComponentBase.extend({
         resetFilterOnHide: false,
         scrollHeight: '200px',
         selectAll: false,
+        selectAllLabel: null,
         selectedItemTemplate: null,
         selectedItemsLabel: '{0} items selected',
         selectionLimit: null,


### PR DESCRIPTION
Fix #5572: Multselect selectAllLabel was being added to DOM