### PR TITLE
Fix #5584: TreeTable fix custom header not sorting

### DIFF
--- a/components/lib/treetable/TreeTableHeader.js
+++ b/components/lib/treetable/TreeTableHeader.js
@@ -39,7 +39,8 @@ export const TreeTableHeader = React.memo((props) => {
                 DomHandler.getAttribute(targetNode, 'data-p-sortable-column') === true ||
                 DomHandler.getAttribute(targetNode, 'data-pc-section') === 'headertitle' ||
                 DomHandler.getAttribute(targetNode, 'data-pc-section') === 'sorticon' ||
-                DomHandler.getAttribute(targetNode.parentElement, 'data-pc-section') === 'sorticon'
+                DomHandler.getAttribute(targetNode.parentElement, 'data-pc-section') === 'sorticon' ||
+                (targetNode.closest('[data-p-sortable-column="true"]') && !targetNode.closest('[data-pc-section="filtermenubutton"]'))
             ) {
                 props.onSort({
                     originalEvent: event,


### PR DESCRIPTION
Fix #5584: TreeTable fix custom header not sorting