### PR TITLE
Fix #5574: Calendar Tailwind context.selected val

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3659,14 +3659,14 @@ export const Calendar = React.memo(
                                     className: cx('month', { isMonthSelected, isSelectable, i, currentYear }),
                                     onClick: (event) => onMonthSelect(event, i),
                                     onKeyDown: (event) => onMonthCellKeydown(event, i),
-                                    'data-p-disabled': !m.selectable,
+                                    'data-p-disabled': !isSelectable(0, i, currentYear),
                                     'data-p-highlight': isMonthSelected(i)
                                 },
                                 ptm('month', {
                                     context: {
                                         month: m,
                                         monthIndex: i,
-                                        disabled: !m.selectable,
+                                        disabled: !isSelectable(0, i, currentYear),
                                         selected: isMonthSelected(i)
                                     }
                                 })


### PR DESCRIPTION
Fix #5574: Calendar Tailwind context.selected val