### PR TITLE
feat:CascadeSelect support scroll in container

### DIFF
--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -235,28 +235,28 @@ export const CascadeSelect = React.memo(
                 const selector = `${attributeSelectorState}_panel`;
                 const innerHTML = `
 @media screen and (max-width: ${props.breakpoint}) {
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-items-wrapper > ul {
+    [data-pc-section="panel"][${selector}] [data-pc-section="wrapper"] > ul {
         max-height: ${props.scrollHeight};
         overflow: ${props.scrollHeight ? 'auto' : ''};
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist-wrapper {
+    [data-pc-section="panel"][${selector}] [data-pc-section="sublistwrapper"] {
         position:relative;
         left:0;
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist {
+    [data-pc-section="panel"][${selector}] [data-pc-section="sublist"] {
         overflow: hidden !important;
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-item-active  .p-cascadeselect-sublist {
+    [data-pc-section="panel"][${selector}] [data-pc-section="item"][data-p-active="true"] > [data-pc-section="sublistwrapper"] > [data-pc-section="sublist"] {
         left: 0;
         box-shadow: none;
         border-radius: 0;
         padding: 0 0 0 calc(var(--inline-spacing) * 2); /* @todo */
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-group-icon:before {
+    [data-pc-section="panel"][${selector}] [data-pc-section="optiongroupicon"]:before {
         content: "\\e930";
     }
 }

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -235,28 +235,28 @@ export const CascadeSelect = React.memo(
                 const selector = `${attributeSelectorState}_panel`;
                 const innerHTML = `
 @media screen and (max-width: ${props.breakpoint}) {
-    [data-pc-section="panel"][${selector}] [data-pc-section="wrapper"] > ul {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-items-wrapper > ul {
         max-height: ${props.scrollHeight};
         overflow: ${props.scrollHeight ? 'auto' : ''};
     }
 
-    [data-pc-section="panel"][${selector}] [data-pc-section="sublistwrapper"] {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist-wrapper {
         position:relative;
         left:0 !important;
     }
 
-    [data-pc-section="panel"][${selector}] [data-pc-section="sublist"] {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist {
         overflow: hidden !important;
     }
 
-    [data-pc-section="panel"][${selector}] [data-pc-section="item"][data-p-active="true"] > [data-pc-section="sublistwrapper"] > [data-pc-section="sublist"] {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-item-active  .p-cascadeselect-sublist {
         left: 0;
         box-shadow: none;
         border-radius: 0;
         padding: 0 0 0 calc(var(--inline-spacing) * 2); /* @todo */
     }
 
-    [data-pc-section="panel"][${selector}] [data-pc-section="optiongroupicon"]:before {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-group-icon:before {
         content: "\\e930";
     }
 }

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -240,11 +240,16 @@ export const CascadeSelect = React.memo(
         overflow: ${props.scrollHeight ? 'auto' : ''};
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist {
-        position: relative;
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist-wrapper {
+        position:relative;
+        left:0;
     }
 
-    .p-cascadeselect-panel[${selector}] .p-cascadeselect-item-active > .p-cascadeselect-sublist {
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-sublist {
+        overflow: hidden !important;
+    }
+
+    .p-cascadeselect-panel[${selector}] .p-cascadeselect-item-active  .p-cascadeselect-sublist {
         left: 0;
         box-shadow: none;
         border-radius: 0;

--- a/components/lib/cascadeselect/CascadeSelect.js
+++ b/components/lib/cascadeselect/CascadeSelect.js
@@ -242,7 +242,7 @@ export const CascadeSelect = React.memo(
 
     [data-pc-section="panel"][${selector}] [data-pc-section="sublistwrapper"] {
         position:relative;
-        left:0;
+        left:0 !important;
     }
 
     [data-pc-section="panel"][${selector}] [data-pc-section="sublist"] {

--- a/components/lib/cascadeselect/CascadeSelectBase.js
+++ b/components/lib/cascadeselect/CascadeSelectBase.js
@@ -24,6 +24,7 @@ const classes = {
             'p-input-filled': (context && context.inputStyle === 'filled') || PrimeReact.inputStyle === 'filled',
             'p-ripple-disabled': (context && context.ripple === false) || PrimeReact.ripple === false
         }),
+    sublistWrapper: 'p-cascadeselect-sublist-wrapper',
     sublist: 'p-cascadeselect-panel p-cascadeselect-items p-cascadeselect-sublist',
     item: ({ option, isGroup, isSelected }) =>
         classNames('p-cascadeselect-item', {
@@ -75,11 +76,6 @@ const styles = `
         min-width: 100%;
     }
     
-    .p-cascadeselect-panel {
-        position: absolute;
-        top: 0;
-        left: 0;
-    }
     
     .p-cascadeselect-item {
         cursor: pointer;
@@ -113,7 +109,7 @@ const styles = `
         width: 1%;
     }
     
-    .p-cascadeselect-sublist {
+    .p-cascadeselect-sublist-wrapper {
         position: absolute;
         min-width: 100%;
         z-index: 1;
@@ -124,7 +120,7 @@ const styles = `
         overflow: visible;
     }
     
-    .p-cascadeselect-item-active > .p-cascadeselect-sublist {
+    .p-cascadeselect-item-active > .p-cascadeselect-sublist-wrapper {
         display: block;
         left: 100%;
         top: 0;

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -168,9 +168,9 @@ export const CascadeSelectSub = React.memo((props) => {
             activeOption && setActiveOptionState(activeOption);
         }
 
-        if (!props.root) {
-            position();
-        }
+        // if (!props.root) {
+        //     position();
+        // }
     });
 
     useUpdateEffect(() => {
@@ -268,16 +268,34 @@ export const CascadeSelectSub = React.memo((props) => {
         return props.options ? props.options.map(createOption) : null;
     };
 
-    const submenu = createMenu();
-    const listProps = mergeProps(
-        {
-            ref: elementRef,
-            className: cx(props.level === 0 ? 'list' : 'sublist', { context }),
-            role: 'listbox',
-            'aria-orientation': 'horizontal'
-        },
-        props.level === 0 ? getPTOptions('list') : getPTOptions('sublist')
-    );
+    const createList = () => {
+        const listProps = mergeProps(
+            {
+                ref: elementRef,
+                className: cx(props.level === 0 ? 'list' : 'sublist', { context }),
+                role: 'listbox',
+                'aria-orientation': 'horizontal'
+            },
+            props.level === 0 ? getPTOptions('list') : getPTOptions('sublist')
+        );
+        const submenu = createMenu();
 
-    return <ul {...listProps}>{submenu}</ul>;
+        return <ul {...listProps}>{submenu}</ul>;
+    };
+
+    const createElement = () => {
+        const list = createList();
+        const listWrapperProps = mergeProps(
+            {
+                className: cx('sublistWrapper')
+            },
+            getPTOptions('sublistWrapper')
+        );
+
+        return props.level === 0 ? list : <div {...listWrapperProps}>{list}</div>;
+    };
+
+    const element = createElement();
+
+    return element;
 });

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -25,7 +25,7 @@ export const CascadeSelectSub = React.memo((props) => {
         const itemOuterWidth = DomHandler.getOuterWidth(parentItem.children[0]);
 
         if (parseInt(containerOffset.left, 10) + itemOuterWidth + sublistWidth > viewport.width - DomHandler.calculateScrollbarWidth()) {
-            elementRef.current.parentElement.style.left = -100 * props.level + '%';
+            elementRef.current.parentElement.style.left = '-100%';
         }
     };
 

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -18,14 +18,14 @@ export const CascadeSelectSub = React.memo((props) => {
     };
 
     const position = () => {
-        const parentItem = elementRef.current.parentElement;
+        const parentItem = elementRef.current.parentElement.parentElement;
         const containerOffset = DomHandler.getOffset(parentItem);
         const viewport = DomHandler.getViewport();
         const sublistWidth = elementRef.current.offsetParent ? elementRef.current.offsetWidth : DomHandler.getHiddenElementOuterWidth(element);
         const itemOuterWidth = DomHandler.getOuterWidth(parentItem.children[0]);
 
         if (parseInt(containerOffset.left, 10) + itemOuterWidth + sublistWidth > viewport.width - DomHandler.calculateScrollbarWidth()) {
-            elementRef.current.style.left = '-100%';
+            elementRef.current.parentElement.style.left = -100 * props.level + '%';
         }
     };
 
@@ -168,9 +168,9 @@ export const CascadeSelectSub = React.memo((props) => {
             activeOption && setActiveOptionState(activeOption);
         }
 
-        // if (!props.root) {
-        //     position();
-        // }
+        if (!props.root) {
+            position();
+        }
     });
 
     useUpdateEffect(() => {

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -247,8 +247,7 @@ export const CascadeSelectSub = React.memo((props) => {
                 style: option.style,
                 role: 'none',
                 'data-p-item-group': isGroup,
-                'data-p-highlight': isSelected,
-                'data-p-active': isSelected
+                'data-p-highlight': isSelected
             },
             getPTOptions('item', { selected: isSelected, group: isGroup })
         );

--- a/components/lib/cascadeselect/CascadeSelectSub.js
+++ b/components/lib/cascadeselect/CascadeSelectSub.js
@@ -247,7 +247,8 @@ export const CascadeSelectSub = React.memo((props) => {
                 style: option.style,
                 role: 'none',
                 'data-p-item-group': isGroup,
-                'data-p-highlight': isSelected
+                'data-p-highlight': isSelected,
+                'data-p-active': isSelected
             },
             getPTOptions('item', { selected: isSelected, group: isGroup })
         );

--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -849,10 +849,13 @@ const Tailwind = {
         dropdownButton: {
             className: classNames('flex items-center justify-center shrink-0', 'bg-transparent text-gray-600 dark:text-white/80 w-[3rem] rounded-tr-6 rounded-br-6')
         },
-        panel: 'absolute py-3 bg-white dark:bg-gray-900 border-0 shadow-md',
+        panel: 'py-3 bg-white dark:bg-gray-900 border-0 shadow-md',
         list: 'm-0 sm:p-0 list-none',
+        sublistWrapper: {
+            className: classNames('block absolute left-full top-0', 'min-w-full z-10')
+        },
         sublist: {
-            className: classNames('block absolute left-full top-0', 'min-w-full z-10', 'py-3 bg-white dark:bg-gray-900 border-0 shadow-md')
+            className: classNames('py-3 bg-white dark:bg-gray-900 border-0 shadow-md')
         },
         item: ({ state }) => ({
             className: classNames('cursor-pointer font-normal whitespace-nowrap', 'm-0 border-0 bg-transparent transition-shadow rounded-none', {


### PR DESCRIPTION
Fix #2229 
- [x] code
- [x] test
- [x] pt & tw

## pc
![20231221155417_rec_](https://github.com/primefaces/primereact/assets/25167742/e220049a-8e2a-4c33-8f2a-9d8ad1a0da00)




## mobile & breakpoinits
### before
![20231221160735_rec_](https://github.com/primefaces/primereact/assets/25167742/94ebc999-969a-4c75-8c3b-a21179e17724)

### after
![20231221151204_rec_](https://github.com/primefaces/primereact/assets/25167742/fb26716f-94fb-4d88-b86d-ca98871a04f2)
