### PR TITLE
Fix #5574: Calendar Tailwind context.selected val

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3708,7 +3708,7 @@ export const Calendar = React.memo(
                                     context: {
                                         year: y,
                                         yearIndex: i,
-                                        selected: isYearSelected(i),
+                                        selected: isYearSelected(y),
                                         disabled: !y.selectable
                                     }
                                 })


### PR DESCRIPTION
Fix #5574: Calendar Tailwind context.selected val