### PR TITLE
fix(themes): Update themes - remove border-width TOAST

### DIFF
--- a/public/themes/arya-blue/theme.css
+++ b/public/themes/arya-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1e1e1e;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #64B5F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #383838;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #383838;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #2396f2;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1e1e1e;
     border: 1px solid #383838;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #121212;
     border: 1px solid #383838;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #383838;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #383838;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #383838;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #383838;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-multiselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #383838;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #383838;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #2396f2;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #383838;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #64B5F6;
     border-color: #64B5F6;
   }
-
   .p-treeselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #383838;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-togglebutton.p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #64B5F6;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #64B5F6;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #64B5F6;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #121212;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -2646,7 +2555,6 @@
     background: rgba(100, 181, 246, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -2815,12 +2723,12 @@
     background: #64B5F6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-column-filter-overlay {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-tree {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(35, 150, 242, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #64B5F6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #64B5F6;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #383838;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #383838;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #383838;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #383838;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #383838;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #383838;
   }
-
   .p-sidebar {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #383838;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #93cbf9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -5277,7 +5145,6 @@
     border-color: #64B5F6;
     color: #64B5F6;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #383838;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
     background-color: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #64B5F6;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #64B5F6;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #64B5F6;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #64B5F6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #64B5F6;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #64B5F6;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #64B5F6;
   }

--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1e1e1e;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #81C784;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #383838;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #383838;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #54b358;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1e1e1e;
     border: 1px solid #383838;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #121212;
     border: 1px solid #383838;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #383838;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #383838;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #383838;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #383838;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-multiselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #383838;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #383838;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #54b358;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #383838;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #81C784;
     border-color: #81C784;
   }
-
   .p-treeselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #383838;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-togglebutton.p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #81C784;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #81C784;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #81C784;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #121212;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -2646,7 +2555,6 @@
     background: rgba(129, 199, 132, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -2815,12 +2723,12 @@
     background: #81C784;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-column-filter-overlay {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-tree {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(84, 179, 88, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #81C784;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #81C784;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #383838;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #383838;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #383838;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #383838;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #383838;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #383838;
   }
-
   .p-sidebar {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #383838;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #a7d8a9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -5277,7 +5145,6 @@
     border-color: #81C784;
     color: #81C784;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #383838;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
     background-color: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #81C784;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #81C784;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #81C784;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #81C784;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #81C784;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #81C784;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #81C784;
   }

--- a/public/themes/arya-orange/theme.css
+++ b/public/themes/arya-orange/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1e1e1e;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #FFD54F;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #383838;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #383838;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #ffc50c;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1e1e1e;
     border: 1px solid #383838;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #121212;
     border: 1px solid #383838;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #383838;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #383838;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #383838;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #383838;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-multiselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #383838;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #383838;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffc50c;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #383838;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #FFD54F;
     border-color: #FFD54F;
   }
-
   .p-treeselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #383838;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-togglebutton.p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #FFD54F;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #FFD54F;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #FFD54F;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #121212;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -2646,7 +2555,6 @@
     background: rgba(255, 213, 79, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -2815,12 +2723,12 @@
     background: #FFD54F;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-column-filter-overlay {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-tree {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(255, 197, 12, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #FFD54F;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #FFD54F;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #383838;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #383838;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #383838;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #383838;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #383838;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #383838;
   }
-
   .p-sidebar {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #383838;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #ffe284;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -5277,7 +5145,6 @@
     border-color: #FFD54F;
     color: #FFD54F;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #383838;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
     background-color: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #FFD54F;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #FFD54F;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #FFD54F;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #FFD54F;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #FFD54F;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #FFD54F;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #FFD54F;
   }

--- a/public/themes/arya-purple/theme.css
+++ b/public/themes/arya-purple/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1e1e1e;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #BA68C8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #383838;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #383838;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #a241b2;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1e1e1e;
     border: 1px solid #383838;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #121212;
     border: 1px solid #383838;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #383838;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #383838;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #383838;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #383838;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-multiselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #383838;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #383838;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #a241b2;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #383838;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #BA68C8;
     border-color: #BA68C8;
   }
-
   .p-treeselect {
     background: #121212;
     border: 1px solid #383838;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #383838;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #383838;
   }
-
   .p-togglebutton.p-button {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #ffffff;
     background: #BA68C8;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #BA68C8;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #BA68C8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #121212;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -2646,7 +2555,6 @@
     background: rgba(186, 104, 200, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -2815,12 +2723,12 @@
     background: #BA68C8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-column-filter-overlay {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-tree {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(162, 65, 178, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #BA68C8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #BA68C8;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #383838;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #383838;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #383838;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #383838;
     background: #1e1e1e;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #383838;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #383838;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #383838;
   }
-
   .p-sidebar {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #383838;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid #383838;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1e1e1e;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #cf95d9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
@@ -5277,7 +5145,6 @@
     border-color: #BA68C8;
     color: #BA68C8;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1e1e1e;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #383838;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
     background-color: #383838;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #BA68C8;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #BA68C8;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #BA68C8;
     color: #ffffff;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #BA68C8;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #BA68C8;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #BA68C8;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #BA68C8;
   }

--- a/public/themes/bootstrap4-dark-blue/theme.css
+++ b/public/themes/bootstrap4-dark-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.15s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.65;
   }
-
   .p-error {
     color: #f19ea6;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-autocomplete-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #2a323d;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-datepicker {
     padding: 0;
     background: #2a323d;
@@ -454,7 +439,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: color 0.15s, box-shadow 0.15s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #8dd0ff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-cascadeselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #3f4b5b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f19ea6;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #3f4b5b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #1dadff;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #151515;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2a323d;
     border: 1px solid #3f4b5b;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: none;
   }
-
   .p-dropdown {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-dropdown-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -960,7 +933,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #3f4b5b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #3f4b5b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f19ea6;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.15s;
   }
-
   .p-float-label > label.p-error {
     color: #f19ea6;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #3f4b5b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #3f4b5b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #f19ea6;
   }
-
   .p-mention-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1284,7 +1230,6 @@
     color: #151515;
     background: #8dd0ff;
   }
-
   .p-multiselect {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1430,7 +1373,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #3f4b5b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #2a323d;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #9fdaa8;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #3f4b5b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #1dadff;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #151515;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f19ea6;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #151515;
   }
-
   .p-selectbutton .p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f19ea6;
   }
-
   .p-slider {
     background: #3f4b5b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #56bdff;
     border-color: #56bdff;
   }
-
   .p-treeselect {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1753,7 +1683,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #3f4b5b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-togglebutton.p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f19ea6;
   }
-
   .p-button {
     color: #151515;
     background: #8dd0ff;
@@ -1916,7 +1843,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #6c757d;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #151515;
     background: #7fd8e6;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #7fd8e6;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #151515;
     background: #9fdaa8;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #9fdaa8;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #151515;
     background: #ffe082;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffe082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #151515;
     background: #b7a2e0;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #b7a2e0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #151515;
     background: #f19ea6;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #f19ea6;
   }
-
   .p-button.p-button-link {
     color: #8dd0ff;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #8dd0ff;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6c757d;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #7fd8e6;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #7fd8e6;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9fdaa8;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #9fdaa8;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffe082;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffe082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #b7a2e0;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #b7a2e0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f19ea6;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #f19ea6;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #3f4b5b;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
@@ -2658,7 +2564,6 @@
     background: #8dd0ff;
     color: #151515;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2764,17 +2669,17 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
@@ -2827,12 +2732,12 @@
     background: #8dd0ff;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #2a323d;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #2a323d;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(141, 208, 255, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-column-filter-overlay {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.5rem;
     border-bottom: 1px solid #3f4b5b;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     color: rgba(255, 255, 255, 0.87);
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-paginator {
     background: #2a323d;
     color: #8dd0ff;
@@ -3261,9 +3155,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 1px solid #3f4b5b;
     color: #8dd0ff;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: #3f4b5b;
     color: #8dd0ff;
@@ -3332,7 +3226,6 @@
     border-color: #3f4b5b;
     color: #8dd0ff;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3391,7 +3284,6 @@
     color: #151515;
     background: #8dd0ff;
   }
-
   .p-tree {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3447,11 +3339,11 @@
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #3eafff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #8dd0ff;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #2a323d;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #3f4b5b;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem 1.25rem;
     border: 1px solid #3f4b5b;
@@ -3801,7 +3690,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -3827,7 +3715,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3868,7 +3755,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #2a323d;
   }
@@ -3892,7 +3778,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #3f4b5b;
     padding: 1rem 1.25rem;
@@ -3942,7 +3827,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3959,12 +3843,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #3f4b5b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f4b5b;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
@@ -4024,7 +3906,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #2a323d;
     border: 1px solid #3f4b5b;
@@ -4035,7 +3916,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4083,7 +3963,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: none;
@@ -4159,7 +4038,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4201,7 +4079,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #3f4b5b;
   }
-
   .p-sidebar {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4212,7 +4089,7 @@
     padding: 1rem 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4222,13 +4099,13 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
@@ -4239,7 +4116,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
@@ -4259,7 +4135,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #3f4b5b;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #2a323d;
     padding: 1rem 1.25rem;
@@ -4290,7 +4165,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #343e4d;
     border: 0 none;
@@ -4322,7 +4196,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -4394,7 +4267,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4409,32 +4281,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4451,22 +4322,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4517,19 +4388,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4699,7 +4570,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -4760,7 +4630,6 @@
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem 1rem;
     background: #343e4d;
@@ -4838,19 +4707,19 @@
     box-shadow: inset 0 0 0 0.15rem #e3f3fe;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4880,7 +4749,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5125,7 +4993,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -5203,7 +5070,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.15s;
@@ -5248,7 +5114,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
@@ -5289,7 +5154,6 @@
     border-color: #3f4b5b #3f4b5b #2a323d #3f4b5b;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -5364,7 +5228,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5420,7 +5283,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5509,7 +5371,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5520,7 +5381,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5560,7 +5420,7 @@
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5570,7 +5430,7 @@
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5580,7 +5440,7 @@
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5590,10 +5450,9 @@
     color: #721c24;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #721c24;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5624,11 +5483,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5682,7 +5541,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -5692,7 +5551,7 @@
     border-radius: 4px;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.6);
   }
@@ -5704,15 +5563,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5722,15 +5578,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5754,7 +5607,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #3f4b5b;
     border-radius: 4px;
@@ -5775,15 +5627,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #2a323d;
   }
-
   .p-chip {
     background-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
@@ -5817,7 +5666,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5839,7 +5687,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5847,7 +5694,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #8dd0ff;
     color: #151515;
@@ -5880,7 +5726,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 4px;
@@ -5895,7 +5740,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e3f3fe;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5911,7 +5755,6 @@
     color: #151515;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -5923,7 +5766,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #8dd0ff;
     color: #151515;
@@ -5965,7 +5807,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #8dd0ff;
     color: #151515;

--- a/public/themes/bootstrap4-dark-purple/theme.css
+++ b/public/themes/bootstrap4-dark-purple/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.15s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.65;
   }
-
   .p-error {
     color: #f19ea6;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-autocomplete-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #2a323d;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-datepicker {
     padding: 0;
     background: #2a323d;
@@ -454,7 +439,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: color 0.15s, box-shadow 0.15s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #c298d8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-cascadeselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #3f4b5b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f19ea6;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #3f4b5b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #9954bb;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #151515;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2a323d;
     border: 1px solid #3f4b5b;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: none;
   }
-
   .p-dropdown {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-dropdown-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -960,7 +933,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #3f4b5b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #3f4b5b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f19ea6;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.15s;
   }
-
   .p-float-label > label.p-error {
     color: #f19ea6;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #3f4b5b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #3f4b5b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #f19ea6;
   }
-
   .p-mention-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1284,7 +1230,6 @@
     color: #151515;
     background: #c298d8;
   }
-
   .p-multiselect {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1430,7 +1373,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #3f4b5b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f19ea6;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #2a323d;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #9fdaa8;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #3f4b5b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #9954bb;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #151515;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f19ea6;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #151515;
   }
-
   .p-selectbutton .p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f19ea6;
   }
-
   .p-slider {
     background: #3f4b5b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #aa70c7;
     border-color: #aa70c7;
   }
-
   .p-treeselect {
     background: #20262e;
     border: 1px solid #3f4b5b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f19ea6;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -1753,7 +1683,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #3f4b5b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #3f4b5b;
   }
-
   .p-togglebutton.p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f19ea6;
   }
-
   .p-button {
     color: #151515;
     background: #c298d8;
@@ -1916,7 +1843,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #6c757d;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #151515;
     background: #7fd8e6;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #7fd8e6;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #151515;
     background: #9fdaa8;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #9fdaa8;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #151515;
     background: #ffe082;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffe082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #151515;
     background: #b7a2e0;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #b7a2e0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #151515;
     background: #f19ea6;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #f19ea6;
   }
-
   .p-button.p-button-link {
     color: #c298d8;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #c298d8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6c757d;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #7fd8e6;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #7fd8e6;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9fdaa8;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #9fdaa8;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffe082;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffe082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #b7a2e0;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #b7a2e0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f19ea6;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #f19ea6;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #3f4b5b;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
@@ -2658,7 +2564,6 @@
     background: #c298d8;
     color: #151515;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2764,17 +2669,17 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
@@ -2827,12 +2732,12 @@
     background: #c298d8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #2a323d;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #2a323d;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(194, 152, 216, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-column-filter-overlay {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.5rem;
     border-bottom: 1px solid #3f4b5b;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     color: rgba(255, 255, 255, 0.87);
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-paginator {
     background: #2a323d;
     color: #c298d8;
@@ -3261,9 +3155,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 1px solid #3f4b5b;
     color: #c298d8;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: #3f4b5b;
     color: #c298d8;
@@ -3332,7 +3226,6 @@
     border-color: #3f4b5b;
     color: #c298d8;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3391,7 +3284,6 @@
     color: #151515;
     background: #c298d8;
   }
-
   .p-tree {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3447,11 +3339,11 @@
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #151515;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #a263c4;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #c298d8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #2a323d;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #3f4b5b;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem 1.25rem;
     border: 1px solid #3f4b5b;
@@ -3801,7 +3690,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -3827,7 +3715,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3868,7 +3755,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #2a323d;
   }
@@ -3892,7 +3778,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #3f4b5b;
     padding: 1rem 1.25rem;
@@ -3942,7 +3827,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #3f4b5b;
     background: #2a323d;
@@ -3959,12 +3843,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #3f4b5b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f4b5b;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
@@ -4024,7 +3906,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #2a323d;
     border: 1px solid #3f4b5b;
@@ -4035,7 +3916,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4083,7 +3963,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: none;
@@ -4159,7 +4038,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4201,7 +4079,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #3f4b5b;
   }
-
   .p-sidebar {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -4212,7 +4089,7 @@
     padding: 1rem 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4222,13 +4099,13 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
@@ -4239,7 +4116,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
@@ -4259,7 +4135,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #3f4b5b;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #2a323d;
     padding: 1rem 1.25rem;
@@ -4290,7 +4165,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #343e4d;
     border: 0 none;
@@ -4322,7 +4196,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -4394,7 +4267,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4409,32 +4281,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4451,22 +4322,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4517,19 +4388,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4699,7 +4570,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -4760,7 +4630,6 @@
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem 1rem;
     background: #343e4d;
@@ -4838,19 +4707,19 @@
     box-shadow: inset 0 0 0 0.15rem #f0e6f5;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4880,7 +4749,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5125,7 +4993,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -5203,7 +5070,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.15s;
@@ -5248,7 +5114,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
@@ -5289,7 +5154,6 @@
     border-color: #3f4b5b #3f4b5b #2a323d #3f4b5b;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #2a323d;
@@ -5364,7 +5228,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5420,7 +5283,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5509,7 +5371,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5520,7 +5381,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5560,7 +5420,7 @@
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5570,7 +5430,7 @@
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5580,7 +5440,7 @@
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5590,10 +5450,9 @@
     color: #721c24;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #721c24;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5624,11 +5483,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5682,7 +5541,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -5692,7 +5551,7 @@
     border-radius: 4px;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.6);
   }
@@ -5704,15 +5563,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5722,15 +5578,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5754,7 +5607,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #3f4b5b;
     border-radius: 4px;
@@ -5775,15 +5627,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #2a323d;
   }
-
   .p-chip {
     background-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
@@ -5817,7 +5666,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5839,7 +5687,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5847,7 +5694,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #c298d8;
     color: #151515;
@@ -5880,7 +5726,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 4px;
@@ -5895,7 +5740,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #f0e6f5;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5911,7 +5755,6 @@
     color: #151515;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
@@ -5923,7 +5766,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #c298d8;
     color: #151515;
@@ -5965,7 +5807,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #c298d8;
     color: #151515;

--- a/public/themes/bootstrap4-light-blue/theme.css
+++ b/public/themes/bootstrap4-light-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.15s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.65;
   }
-
   .p-error {
     color: #dc3545;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #212529;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-datepicker {
     padding: 0;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: box-shadow 0.15s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #212529;
     transition: box-shadow 0.15s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #007bff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #212529;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #efefef;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #dc3545;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #efefef;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #0062cc;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #ffffff;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #212529;
     border: 1px solid #212529;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: none;
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #212529;
@@ -960,7 +933,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #efefef;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #495057;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #dc3545;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6c757d;
     transition-duration: 0.15s;
   }
-
   .p-float-label > label.p-error {
     color: #dc3545;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #495057;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #495057;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #efefef;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #efefef;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #212529;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #dc3545;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #212529;
@@ -1284,7 +1230,6 @@
     color: #ffffff;
     background: #007bff;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #212529;
@@ -1430,7 +1373,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #efefef;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #28a745;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #efefef;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #0062cc;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #dc3545;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #ffffff;
   }
-
   .p-selectbutton .p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #dc3545;
   }
-
   .p-slider {
     background: #e9ecef;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #0069d9;
     border-color: #0069d9;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #212529;
@@ -1753,7 +1683,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #efefef;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-togglebutton.p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #dc3545;
   }
-
   .p-button {
     color: #ffffff;
     background: #007bff;
@@ -1916,7 +1843,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #6c757d;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #17a2b8;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #17a2b8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #28a745;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #28a745;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #ffc107;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffc107;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #6f42c1;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #6f42c1;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #dc3545;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #dc3545;
   }
-
   .p-button.p-button-link {
     color: #007bff;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #007bff;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6c757d;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #17a2b8;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #17a2b8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #28a745;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #28a745;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffc107;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffc107;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6f42c1;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #6f42c1;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #dc3545;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #dc3545;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
@@ -2658,7 +2564,6 @@
     background: #007bff;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2764,17 +2669,17 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
@@ -2827,12 +2732,12 @@
     background: #007bff;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #efefef;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(0, 123, 255, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #212529;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.5rem;
     border-bottom: 1px solid #dee2e6;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #212529;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-paginator {
     background: #ffffff;
     color: #007bff;
@@ -3261,9 +3155,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: #ffffff;
     border: 1px solid #dee2e6;
     color: #007bff;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: #dee2e6;
     color: #007bff;
@@ -3332,7 +3226,6 @@
     border-color: #dee2e6;
     color: #007bff;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3391,7 +3284,6 @@
     color: #ffffff;
     background: #007bff;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3447,11 +3339,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #0062cc;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #007bff;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #efefef;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem 1.25rem;
     border: 1px solid #dee2e6;
@@ -3801,7 +3690,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #212529;
@@ -3827,7 +3715,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3868,7 +3755,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3892,7 +3778,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem 1.25rem;
@@ -3942,7 +3827,6 @@
     color: #212529;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3959,12 +3843,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #efefef;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #dee2e6;
@@ -4024,7 +3906,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #efefef;
     border: 1px solid #dee2e6;
@@ -4035,7 +3916,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #212529;
@@ -4083,7 +3963,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: none;
@@ -4159,7 +4038,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #212529;
@@ -4201,7 +4079,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: rgba(0, 0, 0, 0.2);
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #212529;
@@ -4212,7 +4089,7 @@
     padding: 1rem 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4222,13 +4099,13 @@
     transition: box-shadow 0.15s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
@@ -4239,7 +4116,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #212529;
     color: #ffffff;
@@ -4259,7 +4135,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #212529;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #efefef;
     padding: 1rem 1.25rem;
@@ -4290,7 +4165,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #efefef;
     border: 0 none;
@@ -4322,7 +4196,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4394,7 +4267,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4409,32 +4281,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4451,22 +4322,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4517,19 +4388,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-menuitem-link {
@@ -4699,7 +4570,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4760,7 +4630,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem 1rem;
     background: #efefef;
@@ -4838,19 +4707,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(38, 143, 255, 0.5);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-submenu-list {
@@ -4880,7 +4749,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5125,7 +4993,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5203,7 +5070,6 @@
     padding: 0.75rem 1rem;
     color: #212529;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.15s;
@@ -5248,7 +5114,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #dee2e6;
@@ -5289,7 +5154,6 @@
     border-color: #dee2e6 #dee2e6 #ffffff #dee2e6;
     color: #495057;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5364,7 +5228,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5420,7 +5283,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5509,7 +5371,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5520,7 +5381,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5560,7 +5420,7 @@
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5570,7 +5430,7 @@
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5580,7 +5440,7 @@
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5590,10 +5450,9 @@
     color: #721c24;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #721c24;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5624,11 +5483,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5682,7 +5541,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #efefef;
@@ -5692,7 +5551,7 @@
     border-radius: 4px;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #efefef;
   }
@@ -5704,15 +5563,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5722,15 +5578,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5754,7 +5607,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 4px;
@@ -5775,15 +5627,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #212529;
@@ -5817,7 +5666,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5839,7 +5687,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 4px;
@@ -5847,7 +5694,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #007bff;
     color: #ffffff;
@@ -5880,7 +5726,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 4px;
@@ -5895,7 +5740,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5911,7 +5755,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #212529;
@@ -5923,7 +5766,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #007bff;
     color: #ffffff;
@@ -5965,7 +5807,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #007bff;
     color: #ffffff;

--- a/public/themes/bootstrap4-light-purple/theme.css
+++ b/public/themes/bootstrap4-light-purple/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.15s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.65;
   }
-
   .p-error {
     color: #dc3545;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #212529;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-datepicker {
     padding: 0;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: box-shadow 0.15s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #212529;
     transition: box-shadow 0.15s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #883cae;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #212529;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #efefef;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #dc3545;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #efefef;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #68329e;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #ffffff;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #212529;
     border: 1px solid #212529;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: none;
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #212529;
@@ -960,7 +933,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #efefef;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #495057;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #dc3545;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6c757d;
     transition-duration: 0.15s;
   }
-
   .p-float-label > label.p-error {
     color: #dc3545;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #495057;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #495057;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #efefef;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #efefef;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #212529;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #dc3545;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #212529;
@@ -1284,7 +1230,6 @@
     color: #ffffff;
     background: #883cae;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #212529;
@@ -1430,7 +1373,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #efefef;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #dc3545;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #28a745;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #efefef;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #68329e;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #dc3545;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #ffffff;
   }
-
   .p-selectbutton .p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #dc3545;
   }
-
   .p-slider {
     background: #e9ecef;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #7a38a7;
     border-color: #7a38a7;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #dc3545;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #212529;
@@ -1753,7 +1683,6 @@
     color: #212529;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #efefef;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #efefef;
   }
-
   .p-togglebutton.p-button {
     background: #6c757d;
     border: 1px solid #6c757d;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #dc3545;
   }
-
   .p-button {
     color: #ffffff;
     background: #883cae;
@@ -1916,7 +1843,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #6c757d;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #17a2b8;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #17a2b8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #28a745;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #28a745;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #ffc107;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffc107;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #6f42c1;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #6f42c1;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #dc3545;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #dc3545;
   }
-
   .p-button.p-button-link {
     color: #883cae;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #883cae;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6c757d;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #6c757d;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #17a2b8;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #17a2b8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #28a745;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #28a745;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffc107;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffc107;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #6f42c1;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #6f42c1;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #dc3545;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #dc3545;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
@@ -2658,7 +2564,6 @@
     background: #883cae;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2764,17 +2669,17 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
@@ -2827,12 +2732,12 @@
     background: #883cae;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #efefef;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(136, 60, 174, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #212529;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.5rem;
     border-bottom: 1px solid #dee2e6;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #212529;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-paginator {
     background: #ffffff;
     color: #883cae;
@@ -3261,9 +3155,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: #ffffff;
     border: 1px solid #dee2e6;
     color: #883cae;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: #dee2e6;
     color: #883cae;
@@ -3332,7 +3226,6 @@
     border-color: #dee2e6;
     color: #883cae;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3391,7 +3284,6 @@
     color: #ffffff;
     background: #883cae;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3447,11 +3339,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #6d308b;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 0 0;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #883cae;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #efefef;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem 1.25rem;
     border: 1px solid #dee2e6;
@@ -3801,7 +3690,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #212529;
@@ -3827,7 +3715,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3868,7 +3755,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3892,7 +3778,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem 1.25rem;
@@ -3942,7 +3827,6 @@
     color: #212529;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3959,12 +3843,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #efefef;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #dee2e6;
@@ -4024,7 +3906,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #efefef;
     border: 1px solid #dee2e6;
@@ -4035,7 +3916,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #212529;
@@ -4083,7 +3963,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: none;
@@ -4159,7 +4038,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #212529;
@@ -4201,7 +4079,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: rgba(0, 0, 0, 0.2);
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #212529;
@@ -4212,7 +4089,7 @@
     padding: 1rem 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4222,13 +4099,13 @@
     transition: box-shadow 0.15s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
@@ -4239,7 +4116,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #212529;
     color: #ffffff;
@@ -4259,7 +4135,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #212529;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #efefef;
     padding: 1rem 1.25rem;
@@ -4290,7 +4165,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #efefef;
     border: 0 none;
@@ -4322,7 +4196,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4394,7 +4267,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4409,32 +4281,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4451,22 +4322,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4517,19 +4388,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-megamenu .p-menuitem-link {
@@ -4699,7 +4570,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4760,7 +4630,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem 1rem;
     background: #efefef;
@@ -4838,19 +4707,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(136, 60, 174, 0.5);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: transparent;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.9);
   }
   .p-menubar .p-submenu-list {
@@ -4880,7 +4749,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5125,7 +4993,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5203,7 +5070,6 @@
     padding: 0.75rem 1rem;
     color: #212529;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.15s;
@@ -5248,7 +5114,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #dee2e6;
@@ -5289,7 +5154,6 @@
     border-color: #dee2e6 #dee2e6 #ffffff #dee2e6;
     color: #495057;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5364,7 +5228,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5420,7 +5283,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5509,7 +5371,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5520,7 +5381,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5560,7 +5420,7 @@
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #004085;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5570,7 +5430,7 @@
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #155724;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5580,7 +5440,7 @@
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #856404;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5590,10 +5450,9 @@
     color: #721c24;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #721c24;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5624,11 +5483,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5682,7 +5541,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #efefef;
@@ -5692,7 +5551,7 @@
     border-radius: 4px;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #efefef;
   }
@@ -5704,15 +5563,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5722,15 +5578,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5754,7 +5607,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 4px;
@@ -5775,15 +5627,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #212529;
@@ -5817,7 +5666,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5839,7 +5687,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 4px;
@@ -5847,7 +5694,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #883cae;
     color: #ffffff;
@@ -5880,7 +5726,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 4px;
@@ -5895,7 +5740,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5911,7 +5755,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #212529;
@@ -5923,7 +5766,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #883cae;
     color: #ffffff;
@@ -5965,7 +5807,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #883cae;
     color: #ffffff;

--- a/public/themes/fluent-light/theme.css
+++ b/public/themes/fluent-light/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #a4252c;
   }
-
   .p-text-secondary {
     color: #605e5c;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #a4252c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #323130;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #a4252c;
   }
-
   .p-datepicker {
     padding: 0.75rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 2px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #605e5c;
     border-color: transparent;
     background: #f3f2f1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #323130;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #0078d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a4252c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #323130;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #faf9f8;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #faf9f8;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #a4252c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #faf9f8;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #005a9e;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #a4252c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: rgba(0, 0, 0, 0.133) 0px 3.2px 7.2px 0px, rgba(0, 0, 0, 0.11) 0px 0.6px 1.8px 0px;
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #605e5c;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #a4252c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #323130;
@@ -956,7 +930,6 @@
     color: #323130;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #faf9f8;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f2f1;
     color: #605e5c;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #605e5c;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #a4252c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #a4252c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #605e5c;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #a4252c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #605e5c;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #605e5c;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #605e5c;
   }
-
   :-moz-placeholder {
     color: #605e5c;
   }
-
   ::-moz-placeholder {
     color: #605e5c;
   }
-
   :-ms-input-placeholder {
     color: #605e5c;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #faf9f8;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #faf9f8;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #323130;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #a4252c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #323130;
@@ -1280,7 +1227,6 @@
     color: #323130;
     background: #edebe9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #605e5c;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #a4252c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #323130;
@@ -1426,7 +1370,6 @@
     color: #323130;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #faf9f8;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #faf9f8;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #a4252c;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #498205;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #faf9f8;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #a4252c;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #605e5c;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #605e5c;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #323130;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #605e5c;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #323130;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #323130;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #323130;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #323130;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #a4252c;
   }
-
   .p-slider {
     background: #c8c6c4;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #ffffff;
     border-color: #005a9e;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #605e5c;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #a4252c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #323130;
@@ -1741,7 +1674,6 @@
     color: #323130;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #faf9f8;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #faf9f8;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #605e5c;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #605e5c;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #323130;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #605e5c;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #323130;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #323130;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #323130;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #323130;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #a4252c;
   }
-
   .p-button {
     color: #ffffff;
     background: #0078d4;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #d45c00;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #d45c00;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #00b7c3;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #00b7c3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #498205;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #498205;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #323130;
     background: #ffaa44;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #ffaa44;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #8378de;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #8378de;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #d13438;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #d13438;
   }
-
   .p-button.p-button-link {
     color: #0078d4;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #0078d4;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 2px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #d45c00;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #d45c00;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #00b7c3;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #00b7c3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #498205;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #498205;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffaa44;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #ffaa44;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #8378de;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #8378de;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #d13438;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #d13438;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #605e5c;
     color: #ffffff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 2px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #605e5c;
     border-color: transparent;
     background: #f3f2f1;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
@@ -2646,7 +2555,6 @@
     background: #edebe9;
     color: #323130;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #605e5c;
     border-color: transparent;
     background: #f3f2f1;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
@@ -2815,12 +2723,12 @@
     background: #0078d4;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #faf9f8;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(0, 120, 212, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #323130;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #edebe9;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 0.5rem;
     border-bottom: 1px solid #edebe9;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f2f1;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f2f1;
     color: #323130;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #605e5c;
@@ -3249,9 +3146,9 @@
     border-radius: 2px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #605e5c;
@@ -3262,9 +3159,9 @@
     border-radius: 2px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f2f1;
     border-color: transparent;
     color: #323130;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #323130;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #323130;
     background: #edebe9;
   }
-
   .p-tree {
     border: 1px solid #a19f9d;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #323130;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #323130;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #323130;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #c3bcb5;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #0078d4;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #faf9f8;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #a19f9d;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #a19f9d;
@@ -3764,7 +3656,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #323130;
@@ -3790,7 +3681,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #a19f9d;
     background: #ffffff;
@@ -3831,7 +3721,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3855,7 +3744,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #a19f9d;
     padding: 1rem;
@@ -3905,7 +3793,6 @@
     color: #323130;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #a19f9d;
     background: #ffffff;
@@ -3922,12 +3809,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #edebe9;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f3f2f1;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 0 none;
@@ -3987,7 +3872,6 @@
     border-bottom-right-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-toolbar {
     background: #faf9f8;
     border: 1px solid #a19f9d;
@@ -3998,7 +3882,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #323130;
@@ -4046,7 +3929,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 2px;
     box-shadow: rgba(0, 0, 0, 0.133) 0px 6.4px 14.4px 0px, rgba(0, 0, 0, 0.11) 0px 1.2px 3.6px 0px;
@@ -4122,7 +4004,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #323130;
@@ -4164,7 +4045,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #323130;
@@ -4175,7 +4055,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -4185,13 +4065,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #605e5c;
     border-color: transparent;
     background: #f3f2f1;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
@@ -4202,7 +4082,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #ffffff;
     color: #323130;
@@ -4222,7 +4101,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #ffffff;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #faf9f8;
     padding: 1rem;
@@ -4253,7 +4131,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #eeeeee;
@@ -4285,7 +4162,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #0078d4;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #ffffff;
@@ -4357,7 +4233,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4372,32 +4247,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4414,22 +4288,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4480,19 +4354,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #edebe9;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #323130;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0078d4;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0078d4;
   }
   .p-megamenu .p-menuitem-link {
@@ -4662,7 +4536,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #ffffff;
@@ -4723,7 +4596,6 @@
     border-top: 1px solid #edebe9;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ffffff;
@@ -4801,19 +4673,19 @@
     box-shadow: inset 0 0 0 0.15rem #605e5c;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #edebe9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #323130;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0078d4;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0078d4;
   }
   .p-menubar .p-submenu-list {
@@ -4843,7 +4715,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5064,7 +4935,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #ffffff;
@@ -5142,7 +5012,6 @@
     padding: 0.75rem 0.5rem;
     color: #323130;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5187,7 +5056,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 0 none;
@@ -5228,7 +5096,6 @@
     border-color: #0078d4;
     color: #323130;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #ffffff;
@@ -5303,7 +5170,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5359,7 +5225,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 2px;
@@ -5448,7 +5313,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5458,8 +5322,7 @@
     border-radius: 2px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 0.5rem;
-    border-width: 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5499,7 +5362,7 @@
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #605e5c;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5509,7 +5372,7 @@
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #107c10;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5519,7 +5382,7 @@
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #797775;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5529,10 +5392,9 @@
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #a80000;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5563,11 +5425,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5621,7 +5483,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #faf9f8;
@@ -5631,7 +5493,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #faf9f8;
   }
@@ -5643,15 +5505,12 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5661,15 +5520,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5693,7 +5549,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #edebe9;
     border-radius: 2px;
@@ -5714,15 +5569,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #edebe9;
     color: #323130;
@@ -5756,7 +5608,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5778,7 +5629,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #edebe9;
     border-radius: 2px;
@@ -5786,7 +5636,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #0078d4;
     color: #ffffff;
@@ -5819,7 +5668,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 2px;
@@ -5834,7 +5682,6 @@
     outline-offset: 0;
     box-shadow: inset 0 0 0 1px #605e5c;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 2px;
@@ -5850,7 +5697,6 @@
     color: #ffffff;
     line-height: 2px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #323130;
@@ -5862,7 +5708,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #0078d4;
     color: #ffffff;
@@ -5904,7 +5749,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #0078d4;
     color: #ffffff;
@@ -5935,7 +5779,6 @@
   .p-button-label {
     font-weight: 600;
   }
-
   .p-slider:not(.p-disabled):hover {
     background-color: #deecf9;
   }
@@ -5945,7 +5788,6 @@
   .p-slider:not(.p-disabled):hover .p-slider-handle {
     border-color: #005a9e;
   }
-
   .p-inputswitch {
     width: 40px;
     height: 20px;
@@ -5973,7 +5815,6 @@
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
     border-color: #0078d4;
   }
-
   .p-datepicker .p-datepicker-header .p-datepicker-title {
     order: 1;
     margin: 0 auto 0 0;
@@ -6026,53 +5867,42 @@
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.5rem 0;
   }
-
   .p-datatable {
     font-size: 90%;
   }
-
   .p-toast {
     font-size: 90%;
   }
   .p-toast .p-toast-icon-close-icon {
     font-size: 90%;
   }
-
   .p-message {
     font-size: 90%;
   }
   .p-message .p-message-close .p-message-close-icon {
     font-size: 90%;
   }
-
   .p-tooltip .p-tooltip-text {
     font-size: 90%;
   }
-
   .p-component .p-menu-separator {
     border-color: #eeeeee;
   }
-
   .p-submenu-icon {
     color: #605e5c !important;
   }
-
   .p-menuitem-active .p-submenu-icon {
     color: #323130 !important;
   }
-
   .p-progressbar-label {
     display: none !important;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #0078d4;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #0078d4;
   }
-
   .p-inputtext:disabled {
     background-color: #f3f2f1;
     border-color: #f3f2f1;
@@ -6083,11 +5913,10 @@
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #0078d4;
   }
-
   .p-checkbox .p-checkbox-box.p-disabled,
-.p-radiobutton .p-radiobutton-box.p-disabled,
-.p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container.p-disabled,
-.p-chips .p-chips-multiple-container.p-disabled {
+  .p-radiobutton .p-radiobutton-box.p-disabled,
+  .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container.p-disabled,
+  .p-chips .p-chips-multiple-container.p-disabled {
     background-color: #f3f2f1;
     border-color: #f3f2f1;
     color: #a19f9d;
@@ -6095,14 +5924,13 @@
     user-select: none;
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled).p-focus,
-.p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus,
-.p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus,
-.p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
+  .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus,
+  .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus,
+  .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #0078d4;
   }
-
   .p-dropdown.p-disabled,
-.p-multiselect.p-disabled {
+  .p-multiselect.p-disabled {
     background-color: #f3f2f1;
     border-color: #f3f2f1;
     color: #a19f9d;
@@ -6110,22 +5938,20 @@
     user-select: none;
   }
   .p-dropdown.p-disabled .p-dropdown-label,
-.p-dropdown.p-disabled .p-dropdown-trigger-icon,
-.p-multiselect.p-disabled .p-dropdown-label,
-.p-multiselect.p-disabled .p-dropdown-trigger-icon {
+  .p-dropdown.p-disabled .p-dropdown-trigger-icon,
+  .p-multiselect.p-disabled .p-dropdown-label,
+  .p-multiselect.p-disabled .p-dropdown-trigger-icon {
     color: #a19f9d;
   }
   .p-dropdown:not(.p-disabled).p-focus,
-.p-multiselect:not(.p-disabled).p-focus {
+  .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #0078d4;
   }
-
   .p-inputswitch.p-focus .p-inputswitch-slider {
     box-shadow: none;
     outline: 1px solid #605e5c;
     outline-offset: 2px;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #0078d4;
   }

--- a/public/themes/lara-dark-amber/theme.css
+++ b/public/themes/lara-dark-amber/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #fbbf24;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #fde68a;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #fde68a;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #fbbf24;
     border-color: #fbbf24;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #fbbf24;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #fbbf24;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #fbbf24;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(251, 191, 36, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
@@ -2834,12 +2742,12 @@
     background: #fbbf24;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(251, 191, 36, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(225, 164, 4, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #fbbf24;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #fbbf24;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(251, 191, 36, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(251, 191, 36, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(251, 191, 36, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #fbbf24;
     color: #fbbf24;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #fbbf24;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #fbbf24;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #fbbf24;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #fbbf24;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #fbbf24;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #fbbf24;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(251, 191, 36, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #fbbf24;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #fbbf24;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(251, 191, 36, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #fbbf24;
     color: #030712;

--- a/public/themes/lara-dark-blue/theme.css
+++ b/public/themes/lara-dark-blue/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #60a5fa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #bfdbfe;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #bfdbfe;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #60a5fa;
     border-color: #60a5fa;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #60a5fa;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #60a5fa;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #60a5fa;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(96, 165, 250, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
@@ -2834,12 +2742,12 @@
     background: #60a5fa;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(96, 165, 250, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(29, 127, 248, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #60a5fa;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #60a5fa;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(96, 165, 250, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(96, 165, 250, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(96, 165, 250, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #60a5fa;
     color: #60a5fa;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #60a5fa;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #60a5fa;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #60a5fa;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #60a5fa;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #60a5fa;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #60a5fa;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(96, 165, 250, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #60a5fa;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #60a5fa;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(96, 165, 250, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #60a5fa;
     color: #030712;

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #22d3ee;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #a5f3fc;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #a5f3fc;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #22d3ee;
     border-color: #22d3ee;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #22d3ee;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #22d3ee;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #22d3ee;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(34, 211, 238, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
@@ -2834,12 +2742,12 @@
     background: #22d3ee;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(34, 211, 238, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(16, 177, 202, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #22d3ee;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #22d3ee;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(34, 211, 238, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(34, 211, 238, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(34, 211, 238, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #22d3ee;
     color: #22d3ee;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #22d3ee;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #22d3ee;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #22d3ee;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #22d3ee;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #22d3ee;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #22d3ee;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(34, 211, 238, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #22d3ee;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #22d3ee;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(34, 211, 238, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #22d3ee;
     color: #030712;

--- a/public/themes/lara-dark-green/theme.css
+++ b/public/themes/lara-dark-green/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #34d399;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #a7f3d0;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #a7f3d0;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #34d399;
     border-color: #34d399;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #34d399;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #34d399;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #34d399;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(52, 211, 153, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
@@ -2834,12 +2742,12 @@
     background: #34d399;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(52, 211, 153, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(37, 173, 124, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #34d399;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #34d399;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(52, 211, 153, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(52, 211, 153, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(52, 211, 153, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #34d399;
     color: #34d399;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #34d399;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #34d399;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #34d399;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #34d399;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #34d399;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #34d399;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(52, 211, 153, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #34d399;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #34d399;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(52, 211, 153, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #34d399;
     color: #030712;

--- a/public/themes/lara-dark-indigo/theme.css
+++ b/public/themes/lara-dark-indigo/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #818cf8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #c7d2fe;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #c7d2fe;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #818cf8;
     border-color: #818cf8;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #818cf8;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #818cf8;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #818cf8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(129, 140, 248, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
@@ -2834,12 +2742,12 @@
     background: #818cf8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(129, 140, 248, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(58, 75, 244, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #818cf8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #818cf8;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(129, 140, 248, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(129, 140, 248, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(129, 140, 248, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #818cf8;
     color: #818cf8;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #818cf8;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #818cf8;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #818cf8;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #818cf8;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #818cf8;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #818cf8;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(129, 140, 248, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #818cf8;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #818cf8;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(129, 140, 248, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #818cf8;
     color: #030712;

--- a/public/themes/lara-dark-pink/theme.css
+++ b/public/themes/lara-dark-pink/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #f472b6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #fbcfe8;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #fbcfe8;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #f472b6;
     border-color: #f472b6;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #f472b6;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #f472b6;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #f472b6;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(244, 114, 182, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
@@ -2834,12 +2742,12 @@
     background: #f472b6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(244, 114, 182, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(239, 48, 148, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #f472b6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #f472b6;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(244, 114, 182, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(244, 114, 182, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(244, 114, 182, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #f472b6;
     color: #f472b6;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #f472b6;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #f472b6;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #f472b6;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #f472b6;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #f472b6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #f472b6;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(244, 114, 182, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #f472b6;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #f472b6;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(244, 114, 182, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #f472b6;
     color: #030712;

--- a/public/themes/lara-dark-purple/theme.css
+++ b/public/themes/lara-dark-purple/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #a78bfa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #ddd6fe;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ddd6fe;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #a78bfa;
     border-color: #a78bfa;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #a78bfa;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #a78bfa;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #a78bfa;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(167, 139, 250, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
@@ -2834,12 +2742,12 @@
     background: #a78bfa;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(167, 139, 250, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(110, 64, 247, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #a78bfa;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #a78bfa;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(167, 139, 250, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(167, 139, 250, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(167, 139, 250, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #a78bfa;
     color: #a78bfa;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #a78bfa;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #a78bfa;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #a78bfa;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #a78bfa;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #a78bfa;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #a78bfa;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(167, 139, 250, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #a78bfa;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #a78bfa;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(167, 139, 250, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #a78bfa;
     color: #030712;

--- a/public/themes/lara-dark-teal/theme.css
+++ b/public/themes/lara-dark-teal/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #FCA5A5;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-autocomplete-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -442,11 +429,9 @@
     background: #374151;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2937;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #2dd4bf;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-cascadeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #424b57;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #FCA5A5;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #424b57;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #99f6e4;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2937;
     border: 1px solid #424b57;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #111827;
     border: 1px solid #424b57;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-dropdown-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -975,7 +949,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #424b57;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #424b57;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #FCA5A5;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #FCA5A5;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #424b57;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #424b57;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #FCA5A5;
   }
-
   .p-mention-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1299,7 +1246,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
   }
-
   .p-multiselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1445,7 +1389,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #424b57;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #FCA5A5;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #1f2937;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #424b57;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #99f6e4;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #030712;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-slider {
     background: #424b57;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #2dd4bf;
     border-color: #2dd4bf;
   }
-
   .p-treeselect {
     background: #111827;
     border: 1px solid #424b57;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #FCA5A5;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -1760,7 +1693,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #424b57;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #424b57;
   }
-
   .p-togglebutton.p-button {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #030712;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #030712;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #FCA5A5;
   }
-
   .p-button {
     color: #030712;
     background: #2dd4bf;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #020617;
     background: #94a3b8;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #082f49;
     background: #38bdf8;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #052e16;
     background: #4ade80;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #431407;
     background: #fb923c;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #3b0764;
     background: #c084fc;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #450a0a;
     background: #f87171;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-button.p-button-link {
     color: #2dd4bf;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #2dd4bf;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #94a3b8;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #94a3b8;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #38bdf8;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #38bdf8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4ade80;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #4ade80;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #fb923c;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #fb923c;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #c084fc;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #c084fc;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f87171;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #f87171;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #111827;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
@@ -2665,7 +2574,6 @@
     background: rgba(45, 212, 191, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
@@ -2834,12 +2742,12 @@
     background: #2dd4bf;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2937;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2937;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(45, 212, 191, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-column-filter-overlay {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #424b57;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-paginator {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3178,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
   }
-
   .p-tree {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3454,11 +3349,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(35, 171, 154, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #2dd4bf;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2937;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #2dd4bf;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #424b57;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #424b57;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2937;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #424b57;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #424b57;
     background: #1f2937;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #424b57;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #424b57;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #1f2937;
     border: 1px solid #424b57;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #424b57;
   }
-
   .p-sidebar {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #424b57;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2937;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #374151;
     border: 1px solid #424b57;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(45, 212, 191, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #374151;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #374151;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem rgba(45, 212, 191, 0.2);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(45, 212, 191, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
@@ -5247,7 +5115,6 @@
     border-color: #2dd4bf;
     color: #2dd4bf;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #374151;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #fca5a5;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #424b57;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2937;
   }
-
   .p-chip {
     background-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #2dd4bf;
     color: #030712;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #030712;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #2dd4bf;
     color: #030712;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #2dd4bf;
     color: #030712;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,19 +5816,15 @@
     background-color: #2dd4bf;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #2dd4bf;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #2dd4bf;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(45, 212, 191, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6009,39 +5846,31 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(248, 113, 113, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #2dd4bf;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #2dd4bf;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
     box-shadow: 0 0 0 2px #1c2127, 0 0 0 4px rgba(45, 212, 191, 0.7), 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-message .p-message-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-toast .p-toast-message .p-toast-icon-close:hover {
     background: rgba(255, 255, 255, 0.1);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #2dd4bf;
     color: #030712;

--- a/public/themes/lara-light-amber/theme.css
+++ b/public/themes/lara-light-amber/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #f59e0b;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #b45309;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #b45309;
     background: #fffbeb;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #b45309;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #f59e0b;
     border-color: #f59e0b;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #f59e0b;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #b45309;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #b45309;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
@@ -2665,7 +2574,6 @@
     background: #fffbeb;
     color: #b45309;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
@@ -2834,12 +2742,12 @@
     background: #f59e0b;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(245, 158, 11, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #b45309;
     background: #fffbeb;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #b45309;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #b45309;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #b45309;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #ffe789;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #f59e0b;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #f59e0b;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #fffbeb;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #b45309;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #b45309;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #b45309;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #fef08a;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #fffbeb;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #b45309;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #b45309;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #b45309;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #b45309;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #f59e0b;
     color: #f59e0b;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #f59e0b;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #f59e0b;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #f59e0b;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #f59e0b;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #f59e0b;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #f59e0b;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #facf85, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #facf85, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #f59e0b;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #f59e0b;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #facf85, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #facf85, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #f59e0b;
     color: #ffffff;

--- a/public/themes/lara-light-blue/theme.css
+++ b/public/themes/lara-light-blue/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #3B82F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #1D4ED8;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #1D4ED8;
     background: #EFF6FF;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #1D4ED8;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #3B82F6;
     border-color: #3B82F6;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #3B82F6;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #1D4ED8;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #1D4ED8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
@@ -2665,7 +2574,6 @@
     background: #EFF6FF;
     color: #1D4ED8;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
@@ -2834,12 +2742,12 @@
     background: #3B82F6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(59, 130, 246, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #1D4ED8;
     background: #EFF6FF;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #1D4ED8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #1D4ED8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #1D4ED8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #8cbeff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #3B82F6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #3B82F6;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #EFF6FF;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #1D4ED8;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #1D4ED8;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #1D4ED8;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #BFDBFE;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #EFF6FF;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #1D4ED8;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #1D4ED8;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #1D4ED8;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #1D4ED8;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #3B82F6;
     color: #3B82F6;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #3B82F6;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #3B82F6;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #3B82F6;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #3B82F6;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #3B82F6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #3B82F6;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #9dc1fb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #9dc1fb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #3B82F6;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #3B82F6;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #9dc1fb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #9dc1fb, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #3B82F6;
     color: #ffffff;

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #06b6d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #0e7490;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #0e7490;
     background: #ecfeff;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #0e7490;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #06b6d4;
     border-color: #06b6d4;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #06b6d4;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #0e7490;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #0e7490;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
@@ -2665,7 +2574,6 @@
     background: #ecfeff;
     color: #0e7490;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
@@ -2834,12 +2742,12 @@
     background: #06b6d4;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(6, 182, 212, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #0e7490;
     background: #ecfeff;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #0e7490;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #0e7490;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #0e7490;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #8af9ff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #06b6d4;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #06b6d4;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #ecfeff;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #0e7490;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0e7490;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0e7490;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #a5f3fc;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #ecfeff;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #0e7490;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0e7490;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0e7490;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #0e7490;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #06b6d4;
     color: #06b6d4;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #06b6d4;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #06b6d4;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #06b6d4;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #06b6d4;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #06b6d4;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #06b6d4;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71e7fb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71e7fb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #06b6d4;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #06b6d4;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71e7fb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71e7fb, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #06b6d4;
     color: #ffffff;

--- a/public/themes/lara-light-green/theme.css
+++ b/public/themes/lara-light-green/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #10b981;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #047857;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #047857;
     background: #F0FDFA;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #047857;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #10b981;
     border-color: #10b981;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #10b981;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #047857;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #047857;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
@@ -2665,7 +2574,6 @@
     background: #F0FDFA;
     color: #047857;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
@@ -2834,12 +2742,12 @@
     background: #10b981;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(16, 185, 129, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #047857;
     background: #F0FDFA;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #047857;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #047857;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #047857;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #99f1dd;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #10b981;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #10b981;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F0FDFA;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #047857;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #047857;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #047857;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #a7f3d0;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F0FDFA;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #047857;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #047857;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #047857;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #047857;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #10b981;
     color: #10b981;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #10b981;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #10b981;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #10b981;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #10b981;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #10b981;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #10b981;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71f3c8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71f3c8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #10b981;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #10b981;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71f3c8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #71f3c8, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #10b981;
     color: #ffffff;

--- a/public/themes/lara-light-indigo/theme.css
+++ b/public/themes/lara-light-indigo/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #6366F1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #4338CA;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #4338CA;
     background: #EEF2FF;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #4338CA;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #6366F1;
     border-color: #6366F1;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #6366F1;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #4338CA;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #4338CA;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
@@ -2665,7 +2574,6 @@
     background: #EEF2FF;
     color: #4338CA;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
@@ -2834,12 +2742,12 @@
     background: #6366F1;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(99, 102, 241, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #4338CA;
     background: #EEF2FF;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #4338CA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #4338CA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #4338CA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #8ba7ff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #6366F1;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #6366F1;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #EEF2FF;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #4338CA;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #4338CA;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #4338CA;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #C7D2FE;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #EEF2FF;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #4338CA;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #4338CA;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #4338CA;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #4338CA;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #6366F1;
     color: #6366F1;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #6366F1;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #6366F1;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #6366F1;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #6366F1;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #6366F1;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #6366F1;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b1b3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b1b3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #6366F1;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #6366F1;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b1b3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b1b3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #6366F1;
     color: #ffffff;

--- a/public/themes/lara-light-pink/theme.css
+++ b/public/themes/lara-light-pink/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #ec4899;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #be185d;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #be185d;
     background: #fdf2f8;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #be185d;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #ec4899;
     border-color: #ec4899;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #ec4899;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #be185d;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #be185d;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
@@ -2665,7 +2574,6 @@
     background: #fdf2f8;
     color: #be185d;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
@@ -2834,12 +2742,12 @@
     background: #ec4899;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(236, 72, 153, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #be185d;
     background: #fdf2f8;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #be185d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #be185d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #be185d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #f09cca;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #ec4899;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #ec4899;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #fdf2f8;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #be185d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #be185d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #be185d;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #fbcfe8;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #fdf2f8;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #be185d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #be185d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #be185d;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #be185d;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #ec4899;
     color: #ec4899;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #ec4899;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #ec4899;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #ec4899;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #ec4899;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #ec4899;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #ec4899;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f6a4cc, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f6a4cc, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #ec4899;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #ec4899;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f6a4cc, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f6a4cc, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #ec4899;
     color: #ffffff;

--- a/public/themes/lara-light-purple/theme.css
+++ b/public/themes/lara-light-purple/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #8B5CF6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #6D28D9;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #6D28D9;
     background: #F5F3FF;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #6D28D9;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #8B5CF6;
     border-color: #8B5CF6;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #8B5CF6;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #6D28D9;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #6D28D9;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
@@ -2665,7 +2574,6 @@
     background: #F5F3FF;
     color: #6D28D9;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
@@ -2834,12 +2742,12 @@
     background: #8B5CF6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(139, 92, 246, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #6D28D9;
     background: #F5F3FF;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #6D28D9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #6D28D9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #6D28D9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #a28fff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #8B5CF6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #8B5CF6;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F5F3FF;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #6D28D9;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6D28D9;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6D28D9;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #DDD6FE;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F5F3FF;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #6D28D9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6D28D9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6D28D9;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #6D28D9;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #8B5CF6;
     color: #8B5CF6;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #8B5CF6;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #8B5CF6;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #8B5CF6;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #8B5CF6;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #8B5CF6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #8B5CF6;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #c5aefb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #c5aefb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #8B5CF6;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #8B5CF6;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #c5aefb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #c5aefb, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #8B5CF6;
     color: #ffffff;

--- a/public/themes/lara-light-teal/theme.css
+++ b/public/themes/lara-light-teal/theme.css
@@ -293,40 +293,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #6b7280;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -338,15 +330,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -363,7 +352,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -407,7 +395,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4b5563;
@@ -442,11 +429,9 @@
     background: #ffffff;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +458,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -483,13 +468,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
@@ -498,14 +483,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4b5563;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #14b8a6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -654,7 +639,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -697,7 +681,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -739,7 +722,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f3f4f6;
   }
@@ -749,7 +731,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -798,7 +779,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e24c4c;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f3f4f6;
   }
@@ -811,7 +791,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #0f766e;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -849,25 +828,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -911,7 +886,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4b5563;
@@ -975,7 +949,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f3f4f6;
   }
@@ -988,7 +961,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f3f4f6;
     color: #6b7280;
@@ -1001,68 +973,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d1d5db;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1104,7 +1068,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e24c4c;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1137,59 +1100,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #6b7280;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6b7280;
   }
-
   :-moz-placeholder {
     color: #6b7280;
   }
-
   ::-moz-placeholder {
     color: #6b7280;
   }
-
   :-ms-input-placeholder {
     color: #6b7280;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f3f4f6;
   }
@@ -1199,17 +1150,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4b5563;
@@ -1271,7 +1219,6 @@
   .p-listbox.p-invalid {
     border-color: #e24c4c;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1299,7 +1246,6 @@
     color: #0f766e;
     background: #0f766e;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1349,7 +1295,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1359,7 +1304,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1445,7 +1389,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f3f4f6;
   }
@@ -1455,11 +1398,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e24c4c;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1481,7 +1422,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1525,7 +1465,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f3f4f6;
   }
@@ -1538,7 +1477,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #0f766e;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1568,7 +1506,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1576,7 +1513,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1585,7 +1522,7 @@
     color: #4b5563;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1594,7 +1531,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1603,13 +1540,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1649,7 +1585,6 @@
     background: #14b8a6;
     border-color: #14b8a6;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1696,11 +1631,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e24c4c;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4b5563;
@@ -1760,7 +1693,6 @@
     color: #4b5563;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f3f4f6;
   }
@@ -1770,7 +1702,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d1d5db;
@@ -1778,7 +1709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6b7280;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1787,7 +1718,7 @@
     color: #4b5563;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #374151;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1796,7 +1727,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1805,13 +1736,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e24c4c;
   }
-
   .p-button {
     color: #ffffff;
     background: #14b8a6;
@@ -1923,7 +1853,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1959,7 +1889,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1972,7 +1901,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
@@ -2021,7 +1949,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0ea5e9;
@@ -2070,7 +1997,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
@@ -2119,7 +2045,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #f97316;
@@ -2168,7 +2093,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
@@ -2217,7 +2141,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
@@ -2266,7 +2189,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #0f766e;
     background: transparent;
@@ -2290,7 +2212,6 @@
     color: #0f766e;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2372,12 +2293,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
@@ -2406,7 +2326,6 @@
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0ea5e9;
@@ -2435,7 +2354,6 @@
     border-color: transparent;
     color: #0ea5e9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
@@ -2464,7 +2382,6 @@
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f97316;
@@ -2493,7 +2410,6 @@
     border-color: transparent;
     color: #f97316;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
@@ -2522,7 +2438,6 @@
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
@@ -2551,7 +2466,6 @@
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2563,7 +2477,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2574,55 +2490,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2633,13 +2542,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
@@ -2665,7 +2574,6 @@
     background: #0f766e;
     color: #0f766e;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2759,9 +2667,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -2771,17 +2679,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
@@ -2834,12 +2742,12 @@
     background: #14b8a6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f9fafb;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f9fafb;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2949,11 +2857,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(20, 184, 166, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2997,7 +2903,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3034,12 +2939,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3067,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3087,7 +2989,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4b5563;
@@ -3125,7 +3026,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #e5e7eb;
@@ -3154,7 +3054,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3219,7 +3118,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f3f4f6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f3f4f6;
     color: #4b5563;
@@ -3258,7 +3156,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6b7280;
@@ -3268,9 +3165,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6b7280;
@@ -3281,9 +3178,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f3f4f6;
     border-color: transparent;
     color: #374151;
@@ -3339,7 +3236,6 @@
     border-color: transparent;
     color: #374151;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3398,7 +3294,6 @@
     color: #0f766e;
     background: #0f766e;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3454,11 +3349,11 @@
     color: #0f766e;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #0f766e;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #0f766e;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3496,7 +3391,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #0c5e58;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3632,7 +3526,7 @@
     background: #14b8a6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f9fafb;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3709,7 +3603,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #14b8a6;
     border-radius: 50%;
@@ -3721,20 +3614,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3783,7 +3675,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4b5563;
@@ -3809,7 +3700,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3850,7 +3740,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3874,7 +3763,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3924,7 +3812,6 @@
     color: #4b5563;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3941,12 +3828,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f9fafb;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4006,7 +3891,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #f9fafb;
     border: 1px solid #e5e7eb;
@@ -4017,7 +3901,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4b5563;
@@ -4065,7 +3948,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4141,7 +4023,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4b5563;
@@ -4183,7 +4064,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4b5563;
@@ -4194,7 +4074,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -4204,13 +4084,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #374151;
     border-color: transparent;
     background: #f3f4f6;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
@@ -4221,7 +4101,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4b5563;
     color: #ffffff;
@@ -4241,7 +4120,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4b5563;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f9fafb;
     padding: 1.25rem;
@@ -4272,7 +4150,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4304,7 +4181,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6b7280;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4376,7 +4252,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4391,32 +4266,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4433,22 +4307,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4499,19 +4373,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #0f766e;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #0f766e;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0f766e;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0f766e;
   }
   .p-megamenu .p-menuitem-link {
@@ -4681,7 +4555,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4742,7 +4615,6 @@
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f9fafb;
@@ -4820,19 +4692,19 @@
     box-shadow: inset 0 0 0 0.15rem #99f6e4;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #0f766e;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #0f766e;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #0f766e;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #0f766e;
   }
   .p-menubar .p-submenu-list {
@@ -4862,7 +4734,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #0f766e;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5083,7 +4954,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5161,7 +5031,6 @@
     padding: 0.75rem 1.25rem;
     color: #4b5563;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5206,7 +5075,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5247,7 +5115,6 @@
     border-color: #14b8a6;
     color: #14b8a6;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5322,7 +5189,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5378,7 +5244,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5467,7 +5332,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 1;
   }
@@ -5478,7 +5342,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5518,7 +5381,7 @@
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5528,7 +5391,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5538,7 +5401,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5548,10 +5411,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5582,11 +5444,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5640,7 +5502,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f9fafb;
@@ -5650,7 +5512,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f9fafb;
   }
@@ -5662,15 +5524,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,15 +5539,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5712,7 +5568,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5733,15 +5588,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #4b5563;
@@ -5775,7 +5627,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5797,7 +5648,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e5e7eb;
     border-radius: 6px;
@@ -5805,7 +5655,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #14b8a6;
     color: #ffffff;
@@ -5838,7 +5687,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5853,7 +5701,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5869,7 +5716,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4b5563;
@@ -5881,7 +5727,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #14b8a6;
     color: #ffffff;
@@ -5923,7 +5768,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #14b8a6;
     color: #ffffff;
@@ -5953,16 +5797,13 @@
   .p-button-label {
     font-weight: 700;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
@@ -5975,65 +5816,55 @@
     background-color: #14b8a6;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #14b8a6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #14b8a6;
   }
-
   .p-button:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #75f0e3, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #75f0e3, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-secondary:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #b0b9c6, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-success:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #88eaac, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-info:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #83d3f8, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-warning:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #fcb98b, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-help:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #d4aafb, 0 1px 2px 0 rgb(0, 0, 0);
   }
   .p-button.p-button-danger:enabled:focus {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #f7a2a2, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #14b8a6;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #14b8a6;
   }
-
   .p-speeddial-item.p-focus > .p-speeddial-action {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #75f0e3, 0 1px 2px 0 black;
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #75f0e3, 0 1px 2px 0 rgb(0, 0, 0);
   }
-
   .p-toast-message {
     backdrop-filter: blur(10px);
   }
-
   .p-inline-message-text {
     font-weight: 500;
   }
-
   .p-picklist-buttons .p-button,
-.p-orderlist-controls .p-button {
+  .p-orderlist-controls .p-button {
     transition: opacity 0.2s, background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-
   .p-steps .p-steps-item.p-highlight .p-steps-number {
     background: #14b8a6;
     color: #ffffff;

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #e57373;
   }
-
   .p-text-secondary {
     color: #888888;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-autocomplete-panel {
     background: #323232;
     color: #dedede;
@@ -423,11 +410,9 @@
     background: #191919;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #323232;
@@ -454,23 +439,23 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #dedede;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #FFE082;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -545,7 +530,7 @@
   .p-datepicker .p-timepicker button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-cascadeselect-panel {
     background: #323232;
     color: #dedede;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #4b4b4b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e57373;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #4b4b4b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #FFCA28;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #212529;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-dropdown-panel {
     background: #323232;
     color: #dedede;
@@ -960,7 +933,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #4b4b4b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #252525;
     color: #888888;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #4b4b4b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e57373;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e57373;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #9b9b9b;
   }
-
   :-moz-placeholder {
     color: #9b9b9b;
   }
-
   ::-moz-placeholder {
     color: #9b9b9b;
   }
-
   :-ms-input-placeholder {
     color: #9b9b9b;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #4b4b4b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #4b4b4b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #323232;
     color: #dedede;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #e57373;
   }
-
   .p-mention-panel {
     background: #323232;
     color: #dedede;
@@ -1284,7 +1230,6 @@
     color: #212529;
     background: #FFE082;
   }
-
   .p-multiselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #323232;
     color: #dedede;
@@ -1374,7 +1317,7 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1430,7 +1373,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #4b4b4b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #323232;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #AED581;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #4b4b4b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #FFCA28;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #212529;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #212529;
   }
-
   .p-selectbutton .p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #888888;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #dedede;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-slider {
     background: #4b4b4b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #FFE082;
     border-color: #FFE082;
   }
-
   .p-treeselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #323232;
     color: #dedede;
@@ -1729,7 +1659,7 @@
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1753,7 +1683,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #4b4b4b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-togglebutton.p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #888888;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #dedede;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-button {
     color: #212529;
     background: #FFE082;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #B0BEC5;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212529;
     background: #4FC3F7;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212529;
     background: #AED581;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FFB74D;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212529;
     background: #E57373;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-button.p-button-link {
     color: #FFE082;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #FFE082;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #B0BEC5;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4FC3F7;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #AED581;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFB74D;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #E57373;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,58 +2480,51 @@
     background: #4d4d4d;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2658,7 +2564,6 @@
     background: #FFE082;
     color: #212529;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,29 +2657,29 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2827,12 +2732,12 @@
     background: #FFE082;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #191919;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #252525;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(255, 224, 130, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,16 +2929,14 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3060,11 +2960,10 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-overlay {
     background: #323232;
     color: #dedede;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #191919;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #4c4c4c;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #4c4c4c;
     color: #dedede;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-paginator {
     background: #252525;
     color: #dedede;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #dedede;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #4c4c4c;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #4c4c4c;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #212529;
     background: #FFE082;
   }
-
   .p-tree {
     border: 1px solid #191919;
     background: #323232;
@@ -3411,7 +3303,7 @@
     margin-right: 0.5rem;
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3447,11 +3339,11 @@
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #ffcd35;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3577,7 +3468,7 @@
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3625,7 +3516,7 @@
     background: #FFE082;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #191919;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #191919;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #191919;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #323232;
     color: #dedede;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #191919;
     background: #323232;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #323232;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #191919;
     padding: 0.857rem 1rem;
@@ -3882,7 +3767,7 @@
   .p-panel .p-panel-header .p-panel-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3917,7 +3802,6 @@
     color: #dedede;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #191919;
     background: #323232;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #4b4b4b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f3f3f;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #191919;
     border: 1px solid #191919;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #323232;
     color: #dedede;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4079,7 +3958,7 @@
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #323232;
     color: #dedede;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #191919;
   }
-
   .p-sidebar {
     background: #323232;
     color: #dedede;
@@ -4187,23 +4064,23 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4c4c4c;
     color: #dedede;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4c4c4c;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #191919;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #252525;
     border: 1px solid #191919;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #dedede;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #252525;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #FFE082;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #252525;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #252525;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem white;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #FFE082;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #252525;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #dedede;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #FFE082;
     color: #212529;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #252525;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #4b4b4b;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #323232;
   }
-
   .p-chip {
     background-color: #4b4b4b;
     color: #dedede;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #FFE082;
     color: #212529;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #212529;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #323232;
     color: #dedede;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #FFE082;
     color: #212529;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #FFE082;
     color: #212529;

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #e57373;
   }
-
   .p-text-secondary {
     color: #888888;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-autocomplete-panel {
     background: #323232;
     color: #dedede;
@@ -423,11 +410,9 @@
     background: #191919;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #323232;
@@ -454,23 +439,23 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #dedede;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #81D4FA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -545,7 +530,7 @@
   .p-datepicker .p-timepicker button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-cascadeselect-panel {
     background: #323232;
     color: #dedede;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #4b4b4b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e57373;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #4b4b4b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #29B6F6;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #212529;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-dropdown-panel {
     background: #323232;
     color: #dedede;
@@ -960,7 +933,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #4b4b4b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #252525;
     color: #888888;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #4b4b4b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e57373;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e57373;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #9b9b9b;
   }
-
   :-moz-placeholder {
     color: #9b9b9b;
   }
-
   ::-moz-placeholder {
     color: #9b9b9b;
   }
-
   :-ms-input-placeholder {
     color: #9b9b9b;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #4b4b4b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #4b4b4b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #323232;
     color: #dedede;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #e57373;
   }
-
   .p-mention-panel {
     background: #323232;
     color: #dedede;
@@ -1284,7 +1230,6 @@
     color: #212529;
     background: #81D4FA;
   }
-
   .p-multiselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #323232;
     color: #dedede;
@@ -1374,7 +1317,7 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1430,7 +1373,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #4b4b4b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #323232;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #AED581;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #4b4b4b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #29B6F6;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #212529;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #212529;
   }
-
   .p-selectbutton .p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #888888;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #dedede;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-slider {
     background: #4b4b4b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #81D4FA;
     border-color: #81D4FA;
   }
-
   .p-treeselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #323232;
     color: #dedede;
@@ -1729,7 +1659,7 @@
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1753,7 +1683,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #4b4b4b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-togglebutton.p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #888888;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #dedede;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-button {
     color: #212529;
     background: #81D4FA;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #B0BEC5;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212529;
     background: #4FC3F7;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212529;
     background: #AED581;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FFB74D;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212529;
     background: #E57373;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-button.p-button-link {
     color: #81D4FA;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #81D4FA;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #B0BEC5;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4FC3F7;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #AED581;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFB74D;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #E57373;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,58 +2480,51 @@
     background: #4d4d4d;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2658,7 +2564,6 @@
     background: #81D4FA;
     color: #212529;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,29 +2657,29 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2827,12 +2732,12 @@
     background: #81D4FA;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #191919;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #252525;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(129, 212, 250, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,16 +2929,14 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3060,11 +2960,10 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-overlay {
     background: #323232;
     color: #dedede;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #191919;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #4c4c4c;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #4c4c4c;
     color: #dedede;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-paginator {
     background: #252525;
     color: #dedede;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #dedede;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #4c4c4c;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #4c4c4c;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #212529;
     background: #81D4FA;
   }
-
   .p-tree {
     border: 1px solid #191919;
     background: #323232;
@@ -3411,7 +3303,7 @@
     margin-right: 0.5rem;
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3447,11 +3339,11 @@
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #38bbf7;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3577,7 +3468,7 @@
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3625,7 +3516,7 @@
     background: #81D4FA;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #191919;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #191919;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #191919;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #323232;
     color: #dedede;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #191919;
     background: #323232;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #323232;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #191919;
     padding: 0.857rem 1rem;
@@ -3882,7 +3767,7 @@
   .p-panel .p-panel-header .p-panel-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3917,7 +3802,6 @@
     color: #dedede;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #191919;
     background: #323232;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #4b4b4b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f3f3f;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #191919;
     border: 1px solid #191919;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #323232;
     color: #dedede;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4079,7 +3958,7 @@
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #323232;
     color: #dedede;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #191919;
   }
-
   .p-sidebar {
     background: #323232;
     color: #dedede;
@@ -4187,23 +4064,23 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4c4c4c;
     color: #dedede;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4c4c4c;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #191919;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #252525;
     border: 1px solid #191919;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #dedede;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #252525;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #81D4FA;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #252525;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #252525;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem white;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #81D4FA;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #252525;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #dedede;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #81D4FA;
     color: #212529;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #252525;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #4b4b4b;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #323232;
   }
-
   .p-chip {
     background-color: #4b4b4b;
     color: #dedede;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #81D4FA;
     color: #212529;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #212529;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #323232;
     color: #dedede;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #81D4FA;
     color: #212529;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #81D4FA;
     color: #212529;

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #e57373;
   }
-
   .p-text-secondary {
     color: #888888;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-autocomplete-panel {
     background: #323232;
     color: #dedede;
@@ -423,11 +410,9 @@
     background: #191919;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #323232;
@@ -454,23 +439,23 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #dedede;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #C5E1A5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -545,7 +530,7 @@
   .p-datepicker .p-timepicker button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-cascadeselect-panel {
     background: #323232;
     color: #dedede;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #4b4b4b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e57373;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #4b4b4b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #9CCC65;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #212529;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-dropdown-panel {
     background: #323232;
     color: #dedede;
@@ -960,7 +933,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #4b4b4b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #252525;
     color: #888888;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #4b4b4b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e57373;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e57373;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #9b9b9b;
   }
-
   :-moz-placeholder {
     color: #9b9b9b;
   }
-
   ::-moz-placeholder {
     color: #9b9b9b;
   }
-
   :-ms-input-placeholder {
     color: #9b9b9b;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #4b4b4b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #4b4b4b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #323232;
     color: #dedede;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #e57373;
   }
-
   .p-mention-panel {
     background: #323232;
     color: #dedede;
@@ -1284,7 +1230,6 @@
     color: #212529;
     background: #C5E1A5;
   }
-
   .p-multiselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #323232;
     color: #dedede;
@@ -1374,7 +1317,7 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1430,7 +1373,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #4b4b4b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #323232;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #AED581;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #4b4b4b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #9CCC65;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #212529;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #212529;
   }
-
   .p-selectbutton .p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #888888;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #dedede;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-slider {
     background: #4b4b4b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #C5E1A5;
     border-color: #C5E1A5;
   }
-
   .p-treeselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #323232;
     color: #dedede;
@@ -1729,7 +1659,7 @@
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1753,7 +1683,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #4b4b4b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-togglebutton.p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #888888;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #dedede;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-button {
     color: #212529;
     background: #C5E1A5;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #B0BEC5;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212529;
     background: #4FC3F7;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212529;
     background: #AED581;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FFB74D;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212529;
     background: #E57373;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-button.p-button-link {
     color: #C5E1A5;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #C5E1A5;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #B0BEC5;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4FC3F7;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #AED581;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFB74D;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #E57373;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,58 +2480,51 @@
     background: #4d4d4d;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2658,7 +2564,6 @@
     background: #C5E1A5;
     color: #212529;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,29 +2657,29 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2827,12 +2732,12 @@
     background: #C5E1A5;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #191919;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #252525;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(197, 225, 165, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,16 +2929,14 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3060,11 +2960,10 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-overlay {
     background: #323232;
     color: #dedede;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #191919;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #4c4c4c;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #4c4c4c;
     color: #dedede;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-paginator {
     background: #252525;
     color: #dedede;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #dedede;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #4c4c4c;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #4c4c4c;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #212529;
     background: #C5E1A5;
   }
-
   .p-tree {
     border: 1px solid #191919;
     background: #323232;
@@ -3411,7 +3303,7 @@
     margin-right: 0.5rem;
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3447,11 +3339,11 @@
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #9fce6b;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3577,7 +3468,7 @@
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3625,7 +3516,7 @@
     background: #C5E1A5;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #191919;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #191919;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #191919;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #323232;
     color: #dedede;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #191919;
     background: #323232;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #323232;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #191919;
     padding: 0.857rem 1rem;
@@ -3882,7 +3767,7 @@
   .p-panel .p-panel-header .p-panel-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3917,7 +3802,6 @@
     color: #dedede;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #191919;
     background: #323232;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #4b4b4b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f3f3f;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #191919;
     border: 1px solid #191919;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #323232;
     color: #dedede;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4079,7 +3958,7 @@
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #323232;
     color: #dedede;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #191919;
   }
-
   .p-sidebar {
     background: #323232;
     color: #dedede;
@@ -4187,23 +4064,23 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4c4c4c;
     color: #dedede;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4c4c4c;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #191919;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #252525;
     border: 1px solid #191919;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #dedede;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #252525;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #C5E1A5;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #252525;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #252525;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem white;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #C5E1A5;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #252525;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #dedede;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #C5E1A5;
     color: #212529;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #252525;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #4b4b4b;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #323232;
   }
-
   .p-chip {
     background-color: #4b4b4b;
     color: #dedede;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #C5E1A5;
     color: #212529;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #212529;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #323232;
     color: #dedede;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #C5E1A5;
     color: #212529;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #C5E1A5;
     color: #212529;

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #e57373;
   }
-
   .p-text-secondary {
     color: #888888;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-autocomplete-panel {
     background: #323232;
     color: #dedede;
@@ -423,11 +410,9 @@
     background: #191919;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #323232;
@@ -454,23 +439,23 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #dedede;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #F48FB1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -545,7 +530,7 @@
   .p-datepicker .p-timepicker button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-cascadeselect-panel {
     background: #323232;
     color: #dedede;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #4b4b4b;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e57373;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #4b4b4b;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #EC407A;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #212529;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-dropdown-panel {
     background: #323232;
     color: #dedede;
@@ -960,7 +933,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #4b4b4b;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #252525;
     color: #888888;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #4b4b4b;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e57373;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e57373;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #888888;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #9b9b9b;
   }
-
   :-moz-placeholder {
     color: #9b9b9b;
   }
-
   ::-moz-placeholder {
     color: #9b9b9b;
   }
-
   :-ms-input-placeholder {
     color: #9b9b9b;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #4b4b4b;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #4b4b4b;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #323232;
     color: #dedede;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #e57373;
   }
-
   .p-mention-panel {
     background: #323232;
     color: #dedede;
@@ -1284,7 +1230,6 @@
     color: #212529;
     background: #F48FB1;
   }
-
   .p-multiselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #323232;
     color: #dedede;
@@ -1374,7 +1317,7 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1430,7 +1373,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #4b4b4b;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e57373;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #323232;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #AED581;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #4b4b4b;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #EC407A;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #212529;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #212529;
   }
-
   .p-selectbutton .p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #888888;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #dedede;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-slider {
     background: #4b4b4b;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: #F48FB1;
     border-color: #F48FB1;
   }
-
   .p-treeselect {
     background: #191919;
     border: 1px solid #4b4b4b;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e57373;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #323232;
     color: #dedede;
@@ -1729,7 +1659,7 @@
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -1753,7 +1683,6 @@
     color: #dedede;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #4b4b4b;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #4b4b4b;
   }
-
   .p-togglebutton.p-button {
     background: #252525;
     border: 1px solid #252525;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #888888;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #dedede;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #dedede;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e57373;
   }
-
   .p-button {
     color: #212529;
     background: #F48FB1;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #B0BEC5;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212529;
     background: #4FC3F7;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212529;
     background: #AED581;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FFB74D;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212529;
     background: #E57373;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-button.p-button-link {
     color: #F48FB1;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #F48FB1;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #B0BEC5;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #B0BEC5;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4FC3F7;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #4FC3F7;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #AED581;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #AED581;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFB74D;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #FFB74D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #E57373;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #E57373;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,58 +2480,51 @@
     background: #4d4d4d;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2658,7 +2564,6 @@
     background: #F48FB1;
     color: #212529;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,29 +2657,29 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -2827,12 +2732,12 @@
     background: #F48FB1;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #191919;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #252525;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(244, 143, 177, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,16 +2929,14 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3060,11 +2960,10 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-column-filter-overlay {
     background: #323232;
     color: #dedede;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #191919;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #4c4c4c;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #4c4c4c;
     color: #dedede;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-paginator {
     background: #252525;
     color: #dedede;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #dedede;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #4c4c4c;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #4c4c4c;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #212529;
     background: #F48FB1;
   }
-
   .p-tree {
     border: 1px solid #191919;
     background: #323232;
@@ -3411,7 +3303,7 @@
     margin-right: 0.5rem;
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3447,11 +3339,11 @@
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #212529;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #ed4980;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3577,7 +3468,7 @@
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3625,7 +3516,7 @@
     background: #F48FB1;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #191919;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #191919;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #191919;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #323232;
     color: #dedede;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #191919;
     background: #323232;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #323232;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #191919;
     padding: 0.857rem 1rem;
@@ -3882,7 +3767,7 @@
   .p-panel .p-panel-header .p-panel-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -3917,7 +3802,6 @@
     color: #dedede;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #191919;
     background: #323232;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #4b4b4b;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3f3f3f;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #191919;
     border: 1px solid #191919;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #323232;
     color: #dedede;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4079,7 +3958,7 @@
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #323232;
     color: #dedede;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #191919;
   }
-
   .p-sidebar {
     background: #323232;
     color: #dedede;
@@ -4187,23 +4064,23 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
-    color: #8888;
+    color: rgba(136, 136, 136, 0.5333333333);
     border: 0 none;
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #dedede;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4c4c4c;
     color: #dedede;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4c4c4c;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #191919;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #252525;
     border: 1px solid #191919;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #dedede;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #252525;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F48FB1;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #252525;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #252525;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem white;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #F48FB1;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #212529;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #212529;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #212529;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #252525;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #dedede;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #F48FB1;
     color: #212529;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #252525;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #4b4b4b;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #323232;
   }
-
   .p-chip {
     background-color: #4b4b4b;
     color: #dedede;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #F48FB1;
     color: #212529;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem white;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #212529;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #323232;
     color: #dedede;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #F48FB1;
     color: #212529;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #F48FB1;
     color: #212529;

--- a/public/themes/md-dark-deeppurple/theme.css
+++ b/public/themes/md-dark-deeppurple/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -243,7 +240,7 @@
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options .ql-picker-item:hover {
   color: rgba(255, 255, 255, 0.87);
-  background: rgba(255, 255, 255, 0.04);
+  background: hsla(0deg, 0%, 100%, 0.04);
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded:not(.ql-icon-picker) .ql-picker-item {
   padding: 1rem 1rem;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #f44435;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 1rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-autocomplete-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -434,7 +418,7 @@
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item.p-highlight {
     color: #CE93D8;
@@ -447,16 +431,14 @@
     background: transparent;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-datepicker:not(.p-datepicker-inline) {
@@ -473,12 +455,12 @@
     background: #1e1e1e;
     font-weight: 500;
     margin: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #CE93D8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -557,13 +539,13 @@
   }
   .p-datepicker .p-datepicker-buttonbar {
     padding: 1rem 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
     width: auto;
   }
   .p-datepicker .p-timepicker {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding: 0.5rem;
   }
   .p-datepicker .p-timepicker button {
@@ -622,7 +604,7 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding-right: 0.5rem;
     padding-left: 0.5rem;
     padding-top: 0;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -667,7 +648,7 @@
   }
   .p-cascadeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-cascadeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -735,7 +715,7 @@
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item .p-cascadeselect-group-icon {
     font-size: 0.875rem;
@@ -744,23 +724,21 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
   }
   .p-checkbox .p-checkbox-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 18px;
     height: 18px;
@@ -803,20 +781,18 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44435;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-checkbox .p-checkbox-box.p-highlight {
     background: #CE93D8;
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #CE93D8;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.5rem 1rem;
     gap: 0.5rem;
@@ -854,28 +830,24 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2b2b2b;
     border: 1px solid #1e1e1e;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-dropdown-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -926,7 +897,7 @@
   }
   .p-dropdown-panel .p-dropdown-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -966,7 +937,7 @@
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item-group {
     margin: 0;
@@ -980,100 +951,90 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
-    border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.3);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-right: 1px solid hsla(0deg, 0%, 100%, 0.3);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
   }
   .p-inputswitch .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 0.5rem;
   }
@@ -1095,7 +1056,7 @@
     box-shadow: none;
   }
   .p-inputswitch:not(.p-disabled):hover .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
     background: rgba(206, 147, 216, 0.5);
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44435;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1117,7 +1077,7 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     padding: 1rem 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     appearance: none;
     border-radius: 4px;
@@ -1142,88 +1102,73 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-float-label > label {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44435;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 3rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 3rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 3rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-inputtext:enabled:focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.875rem 0.875rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-listbox .p-listbox-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
@@ -1271,12 +1216,11 @@
   }
   .p-listbox:not(.p-disabled) .p-listbox-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-listbox.p-invalid {
     border-color: #f44435;
   }
-
   .p-mention-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1298,16 +1242,15 @@
   }
   .p-mention-panel .p-mention-items .p-mention-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-mention-panel .p-mention-items .p-mention-item.p-highlight {
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-multiselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1333,7 +1276,7 @@
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.5rem 1rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 2rem;
   }
-
   .p-multiselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1374,7 +1315,7 @@
   }
   .p-multiselect-panel .p-multiselect-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1428,7 +1369,7 @@
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:focus {
     outline: 0 none;
@@ -1450,21 +1391,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1486,13 +1424,12 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
   }
   .p-radiobutton .p-radiobutton-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 20px;
     height: 20px;
@@ -1530,12 +1467,11 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight {
     background: #121212;
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #121212;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f44435;
   }
-
   .p-selectbutton .p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,15 +1542,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     border: 0 none;
     border-radius: 4px;
   }
@@ -1654,10 +1587,9 @@
     background: #CE93D8;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1683,7 +1615,7 @@
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.5rem 1rem;
   }
-
   .p-treeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1715,7 +1645,7 @@
   }
   .p-treeselect-panel .p-treeselect-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1765,17 +1695,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-togglebutton.p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-button {
     color: #121212;
     background: #CE93D8;
@@ -1928,7 +1855,7 @@
     padding: 0.714rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #A5D6A7;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #A5D6A7;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212121;
     background: #90CAF9;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212121;
     background: #C5E1A5;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212121;
     background: #FFF59D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #212121;
     background: #CE93D8;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212121;
     background: #EF9A9A;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-button.p-button-link {
     color: #CE93D8;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #CE93D8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A5D6A7;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #A5D6A7;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #90CAF9;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFF59D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF9A9A;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(165, 214, 167, 0.92);
     color: #212121;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(206, 147, 216, 0.16);
     color: #CE93D8;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #CE93D8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -3119,7 +3017,7 @@
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:focus-visible {
     outline: 0 none;
@@ -3127,13 +3025,12 @@
     box-shadow: none;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -3142,7 +3039,7 @@
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
     margin-bottom: 0.5rem;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3206,7 +3102,7 @@
     transition: transform 0.2s, none;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
@@ -3222,11 +3118,10 @@
     background: rgba(255, 255, 255, 0.02);
   }
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-organizationchart .p-organizationchart-node-content.p-highlight {
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3391,7 +3284,7 @@
     transition: transform 0.2s, none;
   }
   .p-picklist .p-picklist-list .p-picklist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus {
@@ -3403,7 +3296,6 @@
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-tree {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3459,19 +3351,19 @@
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-dragover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-filter-container {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(182, 94, 197, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #CE93D8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.5rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3889,7 +3775,7 @@
     padding: 0 1.25rem;
   }
   .p-divider.p-divider-horizontal:before {
-    border-top: 1px rgba(255, 255, 255, 0.12);
+    border-top: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-horizontal .p-divider-content {
     padding: 0 0.5rem;
@@ -3899,12 +3785,11 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-left: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid rgba(255, 255, 255, 0.12);
     padding: 1rem;
@@ -3954,7 +3839,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3963,20 +3847,18 @@
   }
   .p-splitter .p-splitter-gutter {
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-splitter .p-splitter-gutter .p-splitter-gutter-handle {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
   .p-splitter .p-splitter-gutter-resizing {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(255, 255, 255, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #262626;
   }
-
   .p-sidebar {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #444444;
     color: rgba(255, 255, 255, 0.87);
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #444444;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2b2b2b;
@@ -4395,7 +4268,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-contextmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-contextmenu .p-submenu-icon {
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4598,7 +4469,7 @@
     width: 12.5rem;
   }
   .p-megamenu .p-megamenu-submenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
@@ -4640,7 +4511,7 @@
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-submenu-icon {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -4769,10 +4639,9 @@
     border-top-left-radius: 0;
   }
   .p-menu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 1rem;
     background: #1e1e1e;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4873,7 +4742,7 @@
     width: 12.5rem;
   }
   .p-menubar .p-submenu-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-menubar .p-submenu-list .p-submenu-icon {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -4924,7 +4792,7 @@
       width: 100%;
     }
     .p-menubar .p-menubar-root-list .p-menu-separator {
-      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
       margin: 0.5rem 0;
     }
     .p-menubar .p-menubar-root-list .p-submenu-icon {
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5201,7 +5068,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-slidemenu .p-slidemenu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-slidemenu .p-slidemenu-icon {
@@ -5215,7 +5082,6 @@
     padding: 1rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5252,7 +5118,7 @@
   }
   .p-steps .p-steps-item:before {
     content: " ";
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     width: 100%;
     top: 50%;
     left: 0;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(255, 255, 255, 0.12);
     color: #CE93D8;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5365,7 +5229,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tieredmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-tieredmenu .p-submenu-icon {
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 1rem 1rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.5rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,9 +5619,8 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     border-radius: 4px;
   }
   .p-avatar.p-avatar-lg {
@@ -5787,17 +5639,14 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
     padding: 0 1rem;
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #CE93D8;
     color: #121212;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #121212;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #CE93D8;
     color: #121212;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #CE93D8;
     color: #121212;
@@ -6042,17 +5883,15 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6062,13 +5901,13 @@
     background: transparent;
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(165, 214, 167, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(165, 214, 167, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(144, 202, 249, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(197, 225, 165, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(255, 245, 157, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.76);
   }
@@ -6276,9 +6104,8 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(239, 154, 154, 0.16);
   }
-
   .p-calendar-w-btn {
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     background: #1e1e1e;
     border-radius: 4px;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
@@ -6314,7 +6141,6 @@
     border-color: #CE93D8;
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6329,7 +6155,7 @@
     order: 3;
   }
   .p-datepicker table th {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.38);
     font-weight: 400;
     font-size: 0.875rem;
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(206, 147, 216, 0.16);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
@@ -6353,13 +6178,12 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6369,13 +6193,13 @@
     background: transparent;
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-focus, .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #A5D6A7;
     color: #121212;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,17 +6253,15 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6451,13 +6271,13 @@
     background: transparent;
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus, .p-input-filled .p-cascadeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6488,25 +6308,23 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-checkbox .p-checkbox-box {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
     border-radius: 2px;
     position: relative;
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled).p-focus {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #CE93D8;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,13 +6380,12 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6580,13 +6395,13 @@
     background: transparent;
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #CE93D8;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #CE93D8;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,17 +6464,15 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6675,13 +6482,13 @@
     background: transparent;
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus, .p-input-filled .p-dropdown:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,32 +6524,30 @@
     background: rgba(165, 214, 167, 0.68);
     color: #121212;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));
   }
   .p-input-filled .p-inputtext:enabled:focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6760,13 +6563,12 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12), 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #CE93D8;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
@@ -6918,13 +6706,12 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6934,13 +6721,13 @@
     background: transparent;
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus, .p-input-filled .p-multiselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,30 +6858,27 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled):not(.p-highlight):hover {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #CE93D8;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(244, 68, 53, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);
@@ -7159,11 +6930,9 @@
     background: #262626;
     border-color: rgba(255, 255, 255, 0.12);
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(165, 214, 167, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(165, 214, 167, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(144, 202, 249, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(197, 225, 165, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 245, 157, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(239, 154, 154, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #CE93D8;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,17 +7113,15 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -7378,13 +7131,13 @@
     background: transparent;
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus, .p-input-filled .p-treeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #CE93D8;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);

--- a/public/themes/md-dark-indigo/theme.css
+++ b/public/themes/md-dark-indigo/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -243,7 +240,7 @@
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options .ql-picker-item:hover {
   color: rgba(255, 255, 255, 0.87);
-  background: rgba(255, 255, 255, 0.04);
+  background: hsla(0deg, 0%, 100%, 0.04);
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded:not(.ql-icon-picker) .ql-picker-item {
   padding: 1rem 1rem;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #f44435;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 1rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-autocomplete-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -434,7 +418,7 @@
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item.p-highlight {
     color: #9FA8DA;
@@ -447,16 +431,14 @@
     background: transparent;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-datepicker:not(.p-datepicker-inline) {
@@ -473,12 +455,12 @@
     background: #1e1e1e;
     font-weight: 500;
     margin: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #9FA8DA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -557,13 +539,13 @@
   }
   .p-datepicker .p-datepicker-buttonbar {
     padding: 1rem 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
     width: auto;
   }
   .p-datepicker .p-timepicker {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding: 0.5rem;
   }
   .p-datepicker .p-timepicker button {
@@ -622,7 +604,7 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding-right: 0.5rem;
     padding-left: 0.5rem;
     padding-top: 0;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -667,7 +648,7 @@
   }
   .p-cascadeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-cascadeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -735,7 +715,7 @@
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item .p-cascadeselect-group-icon {
     font-size: 0.875rem;
@@ -744,23 +724,21 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
   }
   .p-checkbox .p-checkbox-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 18px;
     height: 18px;
@@ -803,20 +781,18 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44435;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-checkbox .p-checkbox-box.p-highlight {
     background: #9FA8DA;
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #9FA8DA;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.5rem 1rem;
     gap: 0.5rem;
@@ -854,28 +830,24 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2b2b2b;
     border: 1px solid #1e1e1e;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-dropdown-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -926,7 +897,7 @@
   }
   .p-dropdown-panel .p-dropdown-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -966,7 +937,7 @@
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item-group {
     margin: 0;
@@ -980,100 +951,90 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
-    border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.3);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-right: 1px solid hsla(0deg, 0%, 100%, 0.3);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
   }
   .p-inputswitch .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 0.5rem;
   }
@@ -1095,7 +1056,7 @@
     box-shadow: none;
   }
   .p-inputswitch:not(.p-disabled):hover .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
     background: rgba(159, 168, 218, 0.5);
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44435;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1117,7 +1077,7 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     padding: 1rem 1rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     appearance: none;
     border-radius: 4px;
@@ -1142,88 +1102,73 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-float-label > label {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44435;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 3rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 3rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 3rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-inputtext:enabled:focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.875rem 0.875rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-listbox .p-listbox-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
@@ -1271,12 +1216,11 @@
   }
   .p-listbox:not(.p-disabled) .p-listbox-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-listbox.p-invalid {
     border-color: #f44435;
   }
-
   .p-mention-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1298,16 +1242,15 @@
   }
   .p-mention-panel .p-mention-items .p-mention-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-mention-panel .p-mention-items .p-mention-item.p-highlight {
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-multiselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1333,7 +1276,7 @@
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.5rem 1rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 2rem;
   }
-
   .p-multiselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1374,7 +1315,7 @@
   }
   .p-multiselect-panel .p-multiselect-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1428,7 +1369,7 @@
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:focus {
     outline: 0 none;
@@ -1450,21 +1391,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1e1e1e;
@@ -1486,13 +1424,12 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
   }
   .p-radiobutton .p-radiobutton-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 20px;
     height: 20px;
@@ -1530,12 +1467,11 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight {
     background: #121212;
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #121212;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f44435;
   }
-
   .p-selectbutton .p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,15 +1542,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     border: 0 none;
     border-radius: 4px;
   }
@@ -1654,10 +1587,9 @@
     background: #9FA8DA;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1683,7 +1615,7 @@
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.5rem 1rem;
   }
-
   .p-treeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1715,7 +1645,7 @@
   }
   .p-treeselect-panel .p-treeselect-header {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1765,17 +1695,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-togglebutton.p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-button {
     color: #121212;
     background: #9FA8DA;
@@ -1928,7 +1855,7 @@
     padding: 0.714rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #F48FB1;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212121;
     background: #90CAF9;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212121;
     background: #C5E1A5;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212121;
     background: #FFF59D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #212121;
     background: #CE93D8;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212121;
     background: #EF9A9A;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-button.p-button-link {
     color: #9FA8DA;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #9FA8DA;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #90CAF9;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFF59D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF9A9A;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(244, 143, 177, 0.92);
     color: #212121;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(159, 168, 218, 0.16);
     color: #9FA8DA;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #9FA8DA;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -3119,7 +3017,7 @@
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:focus-visible {
     outline: 0 none;
@@ -3127,13 +3025,12 @@
     box-shadow: none;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -3142,7 +3039,7 @@
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
     margin-bottom: 0.5rem;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3206,7 +3102,7 @@
     transition: transform 0.2s, none;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
@@ -3222,11 +3118,10 @@
     background: rgba(255, 255, 255, 0.02);
   }
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-organizationchart .p-organizationchart-node-content.p-highlight {
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3391,7 +3284,7 @@
     transition: transform 0.2s, none;
   }
   .p-picklist .p-picklist-list .p-picklist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus {
@@ -3403,7 +3296,6 @@
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-tree {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3459,19 +3351,19 @@
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-dragover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-filter-container {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(105, 119, 197, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #9FA8DA;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.5rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3889,7 +3775,7 @@
     padding: 0 1.25rem;
   }
   .p-divider.p-divider-horizontal:before {
-    border-top: 1px rgba(255, 255, 255, 0.12);
+    border-top: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-horizontal .p-divider-content {
     padding: 0 0.5rem;
@@ -3899,12 +3785,11 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-left: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid rgba(255, 255, 255, 0.12);
     padding: 1rem;
@@ -3954,7 +3839,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3963,20 +3847,18 @@
   }
   .p-splitter .p-splitter-gutter {
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-splitter .p-splitter-gutter .p-splitter-gutter-handle {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
   .p-splitter .p-splitter-gutter-resizing {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(255, 255, 255, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #262626;
   }
-
   .p-sidebar {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #444444;
     color: rgba(255, 255, 255, 0.87);
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #444444;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 1rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2b2b2b;
@@ -4395,7 +4268,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-contextmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-contextmenu .p-submenu-icon {
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4598,7 +4469,7 @@
     width: 12.5rem;
   }
   .p-megamenu .p-megamenu-submenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
@@ -4640,7 +4511,7 @@
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-submenu-icon {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -4769,10 +4639,9 @@
     border-top-left-radius: 0;
   }
   .p-menu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 1rem;
     background: #1e1e1e;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4873,7 +4742,7 @@
     width: 12.5rem;
   }
   .p-menubar .p-submenu-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-menubar .p-submenu-list .p-submenu-icon {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -4924,7 +4792,7 @@
       width: 100%;
     }
     .p-menubar .p-menubar-root-list .p-menu-separator {
-      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
       margin: 0.5rem 0;
     }
     .p-menubar .p-menubar-root-list .p-submenu-icon {
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5201,7 +5068,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-slidemenu .p-slidemenu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-slidemenu .p-slidemenu-icon {
@@ -5215,7 +5082,6 @@
     padding: 1rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5252,7 +5118,7 @@
   }
   .p-steps .p-steps-item:before {
     content: " ";
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     width: 100%;
     top: 50%;
     left: 0;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(255, 255, 255, 0.12);
     color: #9FA8DA;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5365,7 +5229,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tieredmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-tieredmenu .p-submenu-icon {
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 1rem 1rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.5rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,9 +5619,8 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     border-radius: 4px;
   }
   .p-avatar.p-avatar-lg {
@@ -5787,17 +5639,14 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
     padding: 0 1rem;
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #9FA8DA;
     color: #121212;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #121212;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #9FA8DA;
     color: #121212;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #9FA8DA;
     color: #121212;
@@ -6042,17 +5883,15 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6062,13 +5901,13 @@
     background: transparent;
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(244, 143, 177, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(244, 143, 177, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(144, 202, 249, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(197, 225, 165, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(255, 245, 157, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.76);
   }
@@ -6276,9 +6104,8 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(239, 154, 154, 0.16);
   }
-
   .p-calendar-w-btn {
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     background: #1e1e1e;
     border-radius: 4px;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
@@ -6314,7 +6141,6 @@
     border-color: #9FA8DA;
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6329,7 +6155,7 @@
     order: 3;
   }
   .p-datepicker table th {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.38);
     font-weight: 400;
     font-size: 0.875rem;
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(159, 168, 218, 0.16);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
@@ -6353,13 +6178,12 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6369,13 +6193,13 @@
     background: transparent;
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-focus, .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #F48FB1;
     color: #121212;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,17 +6253,15 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6451,13 +6271,13 @@
     background: transparent;
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus, .p-input-filled .p-cascadeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6488,25 +6308,23 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-checkbox .p-checkbox-box {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
     border-radius: 2px;
     position: relative;
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled).p-focus {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #9FA8DA;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,13 +6380,12 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6580,13 +6395,13 @@
     background: transparent;
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #9FA8DA;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #9FA8DA;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,17 +6464,15 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6675,13 +6482,13 @@
     background: transparent;
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus, .p-input-filled .p-dropdown:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,32 +6524,30 @@
     background: rgba(244, 143, 177, 0.68);
     color: #121212;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));
   }
   .p-input-filled .p-inputtext:enabled:focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6760,13 +6563,12 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12), 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #9FA8DA;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
@@ -6918,13 +6706,12 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6934,13 +6721,13 @@
     background: transparent;
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus, .p-input-filled .p-multiselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,30 +6858,27 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled):not(.p-highlight):hover {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #9FA8DA;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(244, 68, 53, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);
@@ -7159,11 +6930,9 @@
     background: #262626;
     border-color: rgba(255, 255, 255, 0.12);
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(159, 168, 218, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(244, 143, 177, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(244, 143, 177, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(144, 202, 249, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(197, 225, 165, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 245, 157, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(239, 154, 154, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #9FA8DA;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,17 +7113,15 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -7378,13 +7131,13 @@
     background: transparent;
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus, .p-input-filled .p-treeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #9FA8DA;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);

--- a/public/themes/md-light-deeppurple/theme.css
+++ b/public/themes/md-light-deeppurple/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #B00020;
   }
-
   .p-text-secondary {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 1rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -447,11 +431,9 @@
     background: #ffffff;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -478,7 +460,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(0, 0, 0, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #673AB7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -549,7 +531,7 @@
   .p-datepicker table td.p-datepicker-today > span {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-color: black;
+    border-color: rgb(0, 0, 0);
   }
   .p-datepicker table td.p-datepicker-today > span.p-highlight {
     color: #673AB7;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f5f5f5;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
@@ -803,7 +781,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #B00020;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f5f5f5;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #673AB7;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.5rem 1rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -980,7 +951,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f5f5f5;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid rgba(0, 0, 0, 0.38);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #B00020;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-float-label > label {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #B00020;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 3rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 3rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 3rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f5f5f5;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #dcdcdc;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.875rem 0.875rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #B00020;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1304,7 +1248,6 @@
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.5rem 1rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 2rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1450,7 +1391,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f5f5f5;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f5f5f5;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #B00020;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,13 +1542,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-slider {
     background: #c1c1c1;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #673AB7;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.5rem 1rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1765,7 +1695,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f5f5f5;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-button {
     color: #ffffff;
     background: #673AB7;
@@ -1928,7 +1855,7 @@
     padding: 0.714rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #4CAF50;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #4CAF50;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #2196F3;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #673AB7;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #673AB7;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4CAF50;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #4CAF50;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #2196F3;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(76, 175, 80, 0.92);
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(103, 58, 183, 0.12);
     color: #673AB7;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #673AB7;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(103, 58, 183, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3130,7 +3028,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 1rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(0, 0, 0, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     color: rgba(0, 0, 0, 0.87);
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(0, 0, 0, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3403,7 +3296,6 @@
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
   }
-
   .p-tree {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3459,11 +3351,11 @@
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(82, 46, 146, 0.12);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #673AB7;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.5rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3904,7 +3790,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e0e0e0;
     padding: 1rem;
@@ -3954,7 +3839,6 @@
     color: rgba(0, 0, 0, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3971,12 +3855,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(0, 0, 0, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 1px solid #e0e0e0;
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: rgba(97, 97, 97, 0.9);
     color: #ffffff;
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: rgba(97, 97, 97, 0.9);
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 1rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e5e5;
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4772,7 +4642,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 1rem;
     background: transparent;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5215,7 +5082,6 @@
     padding: 1rem 1rem;
     color: rgba(0, 0, 0, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(0, 0, 0, 0.12);
     color: #673AB7;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 1rem 1rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.5rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,7 +5619,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: rgba(0, 0, 0, 0.12);
     border-radius: 4px;
@@ -5787,15 +5639,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(0, 0, 0, 0.08);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #673AB7;
     color: #ffffff;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #ffffff;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #673AB7;
     color: #ffffff;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #673AB7;
     color: #ffffff;
@@ -6042,11 +5883,9 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(76, 175, 80, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(76, 175, 80, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(33, 150, 243, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(104, 159, 56, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(251, 192, 45, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(156, 39, 176, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.76);
   }
@@ -6276,7 +6104,6 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(211, 47, 47, 0.16);
   }
-
   .p-calendar-w-btn {
     border: 1px solid rgba(0, 0, 0, 0.38);
     background: #ffffff;
@@ -6314,7 +6141,6 @@
     border-color: #673AB7;
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(103, 58, 183, 0.12);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
@@ -6353,7 +6178,6 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #4CAF50;
     color: #ffffff;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,11 +6253,9 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6488,11 +6308,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,7 +6380,6 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #673AB7;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #673AB7;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,11 +6464,9 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,14 +6524,12 @@
     background: rgba(76, 175, 80, 0.68);
     color: #ffffff;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6760,7 +6563,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #673AB7;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
@@ -6918,7 +6706,6 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,21 +6858,18 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(176, 0, 32, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;
@@ -7159,11 +6930,9 @@
     background: #d9d8d9;
     border-color: #d9d8d9;
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(103, 58, 183, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(76, 175, 80, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(76, 175, 80, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(33, 150, 243, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(104, 159, 56, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(251, 192, 45, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(156, 39, 176, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(211, 47, 47, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #673AB7;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,11 +7113,9 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #673AB7;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;

--- a/public/themes/md-light-indigo/theme.css
+++ b/public/themes/md-light-indigo/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #B00020;
   }
-
   .p-text-secondary {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 1rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -447,11 +431,9 @@
     background: #ffffff;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -478,7 +460,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(0, 0, 0, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #3F51B5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -549,7 +531,7 @@
   .p-datepicker table td.p-datepicker-today > span {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-color: black;
+    border-color: rgb(0, 0, 0);
   }
   .p-datepicker table td.p-datepicker-today > span.p-highlight {
     color: #3F51B5;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f5f5f5;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
@@ -803,7 +781,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #B00020;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f5f5f5;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #3F51B5;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.5rem 1rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -980,7 +951,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f5f5f5;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid rgba(0, 0, 0, 0.38);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #B00020;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-float-label > label {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #B00020;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 3rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 3rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 3rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f5f5f5;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #dcdcdc;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.875rem 0.875rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #B00020;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1304,7 +1248,6 @@
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.5rem 1rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 2rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1450,7 +1391,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f5f5f5;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f5f5f5;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #B00020;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,13 +1542,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-slider {
     background: #c1c1c1;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #3F51B5;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.5rem 1rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1765,7 +1695,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f5f5f5;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-button {
     color: #ffffff;
     background: #3F51B5;
@@ -1928,7 +1855,7 @@
     padding: 0.714rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #ff4081;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #ff4081;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #2196F3;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #3F51B5;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #3F51B5;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ff4081;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #ff4081;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #2196F3;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(255, 64, 129, 0.92);
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(63, 81, 181, 0.12);
     color: #3F51B5;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #3F51B5;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(63, 81, 181, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2.5rem;
     height: 2.5rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3130,7 +3028,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 1rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(0, 0, 0, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     color: rgba(0, 0, 0, 0.87);
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(0, 0, 0, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3403,7 +3296,6 @@
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
   }
-
   .p-tree {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3459,11 +3351,11 @@
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(50, 65, 145, 0.12);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #3F51B5;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.5rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3904,7 +3790,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e0e0e0;
     padding: 1rem;
@@ -3954,7 +3839,6 @@
     color: rgba(0, 0, 0, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3971,12 +3855,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(0, 0, 0, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 1px solid #e0e0e0;
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: rgba(97, 97, 97, 0.9);
     color: #ffffff;
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: rgba(97, 97, 97, 0.9);
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 1rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e5e5;
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4772,7 +4642,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 1rem;
     background: transparent;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5215,7 +5082,6 @@
     padding: 1rem 1rem;
     color: rgba(0, 0, 0, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(0, 0, 0, 0.12);
     color: #3F51B5;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 1rem 1rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.5rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,7 +5619,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: rgba(0, 0, 0, 0.12);
     border-radius: 4px;
@@ -5787,15 +5639,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(0, 0, 0, 0.08);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #3F51B5;
     color: #ffffff;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #ffffff;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #3F51B5;
     color: #ffffff;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #3F51B5;
     color: #ffffff;
@@ -6042,11 +5883,9 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(255, 64, 129, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(255, 64, 129, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(33, 150, 243, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(104, 159, 56, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(251, 192, 45, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(156, 39, 176, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.76);
   }
@@ -6276,7 +6104,6 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(211, 47, 47, 0.16);
   }
-
   .p-calendar-w-btn {
     border: 1px solid rgba(0, 0, 0, 0.38);
     background: #ffffff;
@@ -6314,7 +6141,6 @@
     border-color: #3F51B5;
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(63, 81, 181, 0.12);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
@@ -6353,7 +6178,6 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #ff4081;
     color: #ffffff;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,11 +6253,9 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6488,11 +6308,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,7 +6380,6 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #3F51B5;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #3F51B5;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,11 +6464,9 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,14 +6524,12 @@
     background: rgba(255, 64, 129, 0.68);
     color: #ffffff;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6760,7 +6563,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #3F51B5;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
@@ -6918,7 +6706,6 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,21 +6858,18 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(176, 0, 32, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;
@@ -7159,11 +6930,9 @@
     background: #d9d8d9;
     border-color: #d9d8d9;
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(63, 81, 181, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 64, 129, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 64, 129, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(33, 150, 243, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(104, 159, 56, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(251, 192, 45, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(156, 39, 176, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(211, 47, 47, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #3F51B5;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,11 +7113,9 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.5rem;
     padding-bottom: 0.5rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #3F51B5;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;

--- a/public/themes/mdc-dark-deeppurple/theme.css
+++ b/public/themes/mdc-dark-deeppurple/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -243,7 +240,7 @@
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options .ql-picker-item:hover {
   color: rgba(255, 255, 255, 0.87);
-  background: rgba(255, 255, 255, 0.04);
+  background: hsla(0deg, 0%, 100%, 0.04);
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded:not(.ql-icon-picker) .ql-picker-item {
   padding: 0.75rem 0.75rem;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #f44435;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-autocomplete-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -434,7 +418,7 @@
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item.p-highlight {
     color: #CE93D8;
@@ -447,16 +431,14 @@
     background: transparent;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-datepicker:not(.p-datepicker-inline) {
@@ -473,12 +455,12 @@
     background: #1e1e1e;
     font-weight: 500;
     margin: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #CE93D8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -557,13 +539,13 @@
   }
   .p-datepicker .p-datepicker-buttonbar {
     padding: 0.75rem 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
     width: auto;
   }
   .p-datepicker .p-timepicker {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding: 0.5rem;
   }
   .p-datepicker .p-timepicker button {
@@ -622,7 +604,7 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding-right: 0.5rem;
     padding-left: 0.5rem;
     padding-top: 0;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -667,7 +648,7 @@
   }
   .p-cascadeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-cascadeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -735,7 +715,7 @@
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item .p-cascadeselect-group-icon {
     font-size: 0.875rem;
@@ -744,23 +724,21 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
   }
   .p-checkbox .p-checkbox-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 18px;
     height: 18px;
@@ -803,20 +781,18 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44435;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-checkbox .p-checkbox-box.p-highlight {
     background: #CE93D8;
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #CE93D8;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,28 +830,24 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2b2b2b;
     border: 1px solid #1e1e1e;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-dropdown-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -926,7 +897,7 @@
   }
   .p-dropdown-panel .p-dropdown-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -966,7 +937,7 @@
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item-group {
     margin: 0;
@@ -980,100 +951,90 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
-    border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.3);
     padding: 0.75rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-right: 1px solid hsla(0deg, 0%, 100%, 0.3);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.25rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
   }
   .p-inputswitch .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 0.5rem;
   }
@@ -1095,7 +1056,7 @@
     box-shadow: none;
   }
   .p-inputswitch:not(.p-disabled):hover .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
     background: rgba(206, 147, 216, 0.5);
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44435;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1117,7 +1077,7 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     padding: 0.75rem 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     appearance: none;
     border-radius: 4px;
@@ -1142,88 +1102,73 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44435;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-inputtext:enabled:focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-listbox .p-listbox-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
@@ -1271,12 +1216,11 @@
   }
   .p-listbox:not(.p-disabled) .p-listbox-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-listbox.p-invalid {
     border-color: #f44435;
   }
-
   .p-mention-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1298,16 +1242,15 @@
   }
   .p-mention-panel .p-mention-items .p-mention-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-mention-panel .p-mention-items .p-mention-item.p-highlight {
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-multiselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1333,7 +1276,7 @@
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1374,7 +1315,7 @@
   }
   .p-multiselect-panel .p-multiselect-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1428,7 +1369,7 @@
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:focus {
     outline: 0 none;
@@ -1450,21 +1391,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-password-panel {
     padding: 0.75rem;
     background: #1e1e1e;
@@ -1486,13 +1424,12 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
   }
   .p-radiobutton .p-radiobutton-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 20px;
     height: 20px;
@@ -1530,12 +1467,11 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight {
     background: #121212;
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #121212;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f44435;
   }
-
   .p-selectbutton .p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,15 +1542,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     border: 0 none;
     border-radius: 4px;
   }
@@ -1654,10 +1587,9 @@
     background: #CE93D8;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1683,7 +1615,7 @@
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1715,7 +1645,7 @@
   }
   .p-treeselect-panel .p-treeselect-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1765,17 +1695,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-togglebutton.p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-button {
     color: #121212;
     background: #CE93D8;
@@ -1928,7 +1855,7 @@
     padding: 0.571rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #A5D6A7;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #A5D6A7;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212121;
     background: #90CAF9;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212121;
     background: #C5E1A5;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212121;
     background: #FFF59D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #212121;
     background: #CE93D8;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212121;
     background: #EF9A9A;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-button.p-button-link {
     color: #CE93D8;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #CE93D8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A5D6A7;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #A5D6A7;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #90CAF9;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFF59D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF9A9A;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(165, 214, 167, 0.92);
     color: #212121;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(206, 147, 216, 0.16);
     color: #CE93D8;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #CE93D8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -3119,7 +3017,7 @@
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:focus-visible {
     outline: 0 none;
@@ -3127,13 +3025,12 @@
     box-shadow: none;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -3142,7 +3039,7 @@
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
     margin-bottom: 0.5rem;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.75rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.75rem;
   }
@@ -3206,7 +3102,7 @@
     transition: transform 0.2s, none;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
@@ -3222,11 +3118,10 @@
     background: rgba(255, 255, 255, 0.02);
   }
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-organizationchart .p-organizationchart-node-content.p-highlight {
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.75rem;
   }
@@ -3391,7 +3284,7 @@
     transition: transform 0.2s, none;
   }
   .p-picklist .p-picklist-list .p-picklist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus {
@@ -3403,7 +3296,6 @@
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-tree {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3459,19 +3351,19 @@
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #CE93D8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-dragover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-filter-container {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(182, 94, 197, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #CE93D8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 0.75rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.75rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3889,7 +3775,7 @@
     padding: 0 1.25rem;
   }
   .p-divider.p-divider-horizontal:before {
-    border-top: 1px rgba(255, 255, 255, 0.12);
+    border-top: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-horizontal .p-divider-content {
     padding: 0 0.5rem;
@@ -3899,12 +3785,11 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-left: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid rgba(255, 255, 255, 0.12);
     padding: 0.75rem;
@@ -3954,7 +3839,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3963,20 +3847,18 @@
   }
   .p-splitter .p-splitter-gutter {
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-splitter .p-splitter-gutter .p-splitter-gutter-handle {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
   .p-splitter .p-splitter-gutter-resizing {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(255, 255, 255, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #262626;
   }
-
   .p-sidebar {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 0.75rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.75rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #444444;
     color: rgba(255, 255, 255, 0.87);
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #444444;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 0.75rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2b2b2b;
@@ -4395,7 +4268,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-contextmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-contextmenu .p-submenu-icon {
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4598,7 +4469,7 @@
     width: 12.5rem;
   }
   .p-megamenu .p-megamenu-submenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
@@ -4640,7 +4511,7 @@
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-submenu-icon {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -4769,10 +4639,9 @@
     border-top-left-radius: 0;
   }
   .p-menu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.75rem;
     background: #1e1e1e;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4873,7 +4742,7 @@
     width: 12.5rem;
   }
   .p-menubar .p-submenu-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-menubar .p-submenu-list .p-submenu-icon {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -4924,7 +4792,7 @@
       width: 100%;
     }
     .p-menubar .p-menubar-root-list .p-menu-separator {
-      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
       margin: 0.5rem 0;
     }
     .p-menubar .p-menubar-root-list .p-submenu-icon {
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5201,7 +5068,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-slidemenu .p-slidemenu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-slidemenu .p-slidemenu-icon {
@@ -5215,7 +5082,6 @@
     padding: 0.75rem 0.75rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5252,7 +5118,7 @@
   }
   .p-steps .p-steps-item:before {
     content: " ";
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     width: 100%;
     top: 50%;
     left: 0;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(255, 255, 255, 0.12);
     color: #CE93D8;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5365,7 +5229,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tieredmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-tieredmenu .p-submenu-icon {
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 0.75rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.25rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,9 +5619,8 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     border-radius: 4px;
   }
   .p-avatar.p-avatar-lg {
@@ -5787,17 +5639,14 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
     padding: 0 0.75rem;
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #CE93D8;
     color: #121212;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #121212;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #CE93D8;
     color: #121212;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #CE93D8;
     color: #121212;
@@ -6042,17 +5883,15 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6062,13 +5901,13 @@
     background: transparent;
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(165, 214, 167, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(165, 214, 167, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(144, 202, 249, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(197, 225, 165, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(255, 245, 157, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.76);
   }
@@ -6276,9 +6104,8 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(239, 154, 154, 0.16);
   }
-
   .p-calendar-w-btn {
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     background: #1e1e1e;
     border-radius: 4px;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
@@ -6314,7 +6141,6 @@
     border-color: #CE93D8;
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6329,7 +6155,7 @@
     order: 3;
   }
   .p-datepicker table th {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.38);
     font-weight: 400;
     font-size: 0.875rem;
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(206, 147, 216, 0.16);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
@@ -6353,13 +6178,12 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6369,13 +6193,13 @@
     background: transparent;
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-focus, .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #A5D6A7;
     color: #121212;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,17 +6253,15 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6451,13 +6271,13 @@
     background: transparent;
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus, .p-input-filled .p-cascadeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6488,25 +6308,23 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-checkbox .p-checkbox-box {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
     border-radius: 2px;
     position: relative;
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled).p-focus {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #CE93D8;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,13 +6380,12 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6580,13 +6395,13 @@
     background: transparent;
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #CE93D8;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #CE93D8;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,17 +6464,15 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6675,13 +6482,13 @@
     background: transparent;
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus, .p-input-filled .p-dropdown:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,32 +6524,30 @@
     background: rgba(165, 214, 167, 0.68);
     color: #121212;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));
   }
   .p-input-filled .p-inputtext:enabled:focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6760,13 +6563,12 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12), 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #CE93D8;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
@@ -6918,13 +6706,12 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6934,13 +6721,13 @@
     background: transparent;
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus, .p-input-filled .p-multiselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,30 +6858,27 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled):not(.p-highlight):hover {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #CE93D8;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(206, 147, 216, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(244, 68, 53, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);
@@ -7159,11 +6930,9 @@
     background: #262626;
     border-color: rgba(255, 255, 255, 0.12);
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(165, 214, 167, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(165, 214, 167, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(144, 202, 249, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(197, 225, 165, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 245, 157, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(239, 154, 154, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #CE93D8;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(206, 147, 216, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,17 +7113,15 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -7378,13 +7131,13 @@
     background: transparent;
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus, .p-input-filled .p-treeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #CE93D8;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);

--- a/public/themes/mdc-dark-indigo/theme.css
+++ b/public/themes/mdc-dark-indigo/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -243,7 +240,7 @@
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options .ql-picker-item:hover {
   color: rgba(255, 255, 255, 0.87);
-  background: rgba(255, 255, 255, 0.04);
+  background: hsla(0deg, 0%, 100%, 0.04);
 }
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded:not(.ql-icon-picker) .ql-picker-item {
   padding: 0.75rem 0.75rem;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #f44435;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-autocomplete-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -434,7 +418,7 @@
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item.p-highlight {
     color: #9FA8DA;
@@ -447,16 +431,14 @@
     background: transparent;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-datepicker:not(.p-datepicker-inline) {
@@ -473,12 +455,12 @@
     background: #1e1e1e;
     font-weight: 500;
     margin: 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #9FA8DA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -557,13 +539,13 @@
   }
   .p-datepicker .p-datepicker-buttonbar {
     padding: 0.75rem 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
     width: auto;
   }
   .p-datepicker .p-timepicker {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding: 0.5rem;
   }
   .p-datepicker .p-timepicker button {
@@ -622,7 +604,7 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.12);
     padding-right: 0.5rem;
     padding-left: 0.5rem;
     padding-top: 0;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -667,7 +648,7 @@
   }
   .p-cascadeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-cascadeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -735,7 +715,7 @@
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item .p-cascadeselect-group-icon {
     font-size: 0.875rem;
@@ -744,23 +724,21 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
   }
   .p-checkbox .p-checkbox-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 18px;
     height: 18px;
@@ -803,20 +781,18 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44435;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-checkbox .p-checkbox-box.p-highlight {
     background: #9FA8DA;
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #9FA8DA;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,28 +830,24 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #2b2b2b;
     border: 1px solid #1e1e1e;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-dropdown-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -926,7 +897,7 @@
   }
   .p-dropdown-panel .p-dropdown-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -966,7 +937,7 @@
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item-group {
     margin: 0;
@@ -980,100 +951,90 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
-    border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-left: 1px solid hsla(0deg, 0%, 100%, 0.3);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.3);
     padding: 0.75rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-right: 1px solid hsla(0deg, 0%, 100%, 0.3);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.25rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
   }
   .p-inputswitch .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 0.5rem;
   }
@@ -1095,7 +1056,7 @@
     box-shadow: none;
   }
   .p-inputswitch:not(.p-disabled):hover .p-inputswitch-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
     background: rgba(159, 168, 218, 0.5);
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44435;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1117,7 +1077,7 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     padding: 0.75rem 0.75rem;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     appearance: none;
     border-radius: 4px;
@@ -1142,88 +1102,73 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44435;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-inputtext:enabled:focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     border-radius: 4px;
   }
   .p-listbox .p-listbox-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
@@ -1271,12 +1216,11 @@
   }
   .p-listbox:not(.p-disabled) .p-listbox-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-listbox.p-invalid {
     border-color: #f44435;
   }
-
   .p-mention-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1298,16 +1242,15 @@
   }
   .p-mention-panel .p-mention-items .p-mention-item:hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-mention-panel .p-mention-items .p-mention-item.p-highlight {
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-multiselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1333,7 +1276,7 @@
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1374,7 +1315,7 @@
   }
   .p-multiselect-panel .p-multiselect-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1428,7 +1369,7 @@
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:focus {
     outline: 0 none;
@@ -1450,21 +1391,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44435;
   }
-
   .p-password-panel {
     padding: 0.75rem;
     background: #1e1e1e;
@@ -1486,13 +1424,12 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
   }
   .p-radiobutton .p-radiobutton-box {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
     background: #1e1e1e;
     width: 20px;
     height: 20px;
@@ -1530,12 +1467,11 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
-    background-color: rgba(255, 255, 255, 0.06);
+    background-color: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight {
     background: #121212;
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #121212;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f44435;
   }
-
   .p-selectbutton .p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,15 +1542,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-slider {
-    background: rgba(255, 255, 255, 0.3);
+    background: hsla(0deg, 0%, 100%, 0.3);
     border: 0 none;
     border-radius: 4px;
   }
@@ -1654,10 +1587,9 @@
     background: #9FA8DA;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #1e1e1e;
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
     border-radius: 4px;
   }
@@ -1683,7 +1615,7 @@
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
     margin-right: 0.5rem;
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44435;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -1715,7 +1645,7 @@
   }
   .p-treeselect-panel .p-treeselect-header {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -1765,17 +1695,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
-    background: rgba(255, 255, 255, 0.06);
+    background: hsla(0deg, 0%, 100%, 0.06);
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
   }
-
   .p-togglebutton.p-button {
     background: #2f2f2f;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44435;
   }
-
   .p-button {
     color: #121212;
     background: #9FA8DA;
@@ -1928,7 +1855,7 @@
     padding: 0.571rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #121212;
     background: #F48FB1;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #212121;
     background: #90CAF9;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #212121;
     background: #C5E1A5;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212121;
     background: #FFF59D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #212121;
     background: #CE93D8;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #212121;
     background: #EF9A9A;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-button.p-button-link {
     color: #9FA8DA;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #9FA8DA;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #90CAF9;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #90CAF9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFF59D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FFF59D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF9A9A;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #EF9A9A;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(244, 143, 177, 0.92);
     color: #212121;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(159, 168, 218, 0.16);
     color: #9FA8DA;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #9FA8DA;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1e1e1e;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #2b2b2b;
     color: rgba(255, 255, 255, 0.87);
@@ -3119,7 +3017,7 @@
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:not(.p-highlight):not(.p-disabled):hover {
     color: rgba(255, 255, 255, 0.87);
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item:focus-visible {
     outline: 0 none;
@@ -3127,13 +3025,12 @@
     box-shadow: none;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
@@ -3142,7 +3039,7 @@
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
     margin-bottom: 0.5rem;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.75rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.75rem;
   }
@@ -3206,7 +3102,7 @@
     transition: transform 0.2s, none;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
@@ -3222,11 +3118,10 @@
     background: rgba(255, 255, 255, 0.02);
   }
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-organizationchart .p-organizationchart-node-content.p-highlight {
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.75rem;
   }
@@ -3391,7 +3284,7 @@
     transition: transform 0.2s, none;
   }
   .p-picklist .p-picklist-list .p-picklist-item:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus {
@@ -3403,7 +3296,6 @@
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
   }
-
   .p-tree {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3459,19 +3351,19 @@
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #9FA8DA;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-dragover {
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-filter-container {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(105, 119, 197, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #9FA8DA;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1e1e1e;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 0.75rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.75rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1e1e1e;
   }
@@ -3889,7 +3775,7 @@
     padding: 0 1.25rem;
   }
   .p-divider.p-divider-horizontal:before {
-    border-top: 1px rgba(255, 255, 255, 0.12);
+    border-top: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-horizontal .p-divider-content {
     padding: 0 0.5rem;
@@ -3899,12 +3785,11 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-left: 1px hsla(0deg, 0%, 100%, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid rgba(255, 255, 255, 0.12);
     padding: 0.75rem;
@@ -3954,7 +3839,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
@@ -3963,20 +3847,18 @@
   }
   .p-splitter .p-splitter-gutter {
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    background: rgba(255, 255, 255, 0.04);
+    background: hsla(0deg, 0%, 100%, 0.04);
   }
   .p-splitter .p-splitter-gutter .p-splitter-gutter-handle {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
   .p-splitter .p-splitter-gutter-resizing {
-    background: rgba(255, 255, 255, 0.12);
+    background: hsla(0deg, 0%, 100%, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(255, 255, 255, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #262626;
   }
-
   .p-sidebar {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 0.75rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.75rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #444444;
     color: rgba(255, 255, 255, 0.87);
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #444444;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1e1e1e;
     padding: 0.75rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1e1e1e;
     border: 1px solid rgba(255, 255, 255, 0.12);
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #2b2b2b;
@@ -4395,7 +4268,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-contextmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-contextmenu .p-submenu-icon {
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4598,7 +4469,7 @@
     width: 12.5rem;
   }
   .p-megamenu .p-megamenu-submenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
@@ -4640,7 +4511,7 @@
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-submenu-icon {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -4769,10 +4639,9 @@
     border-top-left-radius: 0;
   }
   .p-menu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.75rem;
     background: #1e1e1e;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4873,7 +4742,7 @@
     width: 12.5rem;
   }
   .p-menubar .p-submenu-list .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-menubar .p-submenu-list .p-submenu-icon {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -4924,7 +4792,7 @@
       width: 100%;
     }
     .p-menubar .p-menubar-root-list .p-menu-separator {
-      border-top: 1px solid rgba(255, 255, 255, 0.12);
+      border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
       margin: 0.5rem 0;
     }
     .p-menubar .p-menubar-root-list .p-submenu-icon {
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5201,7 +5068,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-slidemenu .p-slidemenu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-slidemenu .p-slidemenu-icon {
@@ -5215,7 +5082,6 @@
     padding: 0.75rem 0.75rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5252,7 +5118,7 @@
   }
   .p-steps .p-steps-item:before {
     content: " ";
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     width: 100%;
     top: 50%;
     left: 0;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(255, 255, 255, 0.12);
     color: #9FA8DA;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #1e1e1e;
@@ -5365,7 +5229,7 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tieredmenu .p-menu-separator {
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid hsla(0deg, 0%, 100%, 0.12);
     margin: 0.5rem 0;
   }
   .p-tieredmenu .p-submenu-icon {
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 0.75rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.25rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,9 +5619,8 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     border-radius: 4px;
   }
   .p-avatar.p-avatar-lg {
@@ -5787,17 +5639,14 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1e1e1e;
   }
-
   .p-chip {
-    background-color: rgba(255, 255, 255, 0.12);
+    background-color: hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
     padding: 0 0.75rem;
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #9FA8DA;
     color: #121212;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #121212;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #9FA8DA;
     color: #121212;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #9FA8DA;
     color: #121212;
@@ -6042,17 +5883,15 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6062,13 +5901,13 @@
     background: transparent;
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(244, 143, 177, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(244, 143, 177, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(144, 202, 249, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(197, 225, 165, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(255, 245, 157, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(206, 147, 216, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.76);
   }
@@ -6276,9 +6104,8 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(239, 154, 154, 0.16);
   }
-
   .p-calendar-w-btn {
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid hsla(0deg, 0%, 100%, 0.3);
     background: #1e1e1e;
     border-radius: 4px;
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
@@ -6314,7 +6141,6 @@
     border-color: #9FA8DA;
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6329,7 +6155,7 @@
     order: 3;
   }
   .p-datepicker table th {
-    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    border-bottom: 1px solid hsla(0deg, 0%, 100%, 0.12);
     color: rgba(255, 255, 255, 0.38);
     font-weight: 400;
     font-size: 0.875rem;
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(159, 168, 218, 0.16);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
@@ -6353,13 +6178,12 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6369,13 +6193,13 @@
     background: transparent;
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-focus, .p-input-filled .p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #F48FB1;
     color: #121212;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,17 +6253,15 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6451,13 +6271,13 @@
     background: transparent;
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus, .p-input-filled .p-cascadeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6488,25 +6308,23 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-checkbox .p-checkbox-box {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
     border-radius: 2px;
     position: relative;
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box:not(.p-disabled).p-focus {
-    border-color: rgba(255, 255, 255, 0.7);
+    border-color: hsla(0deg, 0%, 100%, 0.7);
   }
   .p-checkbox .p-checkbox-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #9FA8DA;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,13 +6380,12 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6580,13 +6395,13 @@
     background: transparent;
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-focus, .p-input-filled .p-chips-multiple-container:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #9FA8DA;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #9FA8DA;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,17 +6464,15 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6675,13 +6482,13 @@
     background: transparent;
   }
   .p-input-filled .p-dropdown:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus, .p-input-filled .p-dropdown:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,32 +6524,30 @@
     background: rgba(244, 143, 177, 0.68);
     color: #121212;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
   }
   .p-input-filled .p-inputtext:enabled:hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.6));
   }
   .p-input-filled .p-inputtext:enabled:focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6760,13 +6563,12 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12), 0px 3px 1px -2px rgba(255, 255, 255, 0.2), 0px 2px 2px 0px rgba(255, 255, 255, 0.14), 0px 1px 5px 0px rgba(255, 255, 255, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #9FA8DA;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
@@ -6918,13 +6706,12 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -6934,13 +6721,13 @@
     background: transparent;
   }
   .p-input-filled .p-multiselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus, .p-input-filled .p-multiselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,30 +6858,27 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled):not(.p-highlight):hover {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus {
-    border: 2px solid rgba(255, 255, 255, 0.7);
+    border: 2px solid hsla(0deg, 0%, 100%, 0.7);
   }
   .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled).p-focus {
     border-color: #9FA8DA;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(159, 168, 218, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #1e1e1e;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #1e1e1e;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(244, 68, 53, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);
@@ -7159,11 +6930,9 @@
     background: #262626;
     border-color: rgba(255, 255, 255, 0.12);
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(159, 168, 218, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(244, 143, 177, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(244, 143, 177, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(144, 202, 249, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(144, 202, 249, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(197, 225, 165, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(197, 225, 165, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 245, 157, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 245, 157, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(206, 147, 216, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(206, 147, 216, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(239, 154, 154, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(239, 154, 154, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #9FA8DA;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(255, 255, 255, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(255, 255, 255, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(159, 168, 218, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,17 +7113,15 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(159, 168, 218, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid transparent;
-    background: rgba(255, 255, 255, 0.06) no-repeat;
-    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
+    background: hsla(0deg, 0%, 100%, 0.06) no-repeat;
+    background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, hsla(0deg, 0%, 100%, 0.3), hsla(0deg, 0%, 100%, 0.3));
     background-size: 0 2px, 100% 1px;
     background-position: 50% 100%, 50% 100%;
     background-origin: border-box;
@@ -7378,13 +7131,13 @@
     background: transparent;
   }
   .p-input-filled .p-treeselect:not(.p-disabled):hover {
-    background-color: rgba(255, 255, 255, 0.08);
+    background-color: hsla(0deg, 0%, 100%, 0.08);
     border-color: transparent;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.87), rgba(255, 255, 255, 0.87));
   }
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus, .p-input-filled .p-treeselect:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: none;
-    background-color: rgba(255, 255, 255, 0.1);
+    background-color: hsla(0deg, 0%, 100%, 0.1);
     border-color: transparent;
     background-size: 100% 2px, 100% 1px;
   }
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #f44435, #f44435), linear-gradient(to bottom, #f44435, #f44435);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435, inset 0 0 0 1px #f44435;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(255, 255, 255, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #9FA8DA;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #1c1c1c;
     border-color: rgba(255, 255, 255, 0.12);

--- a/public/themes/mdc-light-deeppurple/theme.css
+++ b/public/themes/mdc-light-deeppurple/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #B00020;
   }
-
   .p-text-secondary {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -447,11 +431,9 @@
     background: #ffffff;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -478,7 +460,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(0, 0, 0, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #673AB7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -549,7 +531,7 @@
   .p-datepicker table td.p-datepicker-today > span {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-color: black;
+    border-color: rgb(0, 0, 0);
   }
   .p-datepicker table td.p-datepicker-today > span.p-highlight {
     color: #673AB7;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f5f5f5;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
@@ -803,7 +781,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #B00020;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f5f5f5;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #673AB7;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -980,7 +951,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f5f5f5;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid rgba(0, 0, 0, 0.38);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.25rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #B00020;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #B00020;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f5f5f5;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #dcdcdc;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #B00020;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1304,7 +1248,6 @@
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1450,7 +1391,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f5f5f5;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-password-panel {
     padding: 0.75rem;
     background: #ffffff;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f5f5f5;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #B00020;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,13 +1542,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-slider {
     background: #c1c1c1;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #673AB7;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1765,7 +1695,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f5f5f5;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-button {
     color: #ffffff;
     background: #673AB7;
@@ -1928,7 +1855,7 @@
     padding: 0.571rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #4CAF50;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #4CAF50;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #2196F3;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #673AB7;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #673AB7;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4CAF50;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #4CAF50;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #2196F3;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(76, 175, 80, 0.92);
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(103, 58, 183, 0.12);
     color: #673AB7;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #673AB7;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(103, 58, 183, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3130,7 +3028,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.75rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.75rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(0, 0, 0, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     color: rgba(0, 0, 0, 0.87);
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(0, 0, 0, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.75rem;
   }
@@ -3403,7 +3296,6 @@
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
   }
-
   .p-tree {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3459,11 +3351,11 @@
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #673AB7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(82, 46, 146, 0.12);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #673AB7;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 0.75rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.75rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3904,7 +3790,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e0e0e0;
     padding: 0.75rem;
@@ -3954,7 +3839,6 @@
     color: rgba(0, 0, 0, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3971,12 +3855,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(0, 0, 0, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 1px solid #e0e0e0;
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 0.75rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.75rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: rgba(97, 97, 97, 0.9);
     color: #ffffff;
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: rgba(97, 97, 97, 0.9);
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 0.75rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e5e5;
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4772,7 +4642,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.75rem;
     background: transparent;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5215,7 +5082,6 @@
     padding: 0.75rem 0.75rem;
     color: rgba(0, 0, 0, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(0, 0, 0, 0.12);
     color: #673AB7;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 0.75rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.25rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,7 +5619,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: rgba(0, 0, 0, 0.12);
     border-radius: 4px;
@@ -5787,15 +5639,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(0, 0, 0, 0.08);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #673AB7;
     color: #ffffff;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #ffffff;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #673AB7;
     color: #ffffff;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #673AB7;
     color: #ffffff;
@@ -6042,11 +5883,9 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(76, 175, 80, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(76, 175, 80, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(33, 150, 243, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(104, 159, 56, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(251, 192, 45, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(156, 39, 176, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.76);
   }
@@ -6276,7 +6104,6 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(211, 47, 47, 0.16);
   }
-
   .p-calendar-w-btn {
     border: 1px solid rgba(0, 0, 0, 0.38);
     background: #ffffff;
@@ -6314,7 +6141,6 @@
     border-color: #673AB7;
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(103, 58, 183, 0.12);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
@@ -6353,7 +6178,6 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #4CAF50;
     color: #ffffff;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,11 +6253,9 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6488,11 +6308,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,7 +6380,6 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #673AB7;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #673AB7;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,11 +6464,9 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,14 +6524,12 @@
     background: rgba(76, 175, 80, 0.68);
     color: #ffffff;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6760,7 +6563,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #673AB7;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
@@ -6918,7 +6706,6 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,21 +6858,18 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(103, 58, 183, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(176, 0, 32, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;
@@ -7159,11 +6930,9 @@
     background: #d9d8d9;
     border-color: #d9d8d9;
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(103, 58, 183, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(76, 175, 80, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(76, 175, 80, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(33, 150, 243, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(104, 159, 56, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(251, 192, 45, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(156, 39, 176, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(211, 47, 47, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #673AB7;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(103, 58, 183, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,11 +7113,9 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(103, 58, 183, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #673AB7;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;

--- a/public/themes/mdc-light-indigo/theme.css
+++ b/public/themes/mdc-light-indigo/theme.css
@@ -53,24 +53,21 @@
   font-family: "Roboto";
   font-style: normal;
   font-weight: 400;
-  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto"), local("Roboto-Regular"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-500 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 500;
-  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Medium"), local("Roboto-Medium"), url("./fonts/roboto-v20-latin-ext_latin-500.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-500.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin-ext_latin */
 @font-face {
   font-family: "Roboto";
   font-style: normal;
   font-weight: 700;
-  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Roboto Bold"), local("Roboto-Bold"), url("./fonts/roboto-v20-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/roboto-v20-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f4fafe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.32);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.38;
   }
-
   .p-error {
     color: #B00020;
   }
-
   .p-text-secondary {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -447,11 +431,9 @@
     background: #ffffff;
     font-weight: 400;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -478,7 +460,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(0, 0, 0, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 500;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #3F51B5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -549,7 +531,7 @@
   .p-datepicker table td.p-datepicker-today > span {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-color: black;
+    border-color: rgb(0, 0, 0);
   }
   .p-datepicker table td.p-datepicker-today > span.p-highlight {
     color: #3F51B5;
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f5f5f5;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-checkbox {
     width: 18px;
     height: 18px;
@@ -803,7 +781,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #B00020;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f5f5f5;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #3F51B5;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -980,7 +951,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f5f5f5;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid rgba(0, 0, 0, 0.38);
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.25rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-inputswitch {
     width: 2.75rem;
     height: 1rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #B00020;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #B00020;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f5f5f5;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #dcdcdc;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #B00020;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1304,7 +1248,6 @@
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1450,7 +1391,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f5f5f5;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #B00020;
   }
-
   .p-password-panel {
     padding: 0.75rem;
     background: #ffffff;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f5f5f5;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #B00020;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,13 +1542,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-slider {
     background: #c1c1c1;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #3F51B5;
     border-color: 0 none;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.38);
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #B00020;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -1765,7 +1695,6 @@
     color: rgba(0, 0, 0, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f5f5f5;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #dcdcdc;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.12);
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #B00020;
   }
-
   .p-button {
     color: #ffffff;
     background: #3F51B5;
@@ -1928,7 +1855,7 @@
     padding: 0.571rem;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #ff4081;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #ff4081;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #2196F3;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #3F51B5;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #3F51B5;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ff4081;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #ff4081;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #2196F3;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #2196F3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(255, 64, 129, 0.92);
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.32);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2670,7 +2576,6 @@
     background: rgba(63, 81, 181, 0.12);
     color: #3F51B5;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -2839,12 +2744,12 @@
     background: #3F51B5;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(63, 81, 181, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3130,7 +3028,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.75rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.75rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(0, 0, 0, 0.04);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     color: rgba(0, 0, 0, 0.87);
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-paginator {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3273,9 +3167,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(0, 0, 0, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.75rem;
   }
@@ -3403,7 +3296,6 @@
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
   }
-
   .p-tree {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3459,11 +3351,11 @@
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #3F51B5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(50, 65, 145, 0.12);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #3F51B5;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #bdbdbd;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 0 none;
@@ -3813,7 +3702,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -3839,7 +3727,6 @@
   .p-card .p-card-footer {
     padding: 0.75rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3880,7 +3767,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.75rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3904,7 +3790,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e0e0e0;
     padding: 0.75rem;
@@ -3954,7 +3839,6 @@
     color: rgba(0, 0, 0, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e0e0e0;
     background: #ffffff;
@@ -3971,12 +3855,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: rgba(0, 0, 0, 0.12);
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -4036,7 +3918,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 1px solid #e0e0e0;
@@ -4047,7 +3928,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4095,7 +3975,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0 11px 15px -7px rgba(0, 0, 0, 0.2), 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4171,7 +4050,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4213,7 +4091,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -4224,7 +4101,7 @@
     padding: 0.75rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -4234,13 +4111,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
     border-color: transparent;
     background: rgba(0, 0, 0, 0.04);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: none;
@@ -4251,7 +4128,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.75rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: rgba(97, 97, 97, 0.9);
     color: #ffffff;
@@ -4271,7 +4147,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: rgba(97, 97, 97, 0.9);
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 0.75rem;
@@ -4302,7 +4177,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e5e5;
@@ -4334,7 +4208,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4406,7 +4279,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4421,32 +4293,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4463,22 +4334,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4529,19 +4400,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-megamenu .p-menuitem-link {
@@ -4711,7 +4582,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -4772,7 +4642,6 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
-
   .p-menubar {
     padding: 0.75rem;
     background: transparent;
@@ -4850,19 +4719,19 @@
     box-shadow: none;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(0, 0, 0, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
   .p-menubar .p-submenu-list {
@@ -4892,7 +4761,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5137,7 +5005,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5215,7 +5082,6 @@
     padding: 0.75rem 0.75rem;
     color: rgba(0, 0, 0, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5260,7 +5126,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
@@ -5301,7 +5166,6 @@
     border-color: rgba(0, 0, 0, 0.12);
     color: #3F51B5;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0;
     background: #ffffff;
@@ -5376,7 +5240,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5432,7 +5295,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 0.75rem 0;
     border-radius: 4px;
@@ -5521,7 +5383,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,8 +5392,7 @@
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
-    padding: 1.25rem;
-    border-width: 0 0 0 0;
+    padding: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5572,7 +5432,7 @@
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #01579B;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5582,7 +5442,7 @@
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1B5E20;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5592,7 +5452,7 @@
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5602,10 +5462,9 @@
     color: #B71C1C;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #B71C1C;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5636,11 +5495,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5694,7 +5553,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -5704,7 +5563,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: rgba(255, 255, 255, 0.87);
   }
@@ -5716,15 +5575,12 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5734,15 +5590,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5766,7 +5619,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: rgba(0, 0, 0, 0.12);
     border-radius: 4px;
@@ -5787,15 +5639,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
@@ -5829,7 +5678,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5851,7 +5699,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(0, 0, 0, 0.08);
     border-radius: 4px;
@@ -5859,7 +5706,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #3F51B5;
     color: #ffffff;
@@ -5892,7 +5738,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 1rem 1rem;
     border-radius: 4px;
@@ -5907,7 +5752,6 @@
     outline-offset: 0;
     box-shadow: none;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 4px;
@@ -5923,7 +5767,6 @@
     color: #ffffff;
     line-height: 4px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
@@ -5935,7 +5778,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #3F51B5;
     color: #ffffff;
@@ -5977,7 +5819,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #3F51B5;
     color: #ffffff;
@@ -6042,11 +5883,9 @@
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled .p-accordion-header-link > * {
     opacity: 0.38;
   }
-
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-input-filled .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6076,11 +5915,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-autocomplete-multiple-container .p-autocomplete-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6114,21 +5951,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-autocomplete.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
   .p-autocomplete.p-invalid > .p-autocomplete-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-breadcrumb .p-menuitem-link {
     padding: 0.25rem 0.5rem;
   }
   .p-breadcrumb .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-button {
     font-weight: 500;
     min-width: 4rem;
@@ -6180,7 +6014,6 @@
   .p-button.p-button-raised:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     background: rgba(255, 64, 129, 0.76);
   }
@@ -6196,7 +6029,6 @@
   .p-button.p-button-secondary.p-button-text .p-ink, .p-button.p-button-secondary.p-button-outlined .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-text .p-ink, .p-buttonset.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-secondary.p-button-text .p-ink, .p-fileupload-choose.p-button-secondary.p-button-outlined .p-ink {
     background-color: rgba(255, 64, 129, 0.16);
   }
-
   .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.76);
   }
@@ -6212,7 +6044,6 @@
   .p-button.p-button-info.p-button-text .p-ink, .p-button.p-button-info.p-button-outlined .p-ink, .p-buttonset.p-button-info > .p-button.p-button-text .p-ink, .p-buttonset.p-button-info > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-info > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-info.p-button-text .p-ink, .p-fileupload-choose.p-button-info.p-button-outlined .p-ink {
     background-color: rgba(33, 150, 243, 0.16);
   }
-
   .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.76);
   }
@@ -6228,7 +6059,6 @@
   .p-button.p-button-success.p-button-text .p-ink, .p-button.p-button-success.p-button-outlined .p-ink, .p-buttonset.p-button-success > .p-button.p-button-text .p-ink, .p-buttonset.p-button-success > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-success > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-success.p-button-text .p-ink, .p-fileupload-choose.p-button-success.p-button-outlined .p-ink {
     background-color: rgba(104, 159, 56, 0.16);
   }
-
   .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.76);
   }
@@ -6244,7 +6074,6 @@
   .p-button.p-button-warning.p-button-text .p-ink, .p-button.p-button-warning.p-button-outlined .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-text .p-ink, .p-buttonset.p-button-warning > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-warning > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-warning.p-button-text .p-ink, .p-fileupload-choose.p-button-warning.p-button-outlined .p-ink {
     background-color: rgba(251, 192, 45, 0.16);
   }
-
   .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.76);
   }
@@ -6260,7 +6089,6 @@
   .p-button.p-button-help.p-button-text .p-ink, .p-button.p-button-help.p-button-outlined .p-ink, .p-buttonset.p-button-help > .p-button.p-button-text .p-ink, .p-buttonset.p-button-help > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-help > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-help.p-button-text .p-ink, .p-fileupload-choose.p-button-help.p-button-outlined .p-ink {
     background-color: rgba(156, 39, 176, 0.16);
   }
-
   .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.76);
   }
@@ -6276,7 +6104,6 @@
   .p-button.p-button-danger.p-button-text .p-ink, .p-button.p-button-danger.p-button-outlined .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-text .p-ink, .p-buttonset.p-button-danger > .p-button.p-button-outlined .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-text .p-ink, .p-splitbutton.p-button-danger > .p-button.p-button-outlined .p-ink, .p-fileupload-choose.p-button-danger.p-button-text .p-ink, .p-fileupload-choose.p-button-danger.p-button-outlined .p-ink {
     background-color: rgba(211, 47, 47, 0.16);
   }
-
   .p-calendar-w-btn {
     border: 1px solid rgba(0, 0, 0, 0.38);
     background: #ffffff;
@@ -6314,7 +6141,6 @@
     border-color: #3F51B5;
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-datepicker .p-datepicker-header {
     border-bottom: 0 none;
   }
@@ -6340,7 +6166,6 @@
   .p-datepicker table td.p-datepicker-today.p-highlight {
     box-shadow: 0 0 0 1px rgba(63, 81, 181, 0.12);
   }
-
   .p-calendar.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
@@ -6353,7 +6178,6 @@
   .p-calendar.p-invalid.p-calendar-w-btn:not(.p-disabled).p-inputwrapper-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-calendar-w-btn {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6410,17 +6234,15 @@
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
   .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
-.p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:hover,
+  .p-input-filled .p-calendar.p-invalid.p-calendar-w-btn .p-inputtext:enabled:focus {
     border: 0 none;
     background-image: none;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #ff4081;
     color: #ffffff;
   }
-
   .p-cascadeselect .p-cascadeselect-label, .p-cascadeselect .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6431,11 +6253,9 @@
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-cascadeselect-item-content .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-cascadeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6488,11 +6308,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-cascadeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-checkbox {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -6534,14 +6352,12 @@
   .p-checkbox.p-checkbox-checked:not(.p-checkbox-disabled).p-checkbox-focused {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12);
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-checkbox .p-checkbox-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   @keyframes checkbox-check {
     0% {
       width: 0;
@@ -6564,7 +6380,6 @@
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-input-filled .p-chips-multiple-container {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6594,11 +6409,9 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 1rem;
   }
-
   .p-input-filled .p-float-label .p-chips .p-chips-multiple-container .p-chips-token {
     padding-top: 0;
     padding-bottom: 0;
@@ -6620,11 +6433,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-chips.p-invalid .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-datatable .p-sortable-column {
     outline: 0 none;
   }
@@ -6637,14 +6448,12 @@
   .p-datatable .p-datatable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #3F51B5;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #3F51B5;
   }
-
   .p-dropdown .p-inputtext, .p-dropdown .p-dropdown-trigger {
     background-image: none;
     background: transparent;
@@ -6655,11 +6464,9 @@
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-dropdown-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-dropdown {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6703,11 +6510,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-dropdown.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-galleria .p-galleria-indicators {
     padding: 1rem;
   }
@@ -6719,14 +6524,12 @@
     background: rgba(255, 64, 129, 0.68);
     color: #ffffff;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
   .p-inputtext:enabled:focus.p-invalid {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputtext {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6760,7 +6563,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6775,30 +6577,28 @@
     border-right-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
-.p-input-filled .p-inputgroup button:first-child,
-.p-input-filled .p-inputgroup input:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:first-child,
+  .p-input-filled .p-inputgroup input:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
     border-bottom-left-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
-.p-input-filled .p-inputgroup button:last-child,
-.p-input-filled .p-inputgroup input:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
-.p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-input-filled .p-inputgroup button:last-child,
+  .p-input-filled .p-inputgroup input:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child,
+  .p-input-filled .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-bottom-right-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
     border-bottom-right-radius: 0;
   }
-
   .p-inputnumber.p-invalid .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-input-filled .p-inputnumber.p-invalid .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -6811,7 +6611,6 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-inputswitch .p-inputswitch-slider:before {
     transition-property: box-shadow transform;
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
@@ -6828,51 +6627,45 @@
   .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus .p-inputswitch-slider:before, .p-inputswitch.p-inputswitch-checked.p-inputswitch-focus:not(.p-disabled):hover .p-inputswitch-slider:before {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12), 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
   }
-
   .p-fieldset .p-fieldset-legend {
     border: 0 none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label input.p-filled ~ label,
-.p-float-label textarea:focus ~ label,
-.p-float-label textarea.p-filled ~ label,
-.p-float-label .p-inputwrapper-focus ~ label,
-.p-float-label .p-inputwrapper-filled ~ label {
+  .p-float-label input.p-filled ~ label,
+  .p-float-label textarea:focus ~ label,
+  .p-float-label textarea.p-filled ~ label,
+  .p-float-label .p-inputwrapper-focus ~ label,
+  .p-float-label .p-inputwrapper-filled ~ label {
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
     margin-left: -4px;
     margin-top: 0;
   }
-
   .p-float-label textarea ~ label {
     margin-top: 0;
   }
-
   .p-float-label input:focus ~ label,
-.p-float-label .p-inputwrapper-focus ~ label {
+  .p-float-label .p-inputwrapper-focus ~ label {
     color: #3F51B5;
   }
-
   .p-input-filled .p-float-label .p-inputtext {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
   }
   .p-input-filled .p-float-label input:focus ~ label,
-.p-input-filled .p-float-label input.p-filled ~ label,
-.p-input-filled .p-float-label textarea:focus ~ label,
-.p-input-filled .p-float-label textarea.p-filled ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
-.p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
+  .p-input-filled .p-float-label input.p-filled ~ label,
+  .p-input-filled .p-float-label textarea:focus ~ label,
+  .p-input-filled .p-float-label textarea.p-filled ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-focus ~ label,
+  .p-input-filled .p-float-label .p-inputwrapper-filled ~ label {
     top: 0.25rem !important;
     margin-top: 0;
     background: transparent;
   }
-
   .p-listbox .p-listbox-list .p-listbox-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
@@ -6882,19 +6675,15 @@
   .p-listbox .p-listbox-list .p-listbox-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-megamenu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menu .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-menubar .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-multiselect .p-multiselect-label, .p-multiselect .p-multiselect-trigger {
     background-image: none;
     background: transparent;
@@ -6905,7 +6694,6 @@
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
@@ -6918,7 +6706,6 @@
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-input-filled .p-multiselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -6952,13 +6739,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-multiselect-label .p-multiselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-multiselect .p-multiselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -6987,22 +6772,18 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-multiselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-overlaypanel .p-overlaypanel-content {
     padding: 1.5rem;
   }
-
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-paginator {
     justify-content: flex-end;
   }
@@ -7012,7 +6793,6 @@
   .p-paginator .p-paginator-element:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-input-filled .p-password.p-invalid > .p-inputtext {
     border-color: transparent;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
@@ -7025,18 +6805,16 @@
     box-shadow: none;
     border-color: transparent;
   }
-
   .p-password.p-invalid > .p-inputtext:enabled:focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-panel {
     border-radius: 4px;
     box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 1px 3px 0 rgba(0, 0, 0, 0.12);
   }
   .p-panel .p-panel-header,
-.p-panel .p-panel-content,
-.p-panel .p-panel-footer {
+  .p-panel .p-panel-content,
+  .p-panel .p-panel-footer {
     border: 0 none;
   }
   .p-panel .p-panel-content {
@@ -7048,7 +6826,6 @@
   .p-panel .p-panel-header-icon:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-panelmenu .p-panelmenu-panel {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
     margin-bottom: 0;
@@ -7081,21 +6858,18 @@
   .p-panelmenu .p-panelmenu-panel .p-menuitem .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-picklist .p-picklist-list .p-picklist-item:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-progressbar {
     border-radius: 0;
   }
   .p-progressbar .p-progressbar-label {
     display: none;
   }
-
   .p-radiobutton {
     border-radius: 50%;
     transition: box-shadow 0.2s;
@@ -7121,14 +6895,12 @@
   .p-radiobutton.p-radiobutton-checked:not(.p-radiobutton-disabled).p-radiobutton-focused {
     box-shadow: 0 0 1px 10px rgba(63, 81, 181, 0.12);
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #ffffff;
   }
   .p-input-filled .p-radiobutton .p-radiobutton-box:not(.p-disabled):hover {
     background-color: #ffffff;
   }
-
   .p-rating {
     gap: 0;
   }
@@ -7150,7 +6922,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover.p-rating-cancel-item {
     background: rgba(176, 0, 32, 0.04);
   }
-
   .p-selectbutton .p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;
@@ -7159,11 +6930,9 @@
     background: #d9d8d9;
     border-color: #d9d8d9;
   }
-
   .p-slidemenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-slider .p-slider-handle {
     transition: transform 0.2s, box-shadow 0.2s;
     transform: scale(0.7);
@@ -7174,7 +6943,6 @@
   .p-slider.p-slider-sliding .p-slider-handle {
     transform: scale(1);
   }
-
   .p-splitbutton.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(63, 81, 181, 0.12);
   }
@@ -7206,49 +6974,42 @@
   .p-splitbutton.p-button-raised > .p-button:not(:disabled):focus {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2), 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(255, 64, 129, 0.12);
   }
   .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(255, 64, 129, 0.16);
   }
-
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(33, 150, 243, 0.12);
   }
   .p-splitbutton.p-button-info > .p-button.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(33, 150, 243, 0.16);
   }
-
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(104, 159, 56, 0.12);
   }
   .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(104, 159, 56, 0.16);
   }
-
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(251, 192, 45, 0.12);
   }
   .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(251, 192, 45, 0.16);
   }
-
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(156, 39, 176, 0.12);
   }
   .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(156, 39, 176, 0.16);
   }
-
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):focus {
     background: rgba(211, 47, 47, 0.12);
   }
   .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(211, 47, 47, 0.16);
   }
-
   .p-steps {
     padding: 1rem 0;
   }
@@ -7301,7 +7062,6 @@
   .p-steps .p-steps-item.p-disabled {
     opacity: 1;
   }
-
   .p-tabview .p-tabview-nav {
     position: relative;
   }
@@ -7324,15 +7084,12 @@
     background-color: #3F51B5;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-tieredmenu .p-menuitem-link:focus {
     background: rgba(0, 0, 0, 0.12);
   }
-
   .p-toolbar {
     border: 0 none;
   }
-
   .p-tooltip .p-tooltip-text {
     box-shadow: none;
     font-size: 0.875rem;
@@ -7340,14 +7097,12 @@
   .p-tooltip .p-tooltip-arrow {
     display: none;
   }
-
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus {
     background: rgba(0, 0, 0, 0.12);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content:focus.p-highlight {
     background: rgba(63, 81, 181, 0.24);
   }
-
   .p-treeselect .p-treeselect-label, .p-treeselect .p-treeselect-trigger {
     background-image: none;
     background: transparent;
@@ -7358,11 +7113,9 @@
   .p-treeselect:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
-
   .p-treeselect-item .p-ink {
     background-color: rgba(63, 81, 181, 0.16);
   }
-
   .p-input-filled .p-treeselect {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
@@ -7396,13 +7149,11 @@
     background-image: none;
     background: transparent;
   }
-
   .p-float-label .p-treeselect-label .p-treeselect-token {
     padding: 0.25rem 1rem;
     margin-top: 0.25rem;
     margin-bottom: 0.25rem;
   }
-
   .p-input-filled .p-float-label .p-treeselect .p-treeselect-label {
     padding-top: 1.25rem;
     padding-bottom: 0.25rem;
@@ -7431,11 +7182,9 @@
     box-shadow: none;
     background-image: linear-gradient(to bottom, #B00020, #B00020), linear-gradient(to bottom, #B00020, #B00020);
   }
-
   .p-treeselect.p-invalid:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020, inset 0 0 0 1px #B00020;
   }
-
   .p-treetable .p-sortable-column {
     outline: 0 none;
   }
@@ -7448,7 +7197,6 @@
   .p-treetable .p-treetable-tbody > tr:not(.p-highlight):focus {
     background-color: rgba(0, 0, 0, 0.03);
   }
-
   .p-tabmenu .p-tabmenu-nav {
     position: relative;
   }
@@ -7473,7 +7221,6 @@
     background-color: #3F51B5;
     transition: 500ms cubic-bezier(0.35, 0, 0.25, 1);
   }
-
   .p-togglebutton.p-button:focus {
     background: #e0e0e1;
     border-color: #e0e0e1;

--- a/public/themes/mira/theme.css
+++ b/public/themes/mira/theme.css
@@ -52,29 +52,25 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
-  src: local("Inter"), local("Inter-Regular"), url("./fonts/Inter-Regular.woff2") format("woff2"), url("./fonts/Inter-Regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Inter"), local("Inter-Regular"), url("./fonts/Inter-Regular.woff2") format("woff2"), url("./fonts/Inter-Regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 500;
-  src: local("Inter Medium"), local("Inter-Medium"), url("./fonts/Inter-Medium.woff2") format("woff2"), url("./fonts/Inter-Medium.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Inter Medium"), local("Inter-Medium"), url("./fonts/Inter-Medium.woff2") format("woff2"), url("./fonts/Inter-Medium.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 600;
-  src: local("Inter SemiBold"), local("Inter-SemiBold"), url("./fonts/Inter-SemiBold.woff2") format("woff2"), url("./fonts/Inter-SemiBold.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Inter SemiBold"), local("Inter-SemiBold"), url("./fonts/Inter-SemiBold.woff2") format("woff2"), url("./fonts/Inter-SemiBold.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
-  src: local("Inter Bold"), local("Inter-Bold"), url("./fonts/Inter-Bold.woff2") format("woff2"), url("./fonts/Inter-Bold.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Inter Bold"), local("Inter-Bold"), url("./fonts/Inter-Bold.woff2") format("woff2"), url("./fonts/Inter-Bold.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f7f9fb;
@@ -302,40 +298,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(112, 120, 136, 0.5);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #BF616A;
   }
-
   .p-text-secondary {
     color: #81A1C1;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -347,15 +335,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -372,7 +357,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -416,7 +400,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #BF616A;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #4C566A;
@@ -451,11 +434,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #BF616A;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -482,7 +463,7 @@
     border-top-left-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #81A1C1;
@@ -492,13 +473,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #4C566A;
     border-color: #5E81AC;
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
@@ -507,14 +488,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #4C566A;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #5E81AC;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -663,7 +644,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -706,7 +686,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #BF616A;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #4C566A;
@@ -748,7 +727,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #ECEFF4;
   }
@@ -758,7 +736,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -807,7 +784,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #BF616A;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #ECEFF4;
   }
@@ -820,7 +796,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #81A1C1;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -858,25 +833,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #BF616A;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #D8DEE9;
@@ -920,7 +891,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #BF616A;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #4C566A;
@@ -984,7 +954,6 @@
     color: #4C566A;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #ECEFF4;
   }
@@ -997,7 +966,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #ffffff;
     color: #81A1C1;
@@ -1010,68 +978,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #D8DEE9;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #BF616A;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1113,7 +1073,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #BF616A;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1146,59 +1105,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #4C566A;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #BF616A;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #81A1C1;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #81A1C1;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #4C566A;
   }
-
   :-moz-placeholder {
     color: #4C566A;
   }
-
   ::-moz-placeholder {
     color: #4C566A;
   }
-
   :-ms-input-placeholder {
     color: #4C566A;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #ECEFF4;
   }
@@ -1208,17 +1155,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #4C566A;
@@ -1280,7 +1224,6 @@
   .p-listbox.p-invalid {
     border-color: #BF616A;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #4C566A;
@@ -1308,7 +1251,6 @@
     color: #2E3440;
     background: #D8DEE9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #D8DEE9;
@@ -1358,7 +1300,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #BF616A;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1368,7 +1309,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #4C566A;
@@ -1454,7 +1394,6 @@
     color: #4C566A;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #ECEFF4;
   }
@@ -1464,11 +1403,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #BF616A;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1490,7 +1427,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #7FA366;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1534,7 +1470,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #ECEFF4;
   }
@@ -1547,7 +1482,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #81A1C1;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1577,7 +1511,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #D88889;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 2px solid #D8DEE9;
@@ -1585,7 +1518,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #81A1C1;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1594,7 +1527,7 @@
     color: #4C566A;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #81A1C1;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1603,7 +1536,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1612,13 +1545,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #BF616A;
   }
-
   .p-slider {
     background: #E5E9F0;
     border: 0 none;
@@ -1658,7 +1590,6 @@
     background: #5E81AC;
     border-color: #5E81AC;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #D8DEE9;
@@ -1705,11 +1636,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #BF616A;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #4C566A;
@@ -1769,7 +1698,6 @@
     color: #4C566A;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #ECEFF4;
   }
@@ -1779,7 +1707,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 2px solid #D8DEE9;
@@ -1787,7 +1714,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #81A1C1;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1796,7 +1723,7 @@
     color: #4C566A;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #81A1C1;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1805,7 +1732,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1814,13 +1741,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #BF616A;
   }
-
   .p-button {
     color: #ffffff;
     background: #5E81AC;
@@ -1932,7 +1858,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1968,7 +1894,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1981,7 +1906,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #4C566A;
@@ -2030,7 +1954,6 @@
     border-color: transparent;
     color: #4C566A;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #639BB2;
@@ -2079,7 +2002,6 @@
     border-color: transparent;
     color: #639BB2;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #7FA366;
@@ -2128,7 +2050,6 @@
     border-color: transparent;
     color: #7FA366;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #D08770;
@@ -2177,7 +2098,6 @@
     border-color: transparent;
     color: #D08770;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9A6796;
@@ -2226,7 +2146,6 @@
     border-color: transparent;
     color: #9A6796;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #BF616A;
@@ -2275,7 +2194,6 @@
     border-color: transparent;
     color: #BF616A;
   }
-
   .p-button.p-button-link {
     color: #48678c;
     background: transparent;
@@ -2299,7 +2217,6 @@
     color: #48678c;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 4px;
   }
@@ -2381,12 +2298,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #4C566A;
@@ -2415,7 +2331,6 @@
     border-color: transparent;
     color: #4C566A;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #639BB2;
@@ -2444,7 +2359,6 @@
     border-color: transparent;
     color: #639BB2;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #7FA366;
@@ -2473,7 +2387,6 @@
     border-color: transparent;
     color: #7FA366;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D08770;
@@ -2502,7 +2415,6 @@
     border-color: transparent;
     color: #D08770;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9A6796;
@@ -2531,7 +2443,6 @@
     border-color: transparent;
     color: #9A6796;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #BF616A;
@@ -2560,7 +2471,6 @@
     border-color: transparent;
     color: #BF616A;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2572,7 +2482,9 @@
     width: 2rem;
     height: 2rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2583,55 +2495,48 @@
     background: #3B4252;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(112, 120, 136, 0.5);
     border-radius: 4px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #81A1C1;
@@ -2642,13 +2547,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #4C566A;
     border-color: #5E81AC;
     background: #ffffff;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
@@ -2674,7 +2579,6 @@
     background: #D8DEE9;
     color: #2E3440;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2768,9 +2672,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #81A1C1;
@@ -2780,17 +2684,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #4C566A;
     border-color: #5E81AC;
     background: #ffffff;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
@@ -2843,12 +2747,12 @@
     background: #5E81AC;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ECEFF4;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2958,11 +2862,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(94, 129, 172, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3006,7 +2908,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3043,12 +2944,10 @@
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3076,7 +2975,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3096,7 +2994,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #4C566A;
@@ -3134,7 +3031,6 @@
     border-top: 1px solid #E5E9F0;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3163,7 +3059,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3228,7 +3123,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: transparent;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: transparent;
     color: #4C566A;
@@ -3267,7 +3161,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #4C566A;
@@ -3277,9 +3170,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #4C566A;
@@ -3290,9 +3183,9 @@
     border-radius: 4px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #ECEFF4;
     border-color: #5E81AC;
     color: #4C566A;
@@ -3348,7 +3241,6 @@
     border-color: #5E81AC;
     color: #4C566A;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3407,7 +3299,6 @@
     color: #2E3440;
     background: #D8DEE9;
   }
-
   .p-tree {
     border: 1px solid #E5E9F0;
     background: #ffffff;
@@ -3463,11 +3354,11 @@
     color: #2E3440;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #2E3440;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #2E3440;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3505,7 +3396,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #9fadc9;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3641,7 +3531,7 @@
     background: #5E81AC;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3718,7 +3608,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3730,20 +3619,19 @@
     background-color: #E5E9F0;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #E5E9F0;
@@ -3817,7 +3705,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #4C566A;
@@ -3843,7 +3730,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #E5E9F0;
     background: #ffffff;
@@ -3884,7 +3770,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3908,7 +3793,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #E5E9F0;
     padding: 1rem;
@@ -3958,7 +3842,6 @@
     color: #4C566A;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #E5E9F0;
     background: #ffffff;
@@ -3975,12 +3858,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #c2c7d1;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #ECEFF4;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 2px solid #E5E9F0;
@@ -4040,7 +3921,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 1px solid #E5E9F0;
@@ -4051,7 +3931,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #4C566A;
@@ -4099,7 +3978,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 4px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4175,7 +4053,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #4C566A;
@@ -4217,7 +4094,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #4C566A;
@@ -4228,7 +4104,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #81A1C1;
@@ -4238,13 +4114,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #4C566A;
     border-color: #5E81AC;
     background: #ffffff;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
@@ -4255,7 +4131,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #4C566A;
     color: #ffffff;
@@ -4275,7 +4150,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #4C566A;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 1rem;
@@ -4306,7 +4180,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #E5E9F0;
@@ -4338,7 +4211,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #81A1C1;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4410,7 +4282,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4425,32 +4296,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4467,22 +4337,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4533,19 +4403,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #ffffff;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #4C566A;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #81A1C1;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #81A1C1;
   }
   .p-megamenu .p-menuitem-link {
@@ -4715,7 +4585,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4776,7 +4645,6 @@
     border-top: 1px solid #E5E9F0;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ECEFF4;
@@ -4854,19 +4722,19 @@
     box-shadow: inset 0 0 0 0.15rem #C0D0E0;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #ffffff;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #4C566A;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #81A1C1;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #81A1C1;
   }
   .p-menubar .p-submenu-list {
@@ -4896,7 +4764,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #81A1C1;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5141,7 +5008,6 @@
     border-bottom-right-radius: 4px;
     border-bottom-left-radius: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5219,7 +5085,6 @@
     padding: 0.75rem 1rem;
     color: #4C566A;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5264,7 +5129,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 2px solid #E5E9F0;
@@ -5305,7 +5169,6 @@
     border-color: #5E81AC;
     color: #4C566A;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5380,7 +5243,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5436,7 +5298,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 4px;
@@ -5525,7 +5386,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5536,7 +5396,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5576,7 +5435,7 @@
     color: #2e4f5d;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #17282e;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5586,7 +5445,7 @@
     color: #202919;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #202919;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5596,7 +5455,7 @@
     color: #3c1d14;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #3c1d14;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5606,10 +5465,9 @@
     color: #331518;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #331518;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5640,11 +5498,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5698,7 +5556,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #ECEFF4;
@@ -5708,7 +5566,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #ECEFF4;
   }
@@ -5720,15 +5578,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5738,15 +5593,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5770,7 +5622,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #E5E9F0;
     border-radius: 4px;
@@ -5791,15 +5642,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #E5E9F0;
     color: #4C566A;
@@ -5833,7 +5681,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5855,7 +5702,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #E5E9F0;
     border-radius: 4px;
@@ -5863,7 +5709,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #5E81AC;
     color: #ffffff;
@@ -5896,7 +5741,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 4px;
@@ -5911,7 +5755,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #C0D0E0;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5927,7 +5770,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #4C566A;
@@ -5939,7 +5781,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #5E81AC;
     color: #ffffff;
@@ -5981,7 +5822,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #5E81AC;
     color: #ffffff;
@@ -6015,59 +5855,48 @@
   .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-chips .p-chips-multiple-container:not(.p-disabled):hover {
     background-color: #ECEFF4;
   }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-autocomplete .p-autocomplete-panel .p-autocomplete-item:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
   .p-autocomplete.p-autocomplete-multiple .p-autocomplete-multiple-container:not(.p-disabled):hover {
     background-color: #ECEFF4;
   }
-
   .p-dropdown:not(.p-disabled):hover {
     background-color: #ECEFF4;
   }
-
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item:not(.p-highlight):not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-listbox:not(.p-disabled) .p-listbox-item:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item:not(.p-highlight):not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-multiselect:not(.p-disabled):hover {
     background-color: #ECEFF4;
   }
-
   .p-button {
     font-weight: 500;
   }
-
   .p-radiobutton .p-radiobutton-box:not(.p-disabled):not(.p-highlight):hover {
     background-color: #D8DEE9;
   }
   .p-radiobutton .p-radiobutton-box:not(.p-disabled).p-focus {
     border-color: transparent;
   }
-
   .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
     background-color: #D8DEE9;
   }
   .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-focus {
     border-color: transparent;
   }
-
   .p-accordion .p-accordion-header:not(.p-highlight):not(.p-disabled):hover:not(.p-disabled) .p-accordion-header-link:focus {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
@@ -6077,7 +5906,6 @@
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-datepicker table td > span.p-highlight {
     color: #ffffff;
     background: #5E81AC;
@@ -6090,40 +5918,33 @@
     color: #ffffff;
     background: #5E81AC;
   }
-
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend:hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-menubar .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-tieredmenu .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-menu .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-contextmenu .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     border: 1px solid #5E81AC;
   }
   .p-paginator .p-paginator-pages .p-paginator-page:not(.p-highlight):hover {
     border: 1px solid #5E81AC;
   }
-
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
@@ -6136,22 +5957,18 @@
   .p-datatable.p-datatable-hoverable-rows .p-datatable-tbody > tr:not(.p-highlight):hover {
     outline: 1px solid #81A1C1;
   }
-
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #81A1C1;
     color: #ffffff;
     border: 2px solid #51749e;
   }
-
   .p-picklist .p-picklist-list .p-picklist-item:not(.p-highlight):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
     background: #ffffff;
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
@@ -6169,14 +5986,12 @@
   .p-treetable.p-treetable-hoverable-rows .p-treetable-tbody > tr:not(.p-highlight):hover {
     outline: 1px solid #81A1C1;
   }
-
   .p-megamenu .p-megamenu-root-list > .p-menuitem > .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
   .p-megamenu .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-panelmenu .p-panelmenu-header:not(.p-highlight):not(.p-disabled) > a:hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
@@ -6186,30 +6001,25 @@
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-slidemenu .p-menuitem-link:not(.p-disabled):hover {
     box-shadow: inset 0 0 0 0.1rem #81A1C1;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background: #5E81AC;
     color: #ffffff;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #5E81AC;
     color: #ffffff;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #5E81AC;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #5E81AC;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
 }

--- a/public/themes/nano/theme.css
+++ b/public/themes/nano/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #d8222f;
   }
-
   .p-text-secondary {
     color: #697077;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.25rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #d8222f;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #343a3f;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #d8222f;
   }
-
   .p-datepicker {
     padding: 0.25rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 1px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #343a3f;
     border-color: #121619;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
@@ -479,14 +464,14 @@
     line-height: 1rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #343a3f;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #1174c0;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #d8222f;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #343a3f;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f2f4f8;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 14px;
     height: 14px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #d8222f;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f2f4f8;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #0e5d9a;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.125rem 0.25rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #d8222f;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #a5acb3;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #d8222f;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #343a3f;
@@ -956,7 +930,6 @@
     color: #343a3f;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f2f4f8;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #dde1e6;
     color: #697077;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #a5acb3;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 1px;
     border-bottom-left-radius: 1px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 1px;
     border-bottom-left-radius: 1px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 1px;
     border-bottom-right-radius: 1px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 1px;
     border-bottom-right-radius: 1px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #d8222f;
   }
-
   .p-inputswitch {
     width: 2rem;
     height: 1.155rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #d8222f;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.3125rem 0.3125rem;
   }
-
   .p-float-label > label {
     left: 0.25rem;
     color: #697077;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #d8222f;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.25rem;
     color: #697077;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.25rem;
     color: #697077;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #697077;
   }
-
   :-moz-placeholder {
     color: #697077;
   }
-
   ::-moz-placeholder {
     color: #697077;
   }
-
   :-ms-input-placeholder {
     color: #697077;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f2f4f8;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.21875rem 0.21875rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.3125rem 0.3125rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #343a3f;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #d8222f;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #343a3f;
@@ -1280,7 +1227,6 @@
     color: #ffffff;
     background: #44A1D9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #a5acb3;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #d8222f;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.125rem 0.25rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.25rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #343a3f;
@@ -1426,7 +1370,6 @@
     color: #343a3f;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f2f4f8;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #d8222f;
   }
-
   .p-password-panel {
     padding: 0.5rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #207f3b;
   }
-
   .p-radiobutton {
     width: 14px;
     height: 14px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f2f4f8;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #0e5d9a;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #c0392b;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #a5acb3;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #697077;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #343a3f;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #697077;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #d8222f;
   }
-
   .p-slider {
     background: #dee2e6;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #1174c0;
     border-color: #1174c0;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #a5acb3;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #d8222f;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.125rem 0.25rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #343a3f;
@@ -1741,7 +1674,6 @@
     color: #343a3f;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f2f4f8;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #a5acb3;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #697077;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #343a3f;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #697077;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #d8222f;
   }
-
   .p-button {
     color: #ffffff;
     background: #1174c0;
@@ -1904,7 +1834,7 @@
     padding: 0.25rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #697077;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #697077;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #107d79;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #107d79;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #207f3b;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #207f3b;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #f0c135;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #f0c135;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #8949f8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #8949f8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #d8222f;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #d8222f;
   }
-
   .p-button.p-button-link {
     color: #0e5d9a;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #0e5d9a;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 1px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #697077;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #697077;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #107d79;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #107d79;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #207f3b;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #207f3b;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #f0c135;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #f0c135;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #8949f8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #8949f8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #d8222f;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #d8222f;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 2.75rem;
     height: 2.75rem;
@@ -2544,7 +2458,9 @@
     width: 1rem;
     height: 1rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 2.25rem;
     height: 2.25rem;
@@ -2555,55 +2471,48 @@
     background: #21272a;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 1px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #343a3f;
     border-color: #121619;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
@@ -2646,7 +2555,6 @@
     background: #44A1D9;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 0.25rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #343a3f;
     border-color: #121619;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
@@ -2815,12 +2723,12 @@
     background: #1174c0;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f2f4f8;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f2f4f8;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(17, 116, 192, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 1px;
     border-bottom-right-radius: 1px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 1rem;
     height: 1rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-column-filter-clear-button {
     width: 1rem;
     height: 1rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #343a3f;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.25rem 0.5rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.5rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.5rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #dde1e6;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #dde1e6;
     color: #343a3f;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #697077;
@@ -3249,9 +3146,9 @@
     border-radius: 1px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #697077;
@@ -3262,9 +3159,9 @@
     border-radius: 1px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #dde1e6;
     border-color: transparent;
     color: #343a3f;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #343a3f;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.5rem;
   }
@@ -3379,7 +3275,6 @@
     color: #ffffff;
     background: #44A1D9;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #2785bd;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #1174c0;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f2f4f8;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.75rem;
     border: 1px solid #dee2e6;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 1px;
     border-bottom-left-radius: 1px;
   }
-
   .p-card {
     background: #ffffff;
     color: #343a3f;
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.5rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 0.75rem;
@@ -3930,7 +3818,6 @@
     color: #343a3f;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f2f4f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 1px;
     border-bottom-left-radius: 1px;
   }
-
   .p-toolbar {
     background: #f2f4f8;
     border: 1px solid #dee2e6;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #343a3f;
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 1px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #343a3f;
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #343a3f;
@@ -4200,7 +4080,7 @@
     padding: 0.75rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #343a3f;
     border-color: #121619;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.5rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #343a3f;
     color: #ffffff;
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #343a3f;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f2f4f8;
     padding: 0.75rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #697077;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #dde1e6;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #343a3f;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #697077;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #697077;
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f2f4f8;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #90c9f5;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #dde1e6;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #343a3f;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #697077;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #697077;
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #697077;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 1px;
     border-bottom-left-radius: 1px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5191,7 +5061,6 @@
     padding: 0.5rem 0.5rem;
     color: #343a3f;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -5277,7 +5145,6 @@
     border-color: #1174c0;
     color: #1174c0;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.25rem 0.25rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 1px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #08576a;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #08576a;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #196310;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #196310;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #726203;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #726203;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #6f2205;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #6f2205;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f2f4f8;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f2f4f8;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 1px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #343a3f;
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 2rem;
     height: 2rem;
@@ -5827,7 +5678,6 @@
     width: 1rem;
     height: 1rem;
   }
-
   .p-skeleton {
     background-color: #dde1e6;
     border-radius: 1px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #1174c0;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.25rem 0.25rem;
     border-radius: 1px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #343a3f;
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #1174c0;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #1174c0;
     color: #ffffff;

--- a/public/themes/nova-accent/theme.css
+++ b/public/themes/nova-accent/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #a80000;
   }
-
   .p-text-secondary {
     color: #848484;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #333333;
@@ -423,11 +410,9 @@
     background: #f4f4f4;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #333333;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0.25rem;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f4f4f4;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #a80000;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f4f4f4;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #005b9f;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #333333;
@@ -956,7 +930,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f4f4f4;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #eaeaea;
     color: #848484;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #a6a6a6;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #a80000;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #a80000;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #666666;
   }
-
   :-moz-placeholder {
     color: #666666;
   }
-
   ::-moz-placeholder {
     color: #666666;
   }
-
   :-ms-input-placeholder {
     color: #666666;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f4f4f4;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #f4f4f4;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #333333;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #a80000;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #333333;
@@ -1280,7 +1227,6 @@
     color: #ffffff;
     background: #e02365;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1426,7 +1370,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f4f4f4;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #34A835;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f4f4f4;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #005b9f;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-selectbutton .p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #666666;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #333333;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-slider {
     background: #c8c8c8;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: 2px solid #666666;
     border-color: #007ad9;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1741,7 +1674,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f4f4f4;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-togglebutton.p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #666666;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #333333;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-button {
     color: #ffffff;
     background: #007ad9;
@@ -1904,7 +1834,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #007ad9;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #34A835;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #333333;
     background: #ffba01;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #e91224;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-button.p-button-link {
     color: #005b9f;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #005b9f;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #007ad9;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #34A835;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffba01;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #e91224;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #222c31;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2646,7 +2555,6 @@
     background: #e02365;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2815,12 +2723,12 @@
     background: #007ad9;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #007ad9;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f4f4f4;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(0, 122, 217, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #333333;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #eaeaea;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #eaeaea;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #eaeaea;
     color: #333333;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-paginator {
     background: #f4f4f4;
     color: #333333;
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #848484;
@@ -3262,9 +3159,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #333333;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #333333;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #ffffff;
     background: #e02365;
   }
-
   .p-tree {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #b61a50;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #007ad9;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #007ad9;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #c8c8c8;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #007ad9;
@@ -3764,7 +3656,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #ffffff;
     color: #333333;
@@ -3790,7 +3681,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3831,7 +3721,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3855,7 +3744,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #007ad9;
     padding: 0.857rem 1rem;
@@ -3905,7 +3793,6 @@
     color: #333333;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3922,12 +3809,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #d8dae2;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f8f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3987,7 +3872,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #007ad9;
     border: 1px solid #007ad9;
@@ -3998,7 +3882,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #333333;
@@ -4046,7 +3929,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4122,7 +4004,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #333333;
@@ -4164,7 +4045,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #c8c8c8;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #333333;
@@ -4175,7 +4055,7 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -4185,13 +4065,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -4202,7 +4082,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #333333;
     color: #ffffff;
@@ -4222,7 +4101,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #333333;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #007ad9;
     padding: 0.857rem 1rem;
@@ -4253,7 +4131,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #c8c8c8;
@@ -4285,7 +4162,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #333333;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #ffffff;
@@ -4357,7 +4233,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4372,32 +4247,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4414,22 +4288,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4480,19 +4354,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-megamenu .p-menuitem-link {
@@ -4662,7 +4536,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #ffffff;
@@ -4723,7 +4596,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ffffff;
@@ -4801,19 +4673,19 @@
     box-shadow: inset 0 0 0 0.15rem #8dcdff;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-menubar .p-submenu-list {
@@ -4843,7 +4715,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #333333;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5064,7 +4935,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #ffffff;
@@ -5142,7 +5012,6 @@
     padding: 0.857rem;
     color: #333333;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, box-shadow 0.2s;
@@ -5187,7 +5056,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5228,7 +5096,6 @@
     border-color: #007ad9;
     color: #ffffff;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #ffffff;
@@ -5303,7 +5170,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5359,7 +5225,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5448,7 +5313,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5459,7 +5323,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5499,7 +5362,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5509,7 +5372,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5519,7 +5382,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5529,10 +5392,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5563,11 +5425,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5621,7 +5483,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5631,7 +5493,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5643,15 +5505,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5661,15 +5520,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5693,7 +5549,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #c8c8c8;
     border-radius: 3px;
@@ -5714,15 +5569,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #c8c8c8;
     color: #333333;
@@ -5756,7 +5608,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5778,7 +5629,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #eaeaea;
     border-radius: 3px;
@@ -5786,7 +5636,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5819,7 +5668,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5834,7 +5682,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5850,7 +5697,6 @@
     color: #ffffff;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #333333;
@@ -5862,7 +5708,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #007ad9;
     color: #ffffff;
@@ -5904,7 +5749,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5937,7 +5781,6 @@
   .p-panel .p-panel-header .p-panel-header-icon:enabled:hover {
     color: #5ab7ff;
   }
-
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     color: #ffffff;
   }

--- a/public/themes/nova-alt/theme.css
+++ b/public/themes/nova-alt/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #a80000;
   }
-
   .p-text-secondary {
     color: #848484;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #333333;
@@ -423,11 +410,9 @@
     background: #f4f4f4;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #333333;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0.25rem;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f4f4f4;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #a80000;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f4f4f4;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #005b9f;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #ffffff;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #333333;
@@ -960,7 +933,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f4f4f4;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #eaeaea;
     color: #848484;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #a6a6a6;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #a80000;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #a80000;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #666666;
   }
-
   :-moz-placeholder {
     color: #666666;
   }
-
   ::-moz-placeholder {
     color: #666666;
   }
-
   :-ms-input-placeholder {
     color: #666666;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f4f4f4;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #f4f4f4;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #333333;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #a80000;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #333333;
@@ -1284,7 +1230,6 @@
     color: #ffffff;
     background: #007ad9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1430,7 +1373,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f4f4f4;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #ffffff;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #34A835;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f4f4f4;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #005b9f;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #ffffff;
   }
-
   .p-selectbutton .p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #666666;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #333333;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-slider {
     background: #c8c8c8;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: 2px solid #666666;
     border-color: #007ad9;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1753,7 +1683,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f4f4f4;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-togglebutton.p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #666666;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #333333;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-button {
     color: #ffffff;
     background: #007ad9;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #007ad9;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #34A835;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #333333;
     background: #ffba01;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #e91224;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-button.p-button-link {
     color: #005b9f;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #005b9f;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #007ad9;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #34A835;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffba01;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #e91224;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #222c31;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2658,7 +2564,6 @@
     background: #007ad9;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2764,17 +2669,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2827,12 +2732,12 @@
     background: #007ad9;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #333333;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f4f4f4;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(0, 122, 217, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #333333;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #eaeaea;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #eaeaea;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #eaeaea;
     color: #333333;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-paginator {
     background: #f4f4f4;
     color: #333333;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #848484;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #333333;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #333333;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #ffffff;
     background: #007ad9;
   }
-
   .p-tree {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3447,11 +3339,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #0062ae;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #007ad9;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #333333;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #c8c8c8;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #333333;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #ffffff;
     color: #333333;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #333333;
     padding: 0.857rem 1rem;
@@ -3917,7 +3802,6 @@
     color: #333333;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #d8dae2;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f8f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #333333;
     border: 1px solid #333333;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #333333;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #333333;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #c8c8c8;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #333333;
@@ -4187,7 +4064,7 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -4197,13 +4074,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #333333;
     color: #ffffff;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #333333;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #333333;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #c8c8c8;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #333333;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #ffffff;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #ffffff;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ffffff;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem #8dcdff;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #333333;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #ffffff;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #333333;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #007ad9;
     color: #ffffff;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #ffffff;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #c8c8c8;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #c8c8c8;
     color: #333333;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #eaeaea;
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #ffffff;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #333333;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #007ad9;
     color: #ffffff;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5949,7 +5790,6 @@
   .p-panel .p-panel-header .p-panel-header-icon:enabled:hover {
     color: #b4b4b4;
   }
-
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     color: #ffffff;
   }

--- a/public/themes/nova/theme.css
+++ b/public/themes/nova/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #a80000;
   }
-
   .p-text-secondary {
     color: #848484;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #333333;
@@ -423,11 +410,9 @@
     background: #f4f4f4;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #333333;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0.25rem;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f4f4f4;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #a80000;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f4f4f4;
   }
@@ -792,11 +772,9 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #005b9f;
   }
-
   .p-highlight .p-checkbox .p-checkbox-box {
     border-color: #ffffff;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -834,25 +812,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -896,7 +870,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #333333;
@@ -960,7 +933,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f4f4f4;
   }
@@ -973,7 +945,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #eaeaea;
     color: #848484;
@@ -986,68 +957,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #a6a6a6;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1089,7 +1052,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #a80000;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1122,59 +1084,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #a80000;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #848484;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #666666;
   }
-
   :-moz-placeholder {
     color: #666666;
   }
-
   ::-moz-placeholder {
     color: #666666;
   }
-
   :-ms-input-placeholder {
     color: #666666;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f4f4f4;
   }
@@ -1184,17 +1134,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #f4f4f4;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #333333;
@@ -1256,7 +1203,6 @@
   .p-listbox.p-invalid {
     border-color: #a80000;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #333333;
@@ -1284,7 +1230,6 @@
     color: #ffffff;
     background: #007ad9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1334,7 +1279,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1344,7 +1288,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1430,7 +1373,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f4f4f4;
   }
@@ -1440,11 +1382,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #a80000;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #ffffff;
@@ -1466,7 +1406,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #34A835;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1510,7 +1449,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f4f4f4;
   }
@@ -1523,11 +1461,9 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #005b9f;
   }
-
   .p-highlight .p-radiobutton .p-radiobutton-box {
     border-color: #ffffff;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1557,11 +1493,9 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #b5019f;
   }
-
   .p-highlight .p-rating .p-rating-item.p-rating-item-active .p-rating-icon {
     color: #ffffff;
   }
-
   .p-selectbutton .p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1569,7 +1503,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #666666;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1578,7 +1512,7 @@
     color: #333333;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1587,7 +1521,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1596,13 +1530,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-slider {
     background: #c8c8c8;
     border: 0 none;
@@ -1642,7 +1575,6 @@
     background: 2px solid #666666;
     border-color: #007ad9;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #a6a6a6;
@@ -1689,11 +1621,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #a80000;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #333333;
@@ -1753,7 +1683,6 @@
     color: #333333;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f4f4f4;
   }
@@ -1763,7 +1692,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-togglebutton.p-button {
     background: #dadada;
     border: 1px solid #dadada;
@@ -1771,7 +1699,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #666666;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1780,7 +1708,7 @@
     color: #333333;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #212121;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1789,7 +1717,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1798,13 +1726,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #a80000;
   }
-
   .p-button {
     color: #ffffff;
     background: #007ad9;
@@ -1916,7 +1843,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1952,7 +1879,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1965,7 +1891,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2014,7 +1939,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #007ad9;
@@ -2063,7 +1987,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #34A835;
@@ -2112,7 +2035,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #333333;
     background: #ffba01;
@@ -2161,7 +2083,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2210,7 +2131,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #e91224;
@@ -2259,7 +2179,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-button.p-button-link {
     color: #005b9f;
     background: transparent;
@@ -2283,7 +2202,6 @@
     color: #005b9f;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2365,12 +2283,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2399,7 +2316,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #007ad9;
@@ -2428,7 +2344,6 @@
     border-color: transparent;
     color: #007ad9;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #34A835;
@@ -2457,7 +2372,6 @@
     border-color: transparent;
     color: #34A835;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffba01;
@@ -2486,7 +2400,6 @@
     border-color: transparent;
     color: #ffba01;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2515,7 +2428,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #e91224;
@@ -2544,7 +2456,6 @@
     border-color: transparent;
     color: #e91224;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2556,7 +2467,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2567,55 +2480,48 @@
     background: #222c31;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2626,13 +2532,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2658,7 +2564,6 @@
     background: #007ad9;
     color: #ffffff;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2752,9 +2657,9 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2764,17 +2669,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -2827,12 +2732,12 @@
     background: #007ad9;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f4f4f4;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f4f4f4;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2942,11 +2847,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(0, 122, 217, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2990,7 +2893,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3027,12 +2929,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3060,7 +2960,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #333333;
@@ -3118,7 +3016,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #eaeaea;
@@ -3147,7 +3044,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3212,7 +3108,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #eaeaea;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #eaeaea;
     color: #333333;
@@ -3251,7 +3146,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-paginator {
     background: #f4f4f4;
     color: #333333;
@@ -3261,9 +3155,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #848484;
@@ -3274,9 +3168,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e0e0e0;
     border-color: transparent;
     color: #333333;
@@ -3332,7 +3226,6 @@
     border-color: transparent;
     color: #333333;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3391,7 +3284,6 @@
     color: #ffffff;
     background: #007ad9;
   }
-
   .p-tree {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3447,11 +3339,11 @@
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #ffffff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3489,7 +3381,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #0062ae;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3625,7 +3516,7 @@
     background: #007ad9;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f4f4f4;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3702,7 +3593,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3714,20 +3604,19 @@
     background-color: #c8c8c8;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #c8c8c8;
@@ -3776,7 +3665,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #ffffff;
     color: #333333;
@@ -3802,7 +3690,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3843,7 +3730,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3867,7 +3753,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #c8c8c8;
     padding: 0.857rem 1rem;
@@ -3917,7 +3802,6 @@
     color: #333333;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #c8c8c8;
     background: #ffffff;
@@ -3934,12 +3818,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #d8dae2;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f8f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3999,7 +3881,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #f4f4f4;
     border: 1px solid #c8c8c8;
@@ -4010,7 +3891,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #333333;
@@ -4058,7 +3938,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4134,7 +4013,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #333333;
@@ -4176,7 +4054,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #c8c8c8;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #333333;
@@ -4187,7 +4064,7 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -4197,13 +4074,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #007ad9;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
@@ -4214,7 +4091,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #333333;
     color: #ffffff;
@@ -4234,7 +4110,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #333333;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f4f4f4;
     padding: 0.857rem 1rem;
@@ -4265,7 +4140,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #c8c8c8;
@@ -4297,7 +4171,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #333333;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #ffffff;
@@ -4369,7 +4242,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4384,32 +4256,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4426,22 +4297,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4492,19 +4363,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-megamenu .p-menuitem-link {
@@ -4674,7 +4545,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #ffffff;
@@ -4735,7 +4605,6 @@
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ffffff;
@@ -4813,19 +4682,19 @@
     box-shadow: inset 0 0 0 0.15rem #8dcdff;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #333333;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #333333;
   }
   .p-menubar .p-submenu-list {
@@ -4855,7 +4724,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #333333;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5076,7 +4944,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #ffffff;
@@ -5154,7 +5021,6 @@
     padding: 0.857rem;
     color: #333333;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, box-shadow 0.2s;
@@ -5199,7 +5065,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5240,7 +5105,6 @@
     border-color: #007ad9;
     color: #ffffff;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #ffffff;
@@ -5315,7 +5179,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5371,7 +5234,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5460,7 +5322,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5471,7 +5332,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5511,7 +5371,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5521,7 +5381,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5531,7 +5391,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5541,10 +5401,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5575,11 +5434,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5633,7 +5492,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5643,7 +5502,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5655,15 +5514,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5673,15 +5529,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5705,7 +5558,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #c8c8c8;
     border-radius: 3px;
@@ -5726,15 +5578,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #c8c8c8;
     color: #333333;
@@ -5768,7 +5617,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5790,7 +5638,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #eaeaea;
     border-radius: 3px;
@@ -5798,7 +5645,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5831,7 +5677,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 3px;
@@ -5846,7 +5691,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5862,7 +5706,6 @@
     color: #ffffff;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #333333;
@@ -5874,7 +5717,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #007ad9;
     color: #ffffff;
@@ -5916,7 +5758,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #007ad9;
     color: #ffffff;
@@ -5949,7 +5790,6 @@
   .p-panel .p-panel-header .p-panel-header-icon:enabled:hover {
     color: #333333;
   }
-
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     color: #848484;
   }

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.5;
   }
-
   .p-error {
     color: #e7a3a3;
   }
-
   .p-text-secondary {
     color: #a6a6a6;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.429rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #e7a3a3;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #666666;
@@ -423,11 +410,9 @@
     background: #f4f4f4;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #e7a3a3;
   }
-
   .p-datepicker {
     padding: 0.857rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 2px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #666666;
     border-color: transparent;
     background: transparent;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #666666;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #7B95A3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0.25rem;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e7a3a3;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #666666;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f4f4f4;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #e7a3a3;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f4f4f4;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #617c8a;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.2145rem 0.429rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #e7a3a3;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #dadada;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #e7a3a3;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #666666;
@@ -956,7 +930,6 @@
     color: #666666;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f4f4f4;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #dbdbdb;
     color: #666666;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #dadada;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #e7a3a3;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #e7a3a3;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-float-label > label {
     left: 0.429rem;
     color: #a6a6a6;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e7a3a3;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.429rem;
     color: #a6a6a6;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 1.858rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 1.858rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.429rem;
     color: #a6a6a6;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 1.858rem;
   }
-
   ::-webkit-input-placeholder {
     color: #a6a6a6;
   }
-
   :-moz-placeholder {
     color: #a6a6a6;
   }
-
   ::-moz-placeholder {
     color: #a6a6a6;
   }
-
   :-ms-input-placeholder {
     color: #a6a6a6;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f4f4f4;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #f4f4f4;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.375375rem 0.375375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #666666;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #e7a3a3;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #666666;
@@ -1280,7 +1227,6 @@
     color: #385048;
     background: #AFD3C8;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #dadada;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #e7a3a3;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.2145rem 0.429rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.429rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #666666;
@@ -1426,7 +1370,6 @@
     color: #666666;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f4f4f4;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #e7a3a3;
   }
-
   .p-password-panel {
     padding: 0.571rem 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #A3E2C6;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f4f4f4;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #617c8a;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #d66161;
   }
-
   .p-selectbutton .p-button {
     background: #eaeaea;
     border: 1px solid #eaeaea;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #666666;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #333333;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #666666;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #385048;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #385048;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #385048;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #385048;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #e7a3a3;
   }
-
   .p-slider {
     background: #c4c4c4;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: 2px solid #7f7f7f;
     border-color: #7B95A3;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #dadada;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #e7a3a3;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.2145rem 0.429rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #666666;
@@ -1741,7 +1674,6 @@
     color: #666666;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f4f4f4;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #f4f4f4;
   }
-
   .p-togglebutton.p-button {
     background: #eaeaea;
     border: 1px solid #eaeaea;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #666666;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #333333;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #666666;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #385048;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #385048;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #385048;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #385048;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #e7a3a3;
   }
-
   .p-button {
     color: #ffffff;
     background: #7B95A3;
@@ -1904,7 +1834,7 @@
     padding: 0.429rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #a3897b;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #a3897b;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #3D4447;
     background: #A3DEF8;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #A3DEF8;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #323E39;
     background: #A3E2C6;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #A3E2C6;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #333333;
     background: #ffe38e;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #ffe38e;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #333333;
     background: #e9bef1;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #e9bef1;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #262222;
     background: #F4B6B6;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F4B6B6;
   }
-
   .p-button.p-button-link {
     color: #617c8a;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #617c8a;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 2px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #a3897b;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #a3897b;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A3DEF8;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #A3DEF8;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A3E2C6;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #A3E2C6;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffe38e;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #ffe38e;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #e9bef1;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #e9bef1;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F4B6B6;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F4B6B6;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #222c31;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 2px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #666666;
     border-color: transparent;
     background: transparent;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
@@ -2646,7 +2555,6 @@
     background: #AFD3C8;
     color: #385048;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 0.571rem 0.857rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #666666;
     border-color: transparent;
     background: transparent;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
@@ -2815,12 +2723,12 @@
     background: #7B95A3;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #7B95A3;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(123, 149, 163, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #666666;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dadada;
     margin: 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.429rem 0.857rem;
     border-bottom: 1px solid #dadada;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 0.571rem 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 0.571rem 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f4f4f4;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f4f4f4;
     color: #666666;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #666666;
@@ -3249,9 +3146,9 @@
     border-radius: 2px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #666666;
@@ -3262,9 +3159,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f4f4f4;
     border-color: transparent;
     color: #666666;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #666666;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 0.571rem 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #385048;
     background: #AFD3C8;
   }
-
   .p-tree {
     border: 1px solid #dadada;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #385048;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #385048;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #385048;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #7db8a6;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 1px 0 1px;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #7B95A3;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #7B95A3;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.71375rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 0 none;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #c8c8c8;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 0.857rem 1rem;
     border: 1px solid #7B95A3;
@@ -3764,7 +3656,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 2px;
   }
-
   .p-card {
     background: #ffffff;
     color: #666666;
@@ -3790,7 +3681,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dadada;
     background: #ffffff;
@@ -3831,7 +3721,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 0.571rem 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3855,7 +3744,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #7B95A3;
     padding: 0.857rem 1rem;
@@ -3905,7 +3793,6 @@
     color: #666666;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dadada;
     background: #ffffff;
@@ -3922,12 +3809,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dadada;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f8f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 0 none;
@@ -3987,7 +3872,6 @@
     border-bottom-right-radius: 2px;
     border-bottom-left-radius: 2px;
   }
-
   .p-toolbar {
     background: #7B95A3;
     border: 1px solid #7B95A3;
@@ -3998,7 +3882,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #666666;
@@ -4046,7 +3929,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 2px;
     box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.16);
@@ -4122,7 +4004,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #666666;
@@ -4164,7 +4045,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #f1f1f1;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #666666;
@@ -4175,7 +4055,7 @@
     padding: 0.857rem 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -4185,13 +4065,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #666666;
     border-color: transparent;
     background: transparent;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
@@ -4202,7 +4082,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 0.571rem 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #AFD3C8;
     color: #385048;
@@ -4222,7 +4101,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #AFD3C8;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #7B95A3;
     padding: 0.857rem 1rem;
@@ -4253,7 +4131,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #c8c8c8;
@@ -4285,7 +4162,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #666666;
   }
-
   .p-contextmenu {
     padding: 0;
     background: #ffffff;
@@ -4357,7 +4233,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4372,32 +4247,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4414,22 +4288,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4480,19 +4354,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #666666;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #666666;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #666666;
   }
   .p-megamenu .p-menuitem-link {
@@ -4662,7 +4536,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0;
     background: #ffffff;
@@ -4723,7 +4596,6 @@
     border-top: 1px solid #dadada;
     margin: 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #ffffff;
@@ -4801,19 +4673,19 @@
     box-shadow: inset 0 0 0 0.15rem #e4e9ec;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #eaeaea;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #666666;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #666666;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #666666;
   }
   .p-menubar .p-submenu-list {
@@ -4843,7 +4715,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #666666;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5064,7 +4935,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
   }
-
   .p-slidemenu {
     padding: 0;
     background: #ffffff;
@@ -5142,7 +5012,6 @@
     padding: 0.857rem;
     color: #666666;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
@@ -5187,7 +5056,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 0 none;
@@ -5228,7 +5096,6 @@
     border-color: #dadada;
     color: #385048;
   }
-
   .p-tieredmenu {
     padding: 0;
     background: #ffffff;
@@ -5303,7 +5170,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem;
     margin: 0;
@@ -5359,7 +5225,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 2px;
@@ -5448,7 +5313,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5459,7 +5323,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 0.5rem;
@@ -5499,7 +5362,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5509,7 +5372,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5519,7 +5382,7 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5529,10 +5392,9 @@
     color: #212121;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #212121;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5563,11 +5425,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5621,7 +5483,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #aeb6bf;
@@ -5631,7 +5493,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #aeb6bf;
   }
@@ -5643,15 +5505,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5661,15 +5520,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5693,7 +5549,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dadada;
     border-radius: 2px;
@@ -5714,15 +5569,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dadada;
     color: #666666;
@@ -5756,7 +5608,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5778,7 +5629,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #dadada;
     border-radius: 2px;
@@ -5786,7 +5636,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #7B95A3;
     color: #ffffff;
@@ -5819,7 +5668,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.429rem 0.429rem;
     border-radius: 2px;
@@ -5834,7 +5682,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 24px;
@@ -5850,7 +5697,6 @@
     color: #ffffff;
     line-height: 24px;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #666666;
@@ -5862,7 +5708,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #7B95A3;
     color: #ffffff;
@@ -5904,7 +5749,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #7B95A3;
     color: #ffffff;
@@ -5937,7 +5781,6 @@
   .p-panel .p-panel-header .p-panel-header-icon:enabled:hover {
     color: #ffffff;
   }
-
   .p-dialog .p-dialog-header .p-dialog-header-icon {
     color: #ffffff;
   }

--- a/public/themes/saga-blue/theme.css
+++ b/public/themes/saga-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #f44336;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #495057;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #495057;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #2196F3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f8f9fa;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44336;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f8f9fa;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #0b7ad1;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #495057;
@@ -956,7 +930,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f8f9fa;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #6c757d;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44336;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44336;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f8f9fa;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #495057;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #f44336;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #495057;
@@ -1280,7 +1227,6 @@
     color: #495057;
     background: #E3F2FD;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1426,7 +1370,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f8f9fa;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f8f9fa;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #0b7ad1;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #c0392b;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #495057;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-slider {
     background: #dee2e6;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #2196F3;
     border-color: #2196F3;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1741,7 +1674,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f8f9fa;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #495057;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-button {
     color: #ffffff;
     background: #2196F3;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0288D1;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #0b7ad1;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #0b7ad1;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0288D1;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
@@ -2646,7 +2555,6 @@
     background: #E3F2FD;
     color: #495057;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
@@ -2815,12 +2723,12 @@
     background: #2196F3;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f8f9fa;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(33, 150, 243, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #495057;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #495057;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6c757d;
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6c757d;
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: transparent;
     color: #495057;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #495057;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #495057;
     background: #E3F2FD;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #89c8f7;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #2196F3;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #2196F3;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #dee2e6;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #ffffff;
     color: #495057;
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: #495057;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f9fa;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #f8f9fa;
     border: 1px solid #dee2e6;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #495057;
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #495057;
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #495057;
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #495057;
     color: #ffffff;
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #495057;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f8f9fa;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f8f9fa;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #a6d5fa;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: #495057;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -5277,7 +5145,6 @@
     border-color: #2196F3;
     color: #2196F3;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #495057;
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #2196F3;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #495057;
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #2196F3;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #2196F3;
     color: #ffffff;
@@ -5984,11 +5828,9 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #2196F3;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #2196F3;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #2196F3;
   }

--- a/public/themes/saga-green/theme.css
+++ b/public/themes/saga-green/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #f44336;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #495057;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #495057;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #4CAF50;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f8f9fa;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44336;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f8f9fa;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #3d8c40;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #495057;
@@ -956,7 +930,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f8f9fa;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #6c757d;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44336;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44336;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f8f9fa;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #495057;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #f44336;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #495057;
@@ -1280,7 +1227,6 @@
     color: #495057;
     background: #E8F5E9;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1426,7 +1370,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f8f9fa;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f8f9fa;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #3d8c40;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #c0392b;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #495057;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-slider {
     background: #dee2e6;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #4CAF50;
     border-color: #4CAF50;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1741,7 +1674,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f8f9fa;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #495057;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-button {
     color: #ffffff;
     background: #4CAF50;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0288D1;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #3d8c40;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #3d8c40;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0288D1;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
@@ -2646,7 +2555,6 @@
     background: #E8F5E9;
     color: #495057;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
@@ -2815,12 +2723,12 @@
     background: #4CAF50;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f8f9fa;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(76, 175, 80, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #495057;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #495057;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6c757d;
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6c757d;
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: transparent;
     color: #495057;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #495057;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #495057;
     background: #E8F5E9;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #a6d8a9;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #4CAF50;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #4CAF50;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #dee2e6;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #ffffff;
     color: #495057;
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: #495057;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f9fa;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #f8f9fa;
     border: 1px solid #dee2e6;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #495057;
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #495057;
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #495057;
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #495057;
     color: #ffffff;
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #495057;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f8f9fa;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f8f9fa;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #b7e0b8;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: #495057;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -5277,7 +5145,6 @@
     border-color: #4CAF50;
     color: #4CAF50;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #495057;
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #4CAF50;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #495057;
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #4CAF50;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #4CAF50;
     color: #ffffff;
@@ -5984,11 +5828,9 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #4CAF50;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #4CAF50;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #4CAF50;
   }

--- a/public/themes/saga-orange/theme.css
+++ b/public/themes/saga-orange/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #f44336;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #495057;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #495057;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #FFC107;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f8f9fa;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44336;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f8f9fa;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #d29d00;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #495057;
@@ -956,7 +930,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f8f9fa;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #6c757d;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44336;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44336;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f8f9fa;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #495057;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #f44336;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #495057;
@@ -1280,7 +1227,6 @@
     color: #495057;
     background: #FFF3E0;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1426,7 +1370,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f8f9fa;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f8f9fa;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #d29d00;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #c0392b;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #495057;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-slider {
     background: #dee2e6;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #FFC107;
     border-color: #FFC107;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1741,7 +1674,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f8f9fa;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #495057;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-button {
     color: #212529;
     background: #FFC107;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0288D1;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #d29d00;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #d29d00;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0288D1;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
@@ -2646,7 +2555,6 @@
     background: #FFF3E0;
     color: #495057;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
@@ -2815,12 +2723,12 @@
     background: #FFC107;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f8f9fa;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(255, 193, 7, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #495057;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #495057;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6c757d;
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6c757d;
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: transparent;
     color: #495057;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #495057;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #495057;
     background: #FFF3E0;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #ffce80;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #FFC107;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #FFC107;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #dee2e6;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #ffffff;
     color: #495057;
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: #495057;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f9fa;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #f8f9fa;
     border: 1px solid #dee2e6;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #495057;
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #495057;
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #495057;
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #495057;
     color: #ffffff;
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #495057;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f8f9fa;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f8f9fa;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #ffe69c;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: #495057;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -5277,7 +5145,6 @@
     border-color: #FFC107;
     color: #FFC107;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #495057;
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #FFC107;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #495057;
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #FFC107;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #FFC107;
     color: #212529;
@@ -5984,11 +5828,9 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #FFC107;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #FFC107;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #FFC107;
   }

--- a/public/themes/saga-purple/theme.css
+++ b/public/themes/saga-purple/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #f44336;
   }
-
   .p-text-secondary {
     color: #6c757d;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #495057;
@@ -423,11 +410,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #495057;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #9C27B0;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f8f9fa;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f44336;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f8f9fa;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #7d1f8d;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #495057;
@@ -956,7 +930,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f8f9fa;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #e9ecef;
     color: #6c757d;
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #ced4da;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f44336;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #f44336;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: #6c757d;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: #6c757d;
   }
-
   :-moz-placeholder {
     color: #6c757d;
   }
-
   ::-moz-placeholder {
     color: #6c757d;
   }
-
   :-ms-input-placeholder {
     color: #6c757d;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f8f9fa;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #495057;
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #f44336;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #495057;
@@ -1280,7 +1227,6 @@
     color: #495057;
     background: #F3E5F5;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1426,7 +1370,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f8f9fa;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f44336;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #689F38;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f8f9fa;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #7d1f8d;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #c0392b;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: #495057;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-slider {
     background: #dee2e6;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #9C27B0;
     border-color: #9C27B0;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f44336;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #495057;
@@ -1741,7 +1674,6 @@
     color: #495057;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f8f9fa;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #ced4da;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: #495057;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #6c757d;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f44336;
   }
-
   .p-button {
     color: #ffffff;
     background: #9C27B0;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #607D8B;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #0288D1;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #689F38;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #212529;
     background: #FBC02D;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #9C27B0;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #D32F2F;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-button.p-button-link {
     color: #7d1f8d;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #7d1f8d;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #607D8B;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #607D8B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #0288D1;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #0288D1;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #689F38;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #689F38;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FBC02D;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FBC02D;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9C27B0;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #9C27B0;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #D32F2F;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #D32F2F;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: #343a40;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
@@ -2646,7 +2555,6 @@
     background: #F3E5F5;
     color: #495057;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
@@ -2815,12 +2723,12 @@
     background: #9C27B0;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #f8f9fa;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(156, 39, 176, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #495057;
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #e9ecef;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #e9ecef;
     color: #495057;
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #6c757d;
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #6c757d;
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #e9ecef;
     border-color: transparent;
     color: #495057;
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: #495057;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: #495057;
     background: #F3E5F5;
   }
-
   .p-tree {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3435,11 +3330,11 @@
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #495057;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #d3a1db;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #9C27B0;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #f8f9fa;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #9C27B0;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #dee2e6;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #dee2e6;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #ffffff;
     color: #495057;
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dee2e6;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: #495057;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dee2e6;
     background: #ffffff;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dee2e6;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f8f9fa;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #f8f9fa;
     border: 1px solid #dee2e6;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #495057;
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #495057;
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #495057;
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #495057;
     border-color: transparent;
     background: #e9ecef;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #495057;
     color: #ffffff;
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #495057;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #f8f9fa;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #6c757d;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f8f9fa;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #df9eea;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e9ecef;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #495057;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #6c757d;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #6c757d;
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: #495057;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
@@ -5277,7 +5145,6 @@
     border-color: #9C27B0;
     color: #9C27B0;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dee2e6;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dee2e6;
     color: #495057;
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #e9ecef;
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #9C27B0;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #495057;
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #9C27B0;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #9C27B0;
     color: #ffffff;
@@ -5984,11 +5828,9 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #9C27B0;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #9C27B0;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #9C27B0;
   }

--- a/public/themes/soho-dark/theme.css
+++ b/public/themes/soho-dark/theme.css
@@ -10,7 +10,7 @@
   --text-color:rgba(255, 255, 255, 0.87);
   --text-color-secondary:rgba(255, 255, 255, 0.6);
   --primary-color:#b19df7;
-  --primary-color-text:#1c1d26;
+  --primary-color-text:hsl(234deg, 15%, 13%);
   --surface-0: #1d1e27;
   --surface-50: #34343d;
   --surface-100: #4a4b52;
@@ -53,24 +53,21 @@
   font-family: "Lato";
   font-style: normal;
   font-weight: 300;
-  src: local("Lato Light"), local("Lato-Light"), url("./fonts/lato-v17-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-300.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Light"), local("Lato-Light"), url("./fonts/lato-v17-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-300.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* lato-regular - latin-ext_latin */
 @font-face {
   font-family: "Lato";
   font-style: normal;
   font-weight: 400;
-  src: local("Lato Regular"), local("Lato-Regular"), url("./fonts/lato-v17-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Regular"), local("Lato-Regular"), url("./fonts/lato-v17-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* lato-700 - latin-ext_latin */
 @font-face {
   font-family: "Lato";
   font-style: normal;
   font-weight: 700;
-  src: local("Lato Bold"), local("Lato-Bold"), url("./fonts/lato-v17-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Bold"), local("Lato-Bold"), url("./fonts/lato-v17-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f6fbfe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ff9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ff9a9a;
   }
-
   .p-autocomplete-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -447,11 +431,9 @@
     background: #333544;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ff9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #282936;
@@ -478,7 +460,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #b19df7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ff9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #3e4053;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #3e4053;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -770,7 +748,7 @@
   }
   .p-checkbox .p-checkbox-box .p-checkbox-icon {
     transition-duration: 0.2s;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     font-size: 14px;
   }
   .p-checkbox .p-checkbox-box .p-checkbox-icon.p-icon {
@@ -784,7 +762,7 @@
   .p-checkbox .p-checkbox-box.p-highlight:not(.p-disabled):hover {
     border-color: #9378f4;
     background: #9378f4;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box:hover {
     border-color: #b19df7;
@@ -798,12 +776,11 @@
   .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     border-color: #9378f4;
     background: #9378f4;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ff9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #3e4053;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #9378f4;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ff9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #282936;
     border: 1px solid #3e4053;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #1d1e27;
     border: 1px solid #3e4053;
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ff9a9a;
   }
-
   .p-dropdown-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -980,7 +951,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #3e4053;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #3e4053;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ff9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ff9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ff9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #3e4053;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #3e4053;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #ff9a9a;
   }
-
   .p-mention-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -1304,7 +1248,6 @@
     color: #b19df7;
     background: rgba(177, 157, 247, 0.16);
   }
-
   .p-multiselect {
     background: #1d1e27;
     border: 1px solid #3e4053;
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ff9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -1450,7 +1391,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #3e4053;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #3e4053;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ff9a9a;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #282936;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #93deac;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1513,7 +1450,7 @@
     width: 12px;
     height: 12px;
     transition-duration: 0.2s;
-    background-color: #1c1d26;
+    background-color: hsl(234deg, 15%, 13%);
   }
   .p-radiobutton .p-radiobutton-box.p-highlight {
     border-color: #b19df7;
@@ -1522,7 +1459,7 @@
   .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     border-color: #9378f4;
     background: #9378f4;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-radiobutton.p-invalid > .p-radiobutton-box {
     border-color: #ff9a9a;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #3e4053;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #9378f4;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #282936;
     border: 1px solid #3e4053;
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,31 +1524,30 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
     background: #b19df7;
     border-color: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
-    color: #1c1d26;
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
+    color: hsl(234deg, 15%, 13%);
   }
   .p-selectbutton .p-button.p-highlight:hover {
     background: #a28af5;
     border-color: #a28af5;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
-    color: #1c1d26;
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+    color: hsl(234deg, 15%, 13%);
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ff9a9a;
   }
-
   .p-slider {
     background: #3e4053;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #b19df7;
     border-color: #b19df7;
   }
-
   .p-treeselect {
     background: #1d1e27;
     border: 1px solid #3e4053;
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ff9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -1765,7 +1695,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #3e4053;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #3e4053;
   }
-
   .p-togglebutton.p-button {
     background: #282936;
     border: 1px solid #3e4053;
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,33 +1720,32 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
     background: #b19df7;
     border-color: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
-    color: #1c1d26;
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
+    color: hsl(234deg, 15%, 13%);
   }
   .p-togglebutton.p-button.p-highlight:hover {
     background: #a28af5;
     border-color: #a28af5;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
-    color: #1c1d26;
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+    color: hsl(234deg, 15%, 13%);
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ff9a9a;
   }
-
   .p-button {
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     background: #b19df7;
     border: 1px solid #b19df7;
     padding: 0.75rem 1.25rem;
@@ -1828,12 +1755,12 @@
   }
   .p-button:not(:disabled):hover {
     background: #a28af5;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     border-color: #a28af5;
   }
   .p-button:not(:disabled):active {
     background: #9378f4;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     border-color: #9378f4;
   }
   .p-button.p-button-outlined {
@@ -1915,7 +1842,7 @@
     height: 1rem;
     line-height: 1rem;
     color: #b19df7;
-    background-color: #1c1d26;
+    background-color: hsl(234deg, 15%, 13%);
   }
   .p-button.p-button-raised {
     box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12);
@@ -1928,7 +1855,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #1d1e27;
     background: #d4ea93;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #d4ea93;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #1d1e27;
     background: #9bcaff;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #9bcaff;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #1d1e27;
     background: #93deac;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #93deac;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #1d1e27;
     background: #ffcf91;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #ffcf91;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #1d1e27;
     background: #86e0e7;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #86e0e7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #1d1e27;
     background: #eb9a9c;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #eb9a9c;
   }
-
   .p-button.p-button-link {
     color: #b19df7;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #b19df7;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #d4ea93;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #d4ea93;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #9bcaff;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #9bcaff;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #93deac;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #93deac;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffcf91;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #ffcf91;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #86e0e7;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #86e0e7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #eb9a9c;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #eb9a9c;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #1d1e27;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
@@ -2670,7 +2576,6 @@
     background: rgba(177, 157, 247, 0.16);
     color: #b19df7;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
@@ -2839,12 +2744,12 @@
     background: #b19df7;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #282936;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #282936;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(177, 157, 247, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-column-filter-overlay {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -3130,7 +3028,6 @@
     border-top: 1px solid #3e4053;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #3e4053;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-paginator {
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
@@ -3273,9 +3167,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3286,9 +3180,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3403,7 +3296,6 @@
     color: #b19df7;
     background: rgba(177, 157, 247, 0.16);
   }
-
   .p-tree {
     border: 1px solid #3e4053;
     background: #282936;
@@ -3459,11 +3351,11 @@
     color: #b19df7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #b19df7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #b19df7;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(118, 82, 241, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #b19df7;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #282936;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,32 +3605,30 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #b19df7;
     border-radius: 50%;
     width: 1rem;
     height: 1rem;
-    background-color: #1c1d26;
+    background-color: hsl(234deg, 15%, 13%);
   }
   .p-timeline .p-timeline-event-connector {
     background-color: #3e4053;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #3e4053;
@@ -3788,7 +3677,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -3814,7 +3702,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #3e4053;
     background: #282936;
@@ -3855,7 +3742,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #282936;
   }
@@ -3879,7 +3765,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #3e4053;
     padding: 1.25rem;
@@ -3929,7 +3814,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #3e4053;
     background: #282936;
@@ -3946,12 +3830,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #3e4053;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #3e4053;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3e4053;
@@ -4011,7 +3893,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #282936;
     border: 1px solid #3e4053;
@@ -4022,7 +3903,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -4070,7 +3950,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4146,7 +4025,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -4159,7 +4037,7 @@
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     width: 2rem;
     height: 2rem;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4170,7 +4048,7 @@
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #a28af5;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
   }
   .p-overlaypanel:after {
     border: solid transparent;
@@ -4188,7 +4066,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #3e4053;
   }
-
   .p-sidebar {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -4199,7 +4076,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4209,13 +4086,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
@@ -4226,7 +4103,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #3e4053;
     color: rgba(255, 255, 255, 0.87);
@@ -4246,7 +4122,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #3e4053;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #282936;
     padding: 1.25rem;
@@ -4277,7 +4152,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #333544;
     border: 1px solid #3e4053;
@@ -4309,7 +4183,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #333544;
@@ -4381,7 +4254,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4396,32 +4268,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4438,22 +4309,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4504,19 +4375,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(177, 157, 247, 0.16);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #b19df7;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #b19df7;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #b19df7;
   }
   .p-megamenu .p-menuitem-link {
@@ -4686,7 +4557,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #333544;
@@ -4747,7 +4617,6 @@
     border-top: 1px solid #3e4053;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #333544;
@@ -4825,19 +4694,19 @@
     box-shadow: inset 0 0 0 0.15rem #e0d8fc;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(177, 157, 247, 0.16);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #b19df7;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #b19df7;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #b19df7;
   }
   .p-menubar .p-submenu-list {
@@ -4867,7 +4736,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #b19df7;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5088,7 +4956,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #333544;
@@ -5166,7 +5033,6 @@
     padding: 0.75rem 1.25rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5211,7 +5077,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3e4053;
@@ -5252,7 +5117,6 @@
     border-color: #b19df7;
     color: #b19df7;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #333544;
@@ -5327,7 +5191,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5383,7 +5246,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5472,7 +5334,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5483,7 +5344,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5523,7 +5383,7 @@
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5533,7 +5393,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5543,7 +5403,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5553,10 +5413,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5587,11 +5446,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5645,7 +5504,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5655,7 +5514,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5667,15 +5526,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5685,15 +5541,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5717,7 +5570,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #3e4053;
     border-radius: 6px;
@@ -5738,15 +5590,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #282936;
   }
-
   .p-chip {
     background-color: #3e4053;
     color: rgba(255, 255, 255, 0.87);
@@ -5780,7 +5629,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5802,7 +5650,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5810,10 +5657,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     font-size: 0.75rem;
     font-weight: 700;
     padding: 0.25rem 0.4rem;
@@ -5843,7 +5689,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5858,7 +5703,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #e0d8fc;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5871,10 +5715,9 @@
     background: #b19df7;
   }
   .p-progressbar .p-progressbar-label {
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
@@ -5886,10 +5729,9 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     font-size: 0.75rem;
     font-weight: 700;
     min-width: 1.5rem;
@@ -5928,10 +5770,9 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #b19df7;
-    color: #1c1d26;
+    color: hsl(234deg, 15%, 13%);
     font-size: 0.75rem;
     font-weight: 700;
     padding: 0.25rem 0.4rem;
@@ -5958,23 +5799,20 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #b19df7;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #b19df7;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #b19df7;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #b19df7;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #b19df7;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
 }

--- a/public/themes/soho-light/theme.css
+++ b/public/themes/soho-light/theme.css
@@ -53,24 +53,21 @@
   font-family: "Lato";
   font-style: normal;
   font-weight: 300;
-  src: local("Lato Light"), local("Lato-Light"), url("./fonts/lato-v17-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-300.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Light"), local("Lato-Light"), url("./fonts/lato-v17-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-300.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* lato-regular - latin-ext_latin */
 @font-face {
   font-family: "Lato";
   font-style: normal;
   font-weight: 400;
-  src: local("Lato Regular"), local("Lato-Regular"), url("./fonts/lato-v17-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Regular"), local("Lato-Regular"), url("./fonts/lato-v17-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* lato-700 - latin-ext_latin */
 @font-face {
   font-family: "Lato";
   font-style: normal;
   font-weight: 700;
-  src: local("Lato Bold"), local("Lato-Bold"), url("./fonts/lato-v17-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local("Lato Bold"), local("Lato-Bold"), url("./fonts/lato-v17-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/lato-v17-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f6fbfe;
@@ -298,40 +295,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #ff6767;
   }
-
   .p-text-secondary {
     color: #708da9;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -343,15 +332,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -368,7 +354,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -412,7 +397,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ff6767;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #043d75;
@@ -447,11 +431,9 @@
     background: #eff3f8;
     font-weight: 700;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ff6767;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: linear-gradient(90deg, #7254f3 0%, #9554f3 100%);
@@ -478,7 +460,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -488,13 +470,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #043d75;
     border-color: transparent;
     background: #f6f9fc;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
@@ -503,14 +485,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #ffffff;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 700;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #7254f3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -659,7 +641,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -702,7 +683,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ff6767;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #043d75;
@@ -744,7 +724,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f6f9fc;
   }
@@ -754,7 +733,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 22px;
     height: 22px;
@@ -803,7 +781,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ff6767;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f6f9fc;
   }
@@ -816,7 +793,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #5935f1;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -854,25 +830,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ff6767;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #323232;
     border: 1px solid #191919;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d3dbe3;
@@ -916,7 +888,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ff6767;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #043d75;
@@ -980,7 +951,6 @@
     color: #043d75;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f6f9fc;
   }
@@ -993,7 +963,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f6f9fc;
     color: #708da9;
@@ -1006,68 +975,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d3dbe3;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ff6767;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1109,7 +1070,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ff6767;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1142,59 +1102,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #708da9;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ff6767;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #708da9;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #708da9;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #708da9;
   }
-
   :-moz-placeholder {
     color: #708da9;
   }
-
   ::-moz-placeholder {
     color: #708da9;
   }
-
   :-ms-input-placeholder {
     color: #708da9;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f6f9fc;
   }
@@ -1204,17 +1152,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #043d75;
@@ -1276,7 +1221,6 @@
   .p-listbox.p-invalid {
     border-color: #ff6767;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #043d75;
@@ -1304,7 +1248,6 @@
     color: #7254f3;
     background: #e2dcfc;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d3dbe3;
@@ -1354,7 +1297,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ff6767;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1364,7 +1306,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #043d75;
@@ -1450,7 +1391,6 @@
     color: #043d75;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f6f9fc;
   }
@@ -1460,11 +1400,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ff6767;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
@@ -1486,7 +1424,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #29c76f;
   }
-
   .p-radiobutton {
     width: 22px;
     height: 22px;
@@ -1530,7 +1467,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f6f9fc;
   }
@@ -1543,7 +1479,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #5935f1;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1573,7 +1508,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #e73d3e;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d3dbe3;
@@ -1581,7 +1515,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #708da9;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1590,7 +1524,7 @@
     color: #043d75;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #708da9;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1599,7 +1533,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1608,13 +1542,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ff6767;
   }
-
   .p-slider {
     background: #dfe7ef;
     border: 0 none;
@@ -1654,7 +1587,6 @@
     background: #7254f3;
     border-color: #7254f3;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d3dbe3;
@@ -1701,11 +1633,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ff6767;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #043d75;
@@ -1765,7 +1695,6 @@
     color: #043d75;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f6f9fc;
   }
@@ -1775,7 +1704,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d3dbe3;
@@ -1783,7 +1711,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #708da9;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1792,7 +1720,7 @@
     color: #043d75;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #708da9;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1801,7 +1729,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1810,13 +1738,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ff6767;
   }
-
   .p-button {
     color: #ffffff;
     background: #7254f3;
@@ -1928,7 +1855,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1964,7 +1891,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1977,7 +1903,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #a1c30d;
@@ -2026,7 +1951,6 @@
     border-color: transparent;
     color: #a1c30d;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #5486f3;
@@ -2075,7 +1999,6 @@
     border-color: transparent;
     color: #5486f3;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #29c76f;
@@ -2124,7 +2047,6 @@
     border-color: transparent;
     color: #29c76f;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #ff9f42;
@@ -2173,7 +2095,6 @@
     border-color: transparent;
     color: #ff9f42;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #3ec9d6;
@@ -2222,7 +2143,6 @@
     border-color: transparent;
     color: #3ec9d6;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #ea5455;
@@ -2271,7 +2191,6 @@
     border-color: transparent;
     color: #ea5455;
   }
-
   .p-button.p-button-link {
     color: #5935f1;
     background: transparent;
@@ -2295,7 +2214,6 @@
     color: #5935f1;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2377,12 +2295,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #a1c30d;
@@ -2411,7 +2328,6 @@
     border-color: transparent;
     color: #a1c30d;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #5486f3;
@@ -2440,7 +2356,6 @@
     border-color: transparent;
     color: #5486f3;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #29c76f;
@@ -2469,7 +2384,6 @@
     border-color: transparent;
     color: #29c76f;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ff9f42;
@@ -2498,7 +2412,6 @@
     border-color: transparent;
     color: #ff9f42;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #3ec9d6;
@@ -2527,7 +2440,6 @@
     border-color: transparent;
     color: #3ec9d6;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ea5455;
@@ -2556,7 +2468,6 @@
     border-color: transparent;
     color: #ea5455;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2568,7 +2479,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2579,55 +2492,48 @@
     background: #022354;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -2638,13 +2544,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #043d75;
     border-color: transparent;
     background: #f6f9fc;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
@@ -2670,7 +2576,6 @@
     background: #e2dcfc;
     color: #7254f3;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2764,9 +2669,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -2776,17 +2681,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #043d75;
     border-color: transparent;
     background: #f6f9fc;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
@@ -2839,12 +2744,12 @@
     background: #7254f3;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #eff3f8;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #eff3f8;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2954,11 +2859,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(114, 84, 243, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3002,7 +2905,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3039,12 +2941,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3072,7 +2972,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3092,7 +2991,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #043d75;
@@ -3130,7 +3028,6 @@
     border-top: 1px solid #dfe7ef;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.75rem 1.25rem;
     border-bottom: 1px solid #dfe7ef;
@@ -3159,7 +3056,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3224,7 +3120,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f6f9fc;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f6f9fc;
     color: #043d75;
@@ -3263,7 +3158,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #708da9;
@@ -3273,9 +3167,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #708da9;
@@ -3286,9 +3180,9 @@
     border-radius: 50%;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f6f9fc;
     border-color: transparent;
     color: #043d75;
@@ -3344,7 +3238,6 @@
     border-color: transparent;
     color: #043d75;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3403,7 +3296,6 @@
     color: #7254f3;
     background: #e2dcfc;
   }
-
   .p-tree {
     border: 1px solid #dfe7ef;
     background: #ffffff;
@@ -3459,11 +3351,11 @@
     color: #7254f3;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #7254f3;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #7254f3;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3501,7 +3393,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #9a85f5;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3637,7 +3528,7 @@
     background: #7254f3;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #eff3f8;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3714,7 +3605,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #7254f3;
     border-radius: 50%;
@@ -3726,20 +3616,19 @@
     background-color: #dfe7ef;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #dfe7ef;
@@ -3788,7 +3677,6 @@
   .p-accordion .p-accordion-tab {
     margin-bottom: 4px;
   }
-
   .p-card {
     background: #ffffff;
     color: #043d75;
@@ -3814,7 +3702,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #dfe7ef;
     background: #ffffff;
@@ -3855,7 +3742,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3879,7 +3765,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #dfe7ef;
     padding: 1.25rem;
@@ -3929,7 +3814,6 @@
     color: #043d75;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #dfe7ef;
     background: #ffffff;
@@ -3946,12 +3830,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #dfe7ef;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #eff3f8;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dfe7ef;
@@ -4011,7 +3893,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #eff3f8;
     border: 1px solid #dfe7ef;
@@ -4022,7 +3903,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #043d75;
@@ -4070,7 +3950,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
@@ -4146,7 +4025,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #043d75;
@@ -4188,7 +4066,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #043d75;
@@ -4199,7 +4076,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -4209,13 +4086,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #043d75;
     border-color: transparent;
     background: #f6f9fc;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
@@ -4226,7 +4103,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #043d75;
     color: #ffffff;
@@ -4246,7 +4122,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #043d75;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #eff3f8;
     padding: 1.25rem;
@@ -4277,7 +4152,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #eff3f8;
     border: 1px solid #dfe7ef;
@@ -4309,7 +4183,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #708da9;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #eff3f8;
@@ -4381,7 +4254,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4396,32 +4268,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4438,22 +4309,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4504,19 +4375,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e2dcfc;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #7254f3;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #7254f3;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #7254f3;
   }
   .p-megamenu .p-menuitem-link {
@@ -4686,7 +4557,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #eff3f8;
@@ -4747,7 +4617,6 @@
     border-top: 1px solid #dfe7ef;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #eff3f8;
@@ -4825,19 +4694,19 @@
     box-shadow: inset 0 0 0 0.15rem #c7bbfa;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #e2dcfc;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #7254f3;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #7254f3;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #7254f3;
   }
   .p-menubar .p-submenu-list {
@@ -4867,7 +4736,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #7254f3;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5088,7 +4956,6 @@
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #eff3f8;
@@ -5166,7 +5033,6 @@
     padding: 0.75rem 1.25rem;
     color: #043d75;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5211,7 +5077,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dfe7ef;
@@ -5252,7 +5117,6 @@
     border-color: #7254f3;
     color: #7254f3;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #eff3f8;
@@ -5327,7 +5191,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5383,7 +5246,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5472,7 +5334,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5483,7 +5344,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5523,7 +5383,7 @@
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5533,7 +5393,7 @@
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5543,7 +5403,7 @@
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5553,10 +5413,9 @@
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #ff5757;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5587,11 +5446,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5645,7 +5504,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #eff3f8;
@@ -5655,7 +5514,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #eff3f8;
   }
@@ -5667,15 +5526,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5685,15 +5541,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5717,7 +5570,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #dfe7ef;
     border-radius: 6px;
@@ -5738,15 +5590,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #dfe7ef;
     color: #043d75;
@@ -5780,7 +5629,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5802,7 +5650,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #dfe7ef;
     border-radius: 6px;
@@ -5810,7 +5657,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #7254f3;
     color: #ffffff;
@@ -5843,7 +5689,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 6px;
@@ -5858,7 +5703,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #c7bbfa;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5874,7 +5718,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #043d75;
@@ -5886,7 +5729,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #7254f3;
     color: #ffffff;
@@ -5928,7 +5770,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #7254f3;
     color: #ffffff;
@@ -5957,11 +5798,11 @@
 /* Customizations to the designer theme should be defined here */
 @layer primereact {
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     color: #ffffff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #ffffff;
     background-color: rgba(255, 255, 255, 0.2);
   }
@@ -6007,28 +5848,23 @@
     color: #ffffff;
     background: rgba(255, 255, 255, 0.3);
   }
-
   .p-button .p-button-label {
     font-weight: 700;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #7254f3;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #7254f3;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #7254f3;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-bottom > td {
     box-shadow: inset 0 -2px 0 0 #7254f3;
   }
-
   .p-selectbutton > .p-button,
-.p-togglebutton.p-button {
+  .p-togglebutton.p-button {
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
 }

--- a/public/themes/tailwind-light/theme.css
+++ b/public/themes/tailwind-light/theme.css
@@ -52,36 +52,31 @@
   font-family: "Inter";
   font-style: normal;
   font-weight: 300;
-  src: local(""), url("./fonts/Inter-Light.woff2") format("woff2"), url("./fonts/Inter-Light.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/Inter-Light.woff2") format("woff2"), url("./fonts/Inter-Light.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 400;
-  src: local(""), url("./fonts/Inter-Regular.woff2") format("woff2"), url("./fonts/Inter-Regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/Inter-Regular.woff2") format("woff2"), url("./fonts/Inter-Regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 500;
-  src: local(""), url("./fonts/Inter-Medium.woff2") format("woff2"), url("./fonts/Inter-Medium.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/Inter-Medium.woff2") format("woff2"), url("./fonts/Inter-Medium.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 600;
-  src: local(""), url("./fonts/Inter-SemiBold.woff2") format("woff2"), url("./fonts/Inter-SemiBold.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/Inter-SemiBold.woff2") format("woff2"), url("./fonts/Inter-SemiBold.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 @font-face {
   font-family: "Inter";
   font-style: normal;
   font-weight: 700;
-  src: local(""), url("./fonts/Inter-Bold.woff2") format("woff2"), url("./fonts/Inter-Bold.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/Inter-Bold.woff2") format("woff2"), url("./fonts/Inter-Bold.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f5f9ff;
@@ -245,7 +240,7 @@
 .p-editor-container .p-editor-toolbar.ql-snow .ql-picker.ql-expanded .ql-picker-options {
   background: #ffffff;
   border: 0 none;
-  box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   border-radius: 0.375rem;
   padding: 0.25rem 0;
 }
@@ -309,40 +304,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #e24c4c;
   }
-
   .p-text-secondary {
     color: #71717A;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -354,15 +341,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -379,7 +363,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -423,13 +406,12 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f0a9a7;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-autocomplete-panel .p-autocomplete-items {
     padding: 0.25rem 0;
@@ -458,11 +440,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f0a9a7;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -473,7 +453,7 @@
   .p-datepicker:not(.p-datepicker-inline) {
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-datepicker:not(.p-datepicker-inline) .p-datepicker-header {
     background: #ffffff;
@@ -489,7 +469,7 @@
     border-top-left-radius: 0.375rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #71717A;
@@ -499,13 +479,13 @@
     transition: none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #18181B;
     border-color: transparent;
     background: #f4f4f5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
@@ -514,14 +494,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #3f3f46;
     transition: none;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #4F46E5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -670,7 +650,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -713,13 +692,12 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f0a9a7;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-cascadeselect-panel .p-cascadeselect-items {
     padding: 0.25rem 0;
@@ -755,7 +733,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #fafafa;
   }
@@ -765,7 +742,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-checkbox {
     width: 16px;
     height: 16px;
@@ -814,7 +790,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f0a9a7;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #fafafa;
   }
@@ -827,7 +802,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #4F46E5;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.375rem 0.75rem;
     gap: 0.5rem;
@@ -865,25 +839,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f0a9a7;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #27272A;
     border: 1px solid #18181B;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 1px solid #d4d4d8;
@@ -927,13 +897,12 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f0a9a7;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-dropdown-panel .p-dropdown-header {
     padding: 0.5rem 0.75rem;
@@ -991,7 +960,6 @@
     color: #3f3f46;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #fafafa;
   }
@@ -1004,7 +972,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #fafafa;
     color: #71717A;
@@ -1017,68 +984,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #d4d4d8;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 3rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f0a9a7;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1120,7 +1079,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f0a9a7;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1153,59 +1111,47 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #71717A;
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #e24c4c;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #71717A;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #71717A;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #71717A;
   }
-
   :-moz-placeholder {
     color: #71717A;
   }
-
   ::-moz-placeholder {
     color: #71717A;
   }
-
   :-ms-input-placeholder {
     color: #71717A;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #fafafa;
   }
@@ -1215,17 +1161,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #ffffff;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.65625rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #3f3f46;
@@ -1287,13 +1230,12 @@
   .p-listbox.p-invalid {
     border-color: #f0a9a7;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-mention-panel .p-mention-items {
     padding: 0.25rem 0;
@@ -1315,7 +1257,6 @@
     color: #312E81;
     background: #EEF2FF;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 1px solid #d4d4d8;
@@ -1365,7 +1306,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f0a9a7;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.375rem 0.75rem;
   }
@@ -1375,13 +1315,12 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-multiselect-panel .p-multiselect-header {
     padding: 0.5rem 0.75rem;
@@ -1461,7 +1400,6 @@
     color: #3f3f46;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #fafafa;
   }
@@ -1471,17 +1409,15 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f0a9a7;
   }
-
   .p-password-panel {
     padding: 1.25rem;
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     border-radius: 0.375rem;
   }
   .p-password-panel .p-password-meter {
@@ -1497,7 +1433,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #22C55E;
   }
-
   .p-radiobutton {
     width: 16px;
     height: 16px;
@@ -1541,7 +1476,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #fafafa;
   }
@@ -1554,7 +1488,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #4F46E5;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1584,7 +1517,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #DC2626;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 1px solid #d4d4d8;
@@ -1592,7 +1524,7 @@
     transition: none;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #71717A;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1601,7 +1533,7 @@
     color: #3f3f46;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #71717A;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1610,7 +1542,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1619,13 +1551,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f0a9a7;
   }
-
   .p-slider {
     background: #e5e7eb;
     border: 0 none;
@@ -1665,7 +1596,6 @@
     background: #4F46E5;
     border-color: #4F46E5;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 1px solid #d4d4d8;
@@ -1680,6 +1610,9 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
     border-color: #4F46E5;
+  }
+  .p-treeselect.p-treeselect-clearable .p-treeselect-label {
+    padding-right: 1.75rem;
   }
   .p-treeselect .p-treeselect-label {
     padding: 0.75rem 0.75rem;
@@ -1702,20 +1635,22 @@
     border-top-right-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
   }
+  .p-treeselect .p-treeselect-clear-icon {
+    color: #71717A;
+    right: 3rem;
+  }
   .p-treeselect.p-invalid.p-component {
     border-color: #f0a9a7;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.375rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-treeselect-panel .p-treeselect-header {
     padding: 0.5rem 0.75rem;
@@ -1769,7 +1704,6 @@
     color: #3f3f46;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #fafafa;
   }
@@ -1779,7 +1713,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #ffffff;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 1px solid #d4d4d8;
@@ -1787,7 +1720,7 @@
     transition: none;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #71717A;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1796,7 +1729,7 @@
     color: #3f3f46;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #71717A;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1805,7 +1738,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1814,13 +1747,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f0a9a7;
   }
-
   .p-button {
     color: #ffffff;
     background: #4F46E5;
@@ -1830,12 +1762,12 @@
     transition: none;
     border-radius: 0.375rem;
   }
-  .p-button:enabled:hover, .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-button:not(:disabled):hover {
     background: #4338CA;
     color: #ffffff;
     border-color: #4338CA;
   }
-  .p-button:enabled:active, .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-button:not(:disabled):active {
     background: #4338CA;
     color: #ffffff;
     border-color: #4338CA;
@@ -1845,12 +1777,12 @@
     color: #4F46E5;
     border: 1px solid;
   }
-  .p-button.p-button-outlined:enabled:hover, .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-outlined:not(:disabled):hover {
     background: rgba(79, 70, 229, 0.04);
     color: #4F46E5;
     border: 1px solid;
   }
-  .p-button.p-button-outlined:enabled:active, .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-outlined:not(:disabled):active {
     background: rgba(79, 70, 229, 0.16);
     color: #4F46E5;
     border: 1px solid;
@@ -1859,11 +1791,11 @@
     color: #71717A;
     border-color: #71717A;
   }
-  .p-button.p-button-outlined.p-button-plain:enabled:hover, .p-button.p-button-outlined.p-button-plain:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-outlined.p-button-plain:not(:disabled):hover {
     background: #f4f4f5;
     color: #71717A;
   }
-  .p-button.p-button-outlined.p-button-plain:enabled:active, .p-button.p-button-outlined.p-button-plain:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-outlined.p-button-plain:not(:disabled):active {
     background: #e5e7eb;
     color: #71717A;
   }
@@ -1872,12 +1804,12 @@
     color: #4F46E5;
     border-color: transparent;
   }
-  .p-button.p-button-text:enabled:hover, .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-text:not(:disabled):hover {
     background: rgba(79, 70, 229, 0.04);
     color: #4F46E5;
     border-color: transparent;
   }
-  .p-button.p-button-text:enabled:active, .p-button.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-text:not(:disabled):active {
     background: rgba(79, 70, 229, 0.16);
     color: #4F46E5;
     border-color: transparent;
@@ -1885,11 +1817,11 @@
   .p-button.p-button-text.p-button-plain {
     color: #71717A;
   }
-  .p-button.p-button-text.p-button-plain:enabled:hover, .p-button.p-button-text.p-button-plain:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-text.p-button-plain:not(:disabled):hover {
     background: #f4f4f5;
     color: #71717A;
   }
-  .p-button.p-button-text.p-button-plain:enabled:active, .p-button.p-button-text.p-button-plain:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-text.p-button-plain:not(:disabled):active {
     background: #e5e7eb;
     color: #71717A;
   }
@@ -1932,7 +1864,7 @@
     padding: 0.75rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1968,7 +1900,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1981,21 +1912,20 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #64748B;
     border: 1px solid #64748B;
   }
-  .p-button.p-button-secondary:enabled:hover, .p-button.p-button-secondary:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-secondary > .p-button:enabled:hover, .p-buttonset.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-secondary > .p-button:enabled:hover, .p-splitbutton.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-secondary:enabled:hover, .p-fileupload-choose.p-button-secondary:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-secondary:not(:disabled):hover, .p-buttonset.p-button-secondary > .p-button:not(:disabled):hover, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-secondary:not(:disabled):hover {
     background: #475569;
     color: #ffffff;
     border-color: #475569;
   }
-  .p-button.p-button-secondary:enabled:focus, .p-button.p-button-secondary:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-secondary > .p-button:enabled:focus, .p-buttonset.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-secondary > .p-button:enabled:focus, .p-splitbutton.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-secondary:enabled:focus, .p-fileupload-choose.p-button-secondary:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-secondary:not(:disabled):focus, .p-buttonset.p-button-secondary > .p-button:not(:disabled):focus, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-secondary:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #c0c7d2;
   }
-  .p-button.p-button-secondary:enabled:active, .p-button.p-button-secondary:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-secondary > .p-button:enabled:active, .p-buttonset.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-secondary > .p-button:enabled:active, .p-splitbutton.p-button-secondary > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-secondary:enabled:active, .p-fileupload-choose.p-button-secondary:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-secondary:not(:disabled):active, .p-buttonset.p-button-secondary > .p-button:not(:disabled):active, .p-splitbutton.p-button-secondary > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-secondary:not(:disabled):active {
     background: #475569;
     color: #ffffff;
     border-color: #475569;
@@ -2005,12 +1935,12 @@
     color: #64748B;
     border: 1px solid;
   }
-  .p-button.p-button-secondary.p-button-outlined:enabled:hover, .p-button.p-button-secondary.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-secondary.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-secondary.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-secondary.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-secondary.p-button-outlined:not(:disabled):hover {
     background: rgba(100, 116, 139, 0.04);
     color: #64748B;
     border: 1px solid;
   }
-  .p-button.p-button-secondary.p-button-outlined:enabled:active, .p-button.p-button-secondary.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-secondary.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-secondary.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-secondary.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-secondary > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-secondary > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-secondary.p-button-outlined:not(:disabled):active {
     background: rgba(100, 116, 139, 0.16);
     color: #64748B;
     border: 1px solid;
@@ -2020,31 +1950,30 @@
     color: #64748B;
     border-color: transparent;
   }
-  .p-button.p-button-secondary.p-button-text:enabled:hover, .p-button.p-button-secondary.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-secondary > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-secondary > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-secondary > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-secondary > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-secondary.p-button-text:enabled:hover, .p-fileupload-choose.p-button-secondary.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-secondary.p-button-text:not(:disabled):hover, .p-buttonset.p-button-secondary > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-secondary > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-secondary.p-button-text:not(:disabled):hover {
     background: rgba(100, 116, 139, 0.04);
     border-color: transparent;
     color: #64748B;
   }
-  .p-button.p-button-secondary.p-button-text:enabled:active, .p-button.p-button-secondary.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-secondary > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-secondary > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-secondary > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-secondary > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-secondary.p-button-text:enabled:active, .p-fileupload-choose.p-button-secondary.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-secondary.p-button-text:not(:disabled):active, .p-buttonset.p-button-secondary > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-secondary > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-secondary.p-button-text:not(:disabled):active {
     background: rgba(100, 116, 139, 0.16);
     border-color: transparent;
     color: #64748B;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #3B82F6;
     border: 1px solid #3B82F6;
   }
-  .p-button.p-button-info:enabled:hover, .p-button.p-button-info:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-info > .p-button:enabled:hover, .p-buttonset.p-button-info > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-info > .p-button:enabled:hover, .p-splitbutton.p-button-info > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-info:enabled:hover, .p-fileupload-choose.p-button-info:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-info:not(:disabled):hover, .p-buttonset.p-button-info > .p-button:not(:disabled):hover, .p-splitbutton.p-button-info > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-info:not(:disabled):hover {
     background: #2563EB;
     color: #ffffff;
     border-color: #2563EB;
   }
-  .p-button.p-button-info:enabled:focus, .p-button.p-button-info:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-info > .p-button:enabled:focus, .p-buttonset.p-button-info > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-info > .p-button:enabled:focus, .p-splitbutton.p-button-info > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-info:enabled:focus, .p-fileupload-choose.p-button-info:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-info:not(:disabled):focus, .p-buttonset.p-button-info > .p-button:not(:disabled):focus, .p-splitbutton.p-button-info > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-info:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #b1cdfb;
   }
-  .p-button.p-button-info:enabled:active, .p-button.p-button-info:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-info > .p-button:enabled:active, .p-buttonset.p-button-info > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-info > .p-button:enabled:active, .p-splitbutton.p-button-info > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-info:enabled:active, .p-fileupload-choose.p-button-info:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-info:not(:disabled):active, .p-buttonset.p-button-info > .p-button:not(:disabled):active, .p-splitbutton.p-button-info > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-info:not(:disabled):active {
     background: #2563EB;
     color: #ffffff;
     border-color: #2563EB;
@@ -2054,12 +1983,12 @@
     color: #3B82F6;
     border: 1px solid;
   }
-  .p-button.p-button-info.p-button-outlined:enabled:hover, .p-button.p-button-info.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-info > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-info > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-info > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-info > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-info.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-info.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-info.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-info > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-info > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-info.p-button-outlined:not(:disabled):hover {
     background: rgba(59, 130, 246, 0.04);
     color: #3B82F6;
     border: 1px solid;
   }
-  .p-button.p-button-info.p-button-outlined:enabled:active, .p-button.p-button-info.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-info > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-info > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-info > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-info.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-info.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-info.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-info > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-info.p-button-outlined:not(:disabled):active {
     background: rgba(59, 130, 246, 0.16);
     color: #3B82F6;
     border: 1px solid;
@@ -2069,31 +1998,30 @@
     color: #3B82F6;
     border-color: transparent;
   }
-  .p-button.p-button-info.p-button-text:enabled:hover, .p-button.p-button-info.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-info > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-info > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-info > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-info > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-info.p-button-text:enabled:hover, .p-fileupload-choose.p-button-info.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-info.p-button-text:not(:disabled):hover, .p-buttonset.p-button-info > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-info > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-info.p-button-text:not(:disabled):hover {
     background: rgba(59, 130, 246, 0.04);
     border-color: transparent;
     color: #3B82F6;
   }
-  .p-button.p-button-info.p-button-text:enabled:active, .p-button.p-button-info.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-info > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-info > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-info > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-info.p-button-text:enabled:active, .p-fileupload-choose.p-button-info.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-info.p-button-text:not(:disabled):active, .p-buttonset.p-button-info > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-info > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-info.p-button-text:not(:disabled):active {
     background: rgba(59, 130, 246, 0.16);
     border-color: transparent;
     color: #3B82F6;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #22C55E;
     border: 1px solid #22C55E;
   }
-  .p-button.p-button-success:enabled:hover, .p-button.p-button-success:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-success > .p-button:enabled:hover, .p-buttonset.p-button-success > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-success > .p-button:enabled:hover, .p-splitbutton.p-button-success > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-success:enabled:hover, .p-fileupload-choose.p-button-success:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-success:not(:disabled):hover, .p-buttonset.p-button-success > .p-button:not(:disabled):hover, .p-splitbutton.p-button-success > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-success:not(:disabled):hover {
     background: #16A34A;
     color: #ffffff;
     border-color: #16A34A;
   }
-  .p-button.p-button-success:enabled:focus, .p-button.p-button-success:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-success > .p-button:enabled:focus, .p-buttonset.p-button-success > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-success > .p-button:enabled:focus, .p-splitbutton.p-button-success > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-success:enabled:focus, .p-fileupload-choose.p-button-success:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-success:not(:disabled):focus, .p-buttonset.p-button-success > .p-button:not(:disabled):focus, .p-splitbutton.p-button-success > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-success:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #a0efbd;
   }
-  .p-button.p-button-success:enabled:active, .p-button.p-button-success:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-success > .p-button:enabled:active, .p-buttonset.p-button-success > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-success > .p-button:enabled:active, .p-splitbutton.p-button-success > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-success:enabled:active, .p-fileupload-choose.p-button-success:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-success:not(:disabled):active, .p-buttonset.p-button-success > .p-button:not(:disabled):active, .p-splitbutton.p-button-success > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-success:not(:disabled):active {
     background: #16A34A;
     color: #ffffff;
     border-color: #16A34A;
@@ -2103,12 +2031,12 @@
     color: #22C55E;
     border: 1px solid;
   }
-  .p-button.p-button-success.p-button-outlined:enabled:hover, .p-button.p-button-success.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-success > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-success > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-success > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-success > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-success.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-success.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-success.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-success > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-success > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-success.p-button-outlined:not(:disabled):hover {
     background: rgba(34, 197, 94, 0.04);
     color: #22C55E;
     border: 1px solid;
   }
-  .p-button.p-button-success.p-button-outlined:enabled:active, .p-button.p-button-success.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-success > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-success > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-success > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-success > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-success.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-success.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-success.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-success > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-success > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-success.p-button-outlined:not(:disabled):active {
     background: rgba(34, 197, 94, 0.16);
     color: #22C55E;
     border: 1px solid;
@@ -2118,31 +2046,30 @@
     color: #22C55E;
     border-color: transparent;
   }
-  .p-button.p-button-success.p-button-text:enabled:hover, .p-button.p-button-success.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-success > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-success > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-success > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-success > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-success.p-button-text:enabled:hover, .p-fileupload-choose.p-button-success.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-success.p-button-text:not(:disabled):hover, .p-buttonset.p-button-success > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-success > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-success.p-button-text:not(:disabled):hover {
     background: rgba(34, 197, 94, 0.04);
     border-color: transparent;
     color: #22C55E;
   }
-  .p-button.p-button-success.p-button-text:enabled:active, .p-button.p-button-success.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-success > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-success > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-success > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-success > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-success.p-button-text:enabled:active, .p-fileupload-choose.p-button-success.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-success.p-button-text:not(:disabled):active, .p-buttonset.p-button-success > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-success > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-success.p-button-text:not(:disabled):active {
     background: rgba(34, 197, 94, 0.16);
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #F59E0B;
     border: 1px solid #F59E0B;
   }
-  .p-button.p-button-warning:enabled:hover, .p-button.p-button-warning:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-warning > .p-button:enabled:hover, .p-buttonset.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-warning > .p-button:enabled:hover, .p-splitbutton.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-warning:enabled:hover, .p-fileupload-choose.p-button-warning:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-warning:not(:disabled):hover, .p-buttonset.p-button-warning > .p-button:not(:disabled):hover, .p-splitbutton.p-button-warning > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-warning:not(:disabled):hover {
     background: #D97706;
     color: #ffffff;
     border-color: #D97706;
   }
-  .p-button.p-button-warning:enabled:focus, .p-button.p-button-warning:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-warning > .p-button:enabled:focus, .p-buttonset.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-warning > .p-button:enabled:focus, .p-splitbutton.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-warning:enabled:focus, .p-fileupload-choose.p-button-warning:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-warning:not(:disabled):focus, .p-buttonset.p-button-warning > .p-button:not(:disabled):focus, .p-splitbutton.p-button-warning > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-warning:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #fbd89d;
   }
-  .p-button.p-button-warning:enabled:active, .p-button.p-button-warning:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-warning > .p-button:enabled:active, .p-buttonset.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-warning > .p-button:enabled:active, .p-splitbutton.p-button-warning > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-warning:enabled:active, .p-fileupload-choose.p-button-warning:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-warning:not(:disabled):active, .p-buttonset.p-button-warning > .p-button:not(:disabled):active, .p-splitbutton.p-button-warning > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-warning:not(:disabled):active {
     background: #D97706;
     color: #ffffff;
     border-color: #D97706;
@@ -2152,12 +2079,12 @@
     color: #F59E0B;
     border: 1px solid;
   }
-  .p-button.p-button-warning.p-button-outlined:enabled:hover, .p-button.p-button-warning.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-warning > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-warning > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-warning.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-warning.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-warning.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-warning > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-warning.p-button-outlined:not(:disabled):hover {
     background: rgba(245, 158, 11, 0.04);
     color: #F59E0B;
     border: 1px solid;
   }
-  .p-button.p-button-warning.p-button-outlined:enabled:active, .p-button.p-button-warning.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-warning > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-warning > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-warning.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-warning.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-warning.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-warning > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-warning > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-warning.p-button-outlined:not(:disabled):active {
     background: rgba(245, 158, 11, 0.16);
     color: #F59E0B;
     border: 1px solid;
@@ -2167,31 +2094,30 @@
     color: #F59E0B;
     border-color: transparent;
   }
-  .p-button.p-button-warning.p-button-text:enabled:hover, .p-button.p-button-warning.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-warning > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-warning > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-warning > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-warning > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-warning.p-button-text:enabled:hover, .p-fileupload-choose.p-button-warning.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-warning.p-button-text:not(:disabled):hover, .p-buttonset.p-button-warning > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-warning > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-warning.p-button-text:not(:disabled):hover {
     background: rgba(245, 158, 11, 0.04);
     border-color: transparent;
     color: #F59E0B;
   }
-  .p-button.p-button-warning.p-button-text:enabled:active, .p-button.p-button-warning.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-warning > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-warning > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-warning > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-warning > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-warning.p-button-text:enabled:active, .p-fileupload-choose.p-button-warning.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-warning.p-button-text:not(:disabled):active, .p-buttonset.p-button-warning > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-warning > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-warning.p-button-text:not(:disabled):active {
     background: rgba(245, 158, 11, 0.16);
     border-color: transparent;
     color: #F59E0B;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #A855F7;
     border: 1px solid #A855F7;
   }
-  .p-button.p-button-help:enabled:hover, .p-button.p-button-help:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-help > .p-button:enabled:hover, .p-buttonset.p-button-help > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-help > .p-button:enabled:hover, .p-splitbutton.p-button-help > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-help:enabled:hover, .p-fileupload-choose.p-button-help:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-help:not(:disabled):hover, .p-buttonset.p-button-help > .p-button:not(:disabled):hover, .p-splitbutton.p-button-help > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-help:not(:disabled):hover {
     background: #9333EA;
     color: #ffffff;
     border-color: #9333EA;
   }
-  .p-button.p-button-help:enabled:focus, .p-button.p-button-help:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-help > .p-button:enabled:focus, .p-buttonset.p-button-help > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-help > .p-button:enabled:focus, .p-splitbutton.p-button-help > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-help:enabled:focus, .p-fileupload-choose.p-button-help:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-help:not(:disabled):focus, .p-buttonset.p-button-help > .p-button:not(:disabled):focus, .p-splitbutton.p-button-help > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-help:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #dcbbfc;
   }
-  .p-button.p-button-help:enabled:active, .p-button.p-button-help:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-help > .p-button:enabled:active, .p-buttonset.p-button-help > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-help > .p-button:enabled:active, .p-splitbutton.p-button-help > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-help:enabled:active, .p-fileupload-choose.p-button-help:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-help:not(:disabled):active, .p-buttonset.p-button-help > .p-button:not(:disabled):active, .p-splitbutton.p-button-help > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-help:not(:disabled):active {
     background: #9333EA;
     color: #ffffff;
     border-color: #9333EA;
@@ -2201,12 +2127,12 @@
     color: #A855F7;
     border: 1px solid;
   }
-  .p-button.p-button-help.p-button-outlined:enabled:hover, .p-button.p-button-help.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-help > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-help > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-help > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-help > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-help.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-help.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-help.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-help > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-help > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-help.p-button-outlined:not(:disabled):hover {
     background: rgba(168, 85, 247, 0.04);
     color: #A855F7;
     border: 1px solid;
   }
-  .p-button.p-button-help.p-button-outlined:enabled:active, .p-button.p-button-help.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-help > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-help > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-help > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-help > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-help.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-help.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-help.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-help > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-help > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-help.p-button-outlined:not(:disabled):active {
     background: rgba(168, 85, 247, 0.16);
     color: #A855F7;
     border: 1px solid;
@@ -2216,31 +2142,30 @@
     color: #A855F7;
     border-color: transparent;
   }
-  .p-button.p-button-help.p-button-text:enabled:hover, .p-button.p-button-help.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-help > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-help > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-help > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-help > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-help.p-button-text:enabled:hover, .p-fileupload-choose.p-button-help.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-help.p-button-text:not(:disabled):hover, .p-buttonset.p-button-help > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-help > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-help.p-button-text:not(:disabled):hover {
     background: rgba(168, 85, 247, 0.04);
     border-color: transparent;
     color: #A855F7;
   }
-  .p-button.p-button-help.p-button-text:enabled:active, .p-button.p-button-help.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-help > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-help > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-help > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-help > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-help.p-button-text:enabled:active, .p-fileupload-choose.p-button-help.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-help.p-button-text:not(:disabled):active, .p-buttonset.p-button-help > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-help > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-help.p-button-text:not(:disabled):active {
     background: rgba(168, 85, 247, 0.16);
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #EF4444;
     border: 1px solid #EF4444;
   }
-  .p-button.p-button-danger:enabled:hover, .p-button.p-button-danger:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-danger > .p-button:enabled:hover, .p-buttonset.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-danger > .p-button:enabled:hover, .p-splitbutton.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-danger:enabled:hover, .p-fileupload-choose.p-button-danger:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-danger:not(:disabled):hover, .p-buttonset.p-button-danger > .p-button:not(:disabled):hover, .p-splitbutton.p-button-danger > .p-button:not(:disabled):hover, .p-fileupload-choose.p-button-danger:not(:disabled):hover {
     background: #DC2626;
     color: #ffffff;
     border-color: #DC2626;
   }
-  .p-button.p-button-danger:enabled:focus, .p-button.p-button-danger:not(button):not(a):not(.p-disabled):focus, .p-buttonset.p-button-danger > .p-button:enabled:focus, .p-buttonset.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):focus, .p-splitbutton.p-button-danger > .p-button:enabled:focus, .p-splitbutton.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):focus, .p-fileupload-choose.p-button-danger:enabled:focus, .p-fileupload-choose.p-button-danger:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-danger:not(:disabled):focus, .p-buttonset.p-button-danger > .p-button:not(:disabled):focus, .p-splitbutton.p-button-danger > .p-button:not(:disabled):focus, .p-fileupload-choose.p-button-danger:not(:disabled):focus {
     box-shadow: 0 0 0 0.2rem #f9b4b4;
   }
-  .p-button.p-button-danger:enabled:active, .p-button.p-button-danger:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-danger > .p-button:enabled:active, .p-buttonset.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-danger > .p-button:enabled:active, .p-splitbutton.p-button-danger > .p-button:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-danger:enabled:active, .p-fileupload-choose.p-button-danger:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-danger:not(:disabled):active, .p-buttonset.p-button-danger > .p-button:not(:disabled):active, .p-splitbutton.p-button-danger > .p-button:not(:disabled):active, .p-fileupload-choose.p-button-danger:not(:disabled):active {
     background: #DC2626;
     color: #ffffff;
     border-color: #DC2626;
@@ -2250,12 +2175,12 @@
     color: #EF4444;
     border: 1px solid;
   }
-  .p-button.p-button-danger.p-button-outlined:enabled:hover, .p-button.p-button-danger.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-danger > .p-button.p-button-outlined:enabled:hover, .p-buttonset.p-button-danger > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:enabled:hover, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-danger.p-button-outlined:enabled:hover, .p-fileupload-choose.p-button-danger.p-button-outlined:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-danger.p-button-outlined:not(:disabled):hover, .p-buttonset.p-button-danger > .p-button.p-button-outlined:not(:disabled):hover, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:not(:disabled):hover, .p-fileupload-choose.p-button-danger.p-button-outlined:not(:disabled):hover {
     background: rgba(239, 68, 68, 0.04);
     color: #EF4444;
     border: 1px solid;
   }
-  .p-button.p-button-danger.p-button-outlined:enabled:active, .p-button.p-button-danger.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-danger > .p-button.p-button-outlined:enabled:active, .p-buttonset.p-button-danger > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:enabled:active, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-danger.p-button-outlined:enabled:active, .p-fileupload-choose.p-button-danger.p-button-outlined:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-danger.p-button-outlined:not(:disabled):active, .p-buttonset.p-button-danger > .p-button.p-button-outlined:not(:disabled):active, .p-splitbutton.p-button-danger > .p-button.p-button-outlined:not(:disabled):active, .p-fileupload-choose.p-button-danger.p-button-outlined:not(:disabled):active {
     background: rgba(239, 68, 68, 0.16);
     color: #EF4444;
     border: 1px solid;
@@ -2265,41 +2190,39 @@
     color: #EF4444;
     border-color: transparent;
   }
-  .p-button.p-button-danger.p-button-text:enabled:hover, .p-button.p-button-danger.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-buttonset.p-button-danger > .p-button.p-button-text:enabled:hover, .p-buttonset.p-button-danger > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-splitbutton.p-button-danger > .p-button.p-button-text:enabled:hover, .p-splitbutton.p-button-danger > .p-button.p-button-text:not(button):not(a):not(.p-disabled):hover, .p-fileupload-choose.p-button-danger.p-button-text:enabled:hover, .p-fileupload-choose.p-button-danger.p-button-text:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-danger.p-button-text:not(:disabled):hover, .p-buttonset.p-button-danger > .p-button.p-button-text:not(:disabled):hover, .p-splitbutton.p-button-danger > .p-button.p-button-text:not(:disabled):hover, .p-fileupload-choose.p-button-danger.p-button-text:not(:disabled):hover {
     background: rgba(239, 68, 68, 0.04);
     border-color: transparent;
     color: #EF4444;
   }
-  .p-button.p-button-danger.p-button-text:enabled:active, .p-button.p-button-danger.p-button-text:not(button):not(a):not(.p-disabled):active, .p-buttonset.p-button-danger > .p-button.p-button-text:enabled:active, .p-buttonset.p-button-danger > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-splitbutton.p-button-danger > .p-button.p-button-text:enabled:active, .p-splitbutton.p-button-danger > .p-button.p-button-text:not(button):not(a):not(.p-disabled):active, .p-fileupload-choose.p-button-danger.p-button-text:enabled:active, .p-fileupload-choose.p-button-danger.p-button-text:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-danger.p-button-text:not(:disabled):active, .p-buttonset.p-button-danger > .p-button.p-button-text:not(:disabled):active, .p-splitbutton.p-button-danger > .p-button.p-button-text:not(:disabled):active, .p-fileupload-choose.p-button-danger.p-button-text:not(:disabled):active {
     background: rgba(239, 68, 68, 0.16);
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-button.p-button-link {
     color: #4F46E5;
     background: transparent;
     border: transparent;
   }
-  .p-button.p-button-link:enabled:hover, .p-button.p-button-link:not(button):not(a):not(.p-disabled):hover {
+  .p-button.p-button-link:not(:disabled):hover {
     background: transparent;
     color: #4F46E5;
     border-color: transparent;
   }
-  .p-button.p-button-link:enabled:hover .p-button-label, .p-button.p-button-link:not(button):not(a):not(.p-disabled):hover .p-button-label {
+  .p-button.p-button-link:not(:disabled):hover .p-button-label {
     text-decoration: underline;
   }
-  .p-button.p-button-link:enabled:focus, .p-button.p-button-link:not(button):not(a):not(.p-disabled):focus {
+  .p-button.p-button-link:not(:disabled):focus {
     background: transparent;
     box-shadow: 0 0 0 0.2rem #6366F1;
     border-color: transparent;
   }
-  .p-button.p-button-link:enabled:active, .p-button.p-button-link:not(button):not(a):not(.p-disabled):active {
+  .p-button.p-button-link:not(:disabled):active {
     background: transparent;
     color: #4F46E5;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 0.375rem;
   }
@@ -2308,11 +2231,11 @@
     color: #4F46E5;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(79, 70, 229, 0.04);
     color: #4F46E5;
   }
-  .p-splitbutton.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(79, 70, 229, 0.16);
     color: #4F46E5;
   }
@@ -2320,11 +2243,11 @@
     color: #71717A;
     border-color: #71717A;
   }
-  .p-splitbutton.p-button-outlined.p-button-plain > .p-button:enabled:hover, .p-splitbutton.p-button-outlined.p-button-plain > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-outlined.p-button-plain > .p-button:not(:disabled):hover {
     background: #f4f4f5;
     color: #71717A;
   }
-  .p-splitbutton.p-button-outlined.p-button-plain > .p-button:enabled:active, .p-splitbutton.p-button-outlined.p-button-plain > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-outlined.p-button-plain > .p-button:not(:disabled):active {
     background: #e5e7eb;
     color: #71717A;
   }
@@ -2333,12 +2256,12 @@
     color: #4F46E5;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(79, 70, 229, 0.04);
     color: #4F46E5;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-text > .p-button:not(:disabled):active {
     background: rgba(79, 70, 229, 0.16);
     color: #4F46E5;
     border-color: transparent;
@@ -2346,11 +2269,11 @@
   .p-splitbutton.p-button-text.p-button-plain > .p-button {
     color: #71717A;
   }
-  .p-splitbutton.p-button-text.p-button-plain > .p-button:enabled:hover, .p-splitbutton.p-button-text.p-button-plain > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-text.p-button-plain > .p-button:not(:disabled):hover {
     background: #f4f4f5;
     color: #71717A;
   }
-  .p-splitbutton.p-button-text.p-button-plain > .p-button:enabled:active, .p-splitbutton.p-button-text.p-button-plain > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-text.p-button-plain > .p-button:not(:disabled):active {
     background: #e5e7eb;
     color: #71717A;
   }
@@ -2381,22 +2304,21 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #64748B;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(100, 116, 139, 0.04);
     color: #64748B;
   }
-  .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-secondary.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(100, 116, 139, 0.16);
     color: #64748B;
   }
@@ -2405,27 +2327,26 @@
     color: #64748B;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-secondary.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(100, 116, 139, 0.04);
     border-color: transparent;
     color: #64748B;
   }
-  .p-splitbutton.p-button-secondary.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-secondary.p-button-text > .p-button:not(:disabled):active {
     background: rgba(100, 116, 139, 0.16);
     border-color: transparent;
     color: #64748B;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #3B82F6;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-info.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-info.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-info.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(59, 130, 246, 0.04);
     color: #3B82F6;
   }
-  .p-splitbutton.p-button-info.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-info.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-info.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(59, 130, 246, 0.16);
     color: #3B82F6;
   }
@@ -2434,27 +2355,26 @@
     color: #3B82F6;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-info.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-info.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-info.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(59, 130, 246, 0.04);
     border-color: transparent;
     color: #3B82F6;
   }
-  .p-splitbutton.p-button-info.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-info.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-info.p-button-text > .p-button:not(:disabled):active {
     background: rgba(59, 130, 246, 0.16);
     border-color: transparent;
     color: #3B82F6;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #22C55E;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-success.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(34, 197, 94, 0.04);
     color: #22C55E;
   }
-  .p-splitbutton.p-button-success.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-success.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(34, 197, 94, 0.16);
     color: #22C55E;
   }
@@ -2463,27 +2383,26 @@
     color: #22C55E;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-success.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-success.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(34, 197, 94, 0.04);
     border-color: transparent;
     color: #22C55E;
   }
-  .p-splitbutton.p-button-success.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-success.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-success.p-button-text > .p-button:not(:disabled):active {
     background: rgba(34, 197, 94, 0.16);
     border-color: transparent;
     color: #22C55E;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F59E0B;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-warning.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(245, 158, 11, 0.04);
     color: #F59E0B;
   }
-  .p-splitbutton.p-button-warning.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-warning.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(245, 158, 11, 0.16);
     color: #F59E0B;
   }
@@ -2492,27 +2411,26 @@
     color: #F59E0B;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-warning.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-warning.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(245, 158, 11, 0.04);
     border-color: transparent;
     color: #F59E0B;
   }
-  .p-splitbutton.p-button-warning.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-warning.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-warning.p-button-text > .p-button:not(:disabled):active {
     background: rgba(245, 158, 11, 0.16);
     border-color: transparent;
     color: #F59E0B;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #A855F7;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-help.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(168, 85, 247, 0.04);
     color: #A855F7;
   }
-  .p-splitbutton.p-button-help.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-help.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(168, 85, 247, 0.16);
     color: #A855F7;
   }
@@ -2521,27 +2439,26 @@
     color: #A855F7;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-help.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-help.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(168, 85, 247, 0.04);
     border-color: transparent;
     color: #A855F7;
   }
-  .p-splitbutton.p-button-help.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-help.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-help.p-button-text > .p-button:not(:disabled):active {
     background: rgba(168, 85, 247, 0.16);
     border-color: transparent;
     color: #A855F7;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #EF4444;
     border: 1px solid;
   }
-  .p-splitbutton.p-button-danger.p-button-outlined > .p-button:enabled:hover, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):hover {
     background: rgba(239, 68, 68, 0.04);
     color: #EF4444;
   }
-  .p-splitbutton.p-button-danger.p-button-outlined > .p-button:enabled:active, .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-danger.p-button-outlined > .p-button:not(:disabled):active {
     background: rgba(239, 68, 68, 0.16);
     color: #EF4444;
   }
@@ -2550,17 +2467,16 @@
     color: #EF4444;
     border-color: transparent;
   }
-  .p-splitbutton.p-button-danger.p-button-text > .p-button:enabled:hover, .p-splitbutton.p-button-danger.p-button-text > .p-button:not(button):not(a):not(.p-disabled):hover {
+  .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):hover {
     background: rgba(239, 68, 68, 0.04);
     border-color: transparent;
     color: #EF4444;
   }
-  .p-splitbutton.p-button-danger.p-button-text > .p-button:enabled:active, .p-splitbutton.p-button-danger.p-button-text > .p-button:not(button):not(a):not(.p-disabled):active {
+  .p-splitbutton.p-button-danger.p-button-text > .p-button:not(:disabled):active {
     background: rgba(239, 68, 68, 0.16);
     border-color: transparent;
     color: #EF4444;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2572,7 +2488,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2583,54 +2501,48 @@
     background: #27272A;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
+    border-radius: 0.375rem;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #71717A;
@@ -2641,13 +2553,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #18181B;
     border-color: transparent;
     background: #f4f4f5;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
@@ -2673,7 +2585,6 @@
     background: #EEF2FF;
     color: #312E81;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -2767,9 +2678,9 @@
     padding: 1rem 1.5rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #71717A;
@@ -2779,17 +2690,17 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #18181B;
     border-color: transparent;
     background: #f4f4f5;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
@@ -2807,6 +2718,10 @@
   .p-datatable .p-datatable-tbody > tr.p-highlight {
     background: #EEF2FF;
     color: #312E81;
+  }
+  .p-datatable .p-datatable-tbody > tr.p-highlight-contextmenu {
+    outline: 0.15rem solid #6366F1;
+    outline-offset: -0.15rem;
   }
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #EEF2FF;
@@ -2838,12 +2753,12 @@
     background: #4F46E5;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #fafafa;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #fafafa;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2953,11 +2868,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 0.9375rem 1.875rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(79, 70, 229, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3001,7 +2914,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3038,12 +2950,10 @@
     border-bottom-left-radius: 0.375rem;
     border-bottom-right-radius: 0.375rem;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3071,7 +2981,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3091,13 +3000,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
     border-radius: 0.375rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     min-width: 12.5rem;
   }
   .p-column-filter-overlay .p-column-filter-row-items {
@@ -3129,7 +3037,6 @@
     border-top: 1px solid #f3f4f6;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 0.75rem;
     border-bottom: 0 none;
@@ -3158,7 +3065,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1.25rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1.25rem;
   }
@@ -3223,7 +3129,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #f4f4f5;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #f4f4f5;
     color: #18181B;
@@ -3262,7 +3167,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #71717A;
@@ -3272,9 +3176,9 @@
     border-radius: 0.375rem;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 1px solid #d4d4d8;
     color: #71717A;
@@ -3285,9 +3189,9 @@
     border-radius: 0;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #f4f4f5;
     border-color: #d4d4d8;
     color: #3f3f46;
@@ -3343,7 +3247,6 @@
     border-color: #d4d4d8;
     color: #3f3f46;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1.25rem;
   }
@@ -3402,7 +3305,6 @@
     color: #312E81;
     background: #EEF2FF;
   }
-
   .p-tree {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3458,11 +3360,11 @@
     color: #312E81;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #312E81;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #312E81;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3500,7 +3402,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #8ba7ff;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 1px 0;
     border-radius: 0;
@@ -3636,7 +3537,7 @@
     background: #4F46E5;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #fafafa;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3713,7 +3614,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 0.9375rem 1.875rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #4F46E5;
     border-radius: 50%;
@@ -3725,20 +3625,19 @@
     background-color: #e5e7eb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1.25rem;
     border: 1px solid #e5e7eb;
@@ -3812,7 +3711,6 @@
     border-bottom-right-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem;
   }
-
   .p-card {
     background: #ffffff;
     color: #3f3f46;
@@ -3838,7 +3736,6 @@
   .p-card .p-card-footer {
     padding: 1.25rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3879,7 +3776,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1.25rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3903,7 +3799,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #e5e7eb;
     padding: 1.25rem;
@@ -3953,7 +3848,6 @@
     color: #3f3f46;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #e5e7eb;
     background: #ffffff;
@@ -3970,12 +3864,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #e5e7eb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #fafafa;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4035,7 +3927,6 @@
     border-bottom-right-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem;
   }
-
   .p-toolbar {
     background: #fafafa;
     border: 1px solid #e5e7eb;
@@ -4046,7 +3937,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #3f3f46;
@@ -4076,7 +3966,7 @@
   .p-confirm-popup:before {
     border: solid transparent;
     border-color: rgba(255, 255, 255, 0);
-    border-bottom-color: #ffffff;
+    border-bottom-color: #f2f2f2;
   }
   .p-confirm-popup.p-confirm-popup-flipped:after {
     border-top-color: #ffffff;
@@ -4094,7 +3984,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 0.375rem;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
@@ -4170,7 +4059,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #3f3f46;
@@ -4212,7 +4100,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #3f3f46;
@@ -4223,7 +4110,7 @@
     padding: 1.25rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #71717A;
@@ -4233,13 +4120,13 @@
     transition: none;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #18181B;
     border-color: transparent;
     background: #f4f4f5;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
@@ -4250,12 +4137,11 @@
   .p-sidebar .p-sidebar-content {
     padding: 1.25rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #3f3f46;
     color: #ffffff;
     padding: 0.75rem 0.75rem;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     border-radius: 0.375rem;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
@@ -4270,7 +4156,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #3f3f46;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #fafafa;
     padding: 1.25rem;
@@ -4301,7 +4186,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -4333,13 +4217,12 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #71717A;
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     border-radius: 0.375rem;
     width: 12.5rem;
   }
@@ -4381,7 +4264,7 @@
     padding: 0.25rem 0;
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     border-radius: 0.375rem;
   }
   .p-contextmenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
@@ -4405,7 +4288,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4420,32 +4302,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4462,22 +4343,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4528,19 +4409,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #f4f4f5;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #3f3f46;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #71717A;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #71717A;
   }
   .p-megamenu .p-menuitem-link {
@@ -4581,7 +4462,7 @@
     background: #ffffff;
     color: #3f3f46;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-megamenu .p-megamenu-submenu-header {
     margin: 0;
@@ -4636,7 +4517,7 @@
     padding: 0.25rem 0;
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-megamenu.p-megamenu-mobile-active .p-megamenu-root-list .p-menu-separator {
     border-top: 1px solid #f3f4f6;
@@ -4710,7 +4591,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -4756,7 +4636,7 @@
   .p-menu.p-menu-overlay {
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-menu .p-submenu-header {
     margin: 0;
@@ -4771,7 +4651,6 @@
     border-top: 1px solid #f3f4f6;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 1rem;
     background: #fafafa;
@@ -4849,26 +4728,26 @@
     box-shadow: inset 0 0 0 0.15rem #6366F1;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #f4f4f5;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #3f3f46;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #71717A;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #71717A;
   }
   .p-menubar .p-submenu-list {
     padding: 0.25rem 0;
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     width: 12.5rem;
   }
   .p-menubar .p-submenu-list .p-menu-separator {
@@ -4891,7 +4770,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #71717A;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -4919,7 +4797,7 @@
       padding: 0.25rem 0;
       background: #ffffff;
       border: 0 none;
-      box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+      box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
       width: 100%;
     }
     .p-menubar .p-menubar-root-list .p-menu-separator {
@@ -5136,7 +5014,6 @@
     border-bottom-right-radius: 0.375rem;
     border-bottom-left-radius: 0.375rem;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5182,13 +5059,13 @@
   .p-slidemenu.p-slidemenu-overlay {
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-slidemenu .p-slidemenu-list {
     padding: 0.25rem 0;
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-slidemenu .p-slidemenu.p-slidemenu-active > .p-slidemenu-link {
     background: #f4f4f5;
@@ -5214,7 +5091,6 @@
     padding: 0.75rem 1rem;
     color: #3f3f46;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: none;
@@ -5259,7 +5135,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
@@ -5300,7 +5175,6 @@
     border-color: #4F46E5;
     color: #4F46E5;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #ffffff;
@@ -5346,13 +5220,13 @@
   .p-tieredmenu.p-tieredmenu-overlay {
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-tieredmenu .p-submenu-list {
     padding: 0.25rem 0;
     background: #ffffff;
     border: 0 none;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
   }
   .p-tieredmenu .p-menuitem.p-menuitem-active > .p-menuitem-link {
     background: #f4f4f5;
@@ -5375,7 +5249,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.75rem 0.75rem;
     margin: 0;
@@ -5431,7 +5304,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 0.375rem;
@@ -5447,7 +5319,7 @@
     transition: none;
   }
   .p-message .p-message-close:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.5);
   }
   .p-message .p-message-close:focus-visible {
     outline: 0 none;
@@ -5520,7 +5392,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5531,7 +5402,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5557,7 +5427,7 @@
     transition: none;
   }
   .p-toast .p-toast-message .p-toast-icon-close:hover {
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba(255, 255, 255, 0.5);
   }
   .p-toast .p-toast-message .p-toast-icon-close:focus-visible {
     outline: 0 none;
@@ -5571,7 +5441,7 @@
     color: #2563EB;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #2563EB;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5581,7 +5451,7 @@
     color: #059669;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #059669;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5591,7 +5461,7 @@
     color: #D97706;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #D97706;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5601,10 +5471,9 @@
     color: #DC2626;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #DC2626;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5635,11 +5504,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5693,7 +5562,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #fafafa;
@@ -5703,7 +5572,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #fafafa;
   }
@@ -5715,15 +5584,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5733,15 +5599,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5765,7 +5628,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #e5e7eb;
     border-radius: 0.375rem;
@@ -5786,15 +5648,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #e5e7eb;
     color: #3f3f46;
@@ -5828,12 +5687,11 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
     border-radius: 50%;
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
     transition: none;
   }
   .p-scrolltop.p-link {
@@ -5850,7 +5708,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #f4f4f5;
     border-radius: 0.375rem;
@@ -5858,7 +5715,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #4F46E5;
     color: #ffffff;
@@ -5891,7 +5747,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.75rem 0.75rem;
     border-radius: 0.375rem;
@@ -5906,7 +5761,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #6366F1;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5922,7 +5776,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #3f3f46;
@@ -5934,7 +5787,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #4F46E5;
     color: #ffffff;
@@ -5976,7 +5828,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #4F46E5;
     color: #ffffff;
@@ -6005,29 +5856,23 @@
 /* Customizations to the designer theme should be defined here */
 @layer primereact {
   .p-inputtext, .p-togglebutton, .p-selectbutton, .p-inputgroup {
-    box-shadow: 0 0 #0000, 0 0 #0000, 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    box-shadow: 0 0 rgba(0, 0, 0, 0), 0 0 rgba(0, 0, 0, 0), 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   }
-
   .p-inputgroup .p-inputtext, .p-inputgroup .p-togglebutton, .p-inputgroup .p-selectbutton {
     box-shadow: none;
   }
-
   .p-inputtext.p-invalid.p-component:enabled:focus {
     box-shadow: 0 0 0 1px #f0a9a7;
   }
-
   .p-highlight {
     font-weight: 600;
   }
-
   .p-button-label {
     font-weight: 500;
   }
-
   .p-inputswitch.p-focus .p-inputswitch-slider {
     box-shadow: 0 0 0 2px #6366F1;
   }
-
   .p-paginator .p-paginator-pages .p-paginator-page {
     margin-left: -1px;
   }
@@ -6038,7 +5883,6 @@
   .p-paginator .p-paginator-current {
     border: 0 none;
   }
-
   .p-button:focus {
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #6366F1, 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
@@ -6060,18 +5904,15 @@
   .p-button.p-button-danger:enabled:focus {
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #EF4444, 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-checkbox .p-checkbox-box {
     border-radius: 0.25rem;
   }
   .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-focus {
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #6366F1, 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-radiobutton:not(.p-radiobutton-disabled) .p-radiobutton-box.p-focus {
     box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #6366F1, 0 1px 2px 0 rgba(0, 0, 0, 0);
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #4F46E5;
   }

--- a/public/themes/vela-blue/theme.css
+++ b/public/themes/vela-blue/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1f2d40;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2d40;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #64B5F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #304562;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #304562;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #2396f2;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2d40;
     border: 1px solid #304562;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #17212f;
     border: 1px solid #304562;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #304562;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #304562;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #304562;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #304562;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-multiselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #304562;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1f2d40;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #304562;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #2396f2;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #304562;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #64B5F6;
     border-color: #64B5F6;
   }
-
   .p-treeselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #304562;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-togglebutton.p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #64B5F6;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #64B5F6;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #64B5F6;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #17212f;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -2646,7 +2555,6 @@
     background: rgba(100, 181, 246, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -2815,12 +2723,12 @@
     background: #64B5F6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2d40;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2d40;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-column-filter-overlay {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-paginator {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
   }
-
   .p-tree {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(35, 150, 242, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #64B5F6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2d40;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #64B5F6;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #304562;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #304562;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2d40;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #304562;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #304562;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #304562;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #304562;
   }
-
   .p-sidebar {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #304562;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2d40;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1f2d40;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #93cbf9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -5277,7 +5145,6 @@
     border-color: #64B5F6;
     color: #64B5F6;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #304562;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2d40;
   }
-
   .p-chip {
     background-color: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #64B5F6;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #93cbf9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #64B5F6;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #64B5F6;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #64B5F6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #64B5F6;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #64B5F6;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #64B5F6;
   }

--- a/public/themes/vela-green/theme.css
+++ b/public/themes/vela-green/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1f2d40;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2d40;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #81C784;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #304562;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #304562;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #54b358;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2d40;
     border: 1px solid #304562;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #17212f;
     border: 1px solid #304562;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #304562;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #304562;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #304562;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #304562;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-multiselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #304562;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1f2d40;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #304562;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #54b358;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #304562;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #81C784;
     border-color: #81C784;
   }
-
   .p-treeselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #304562;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-togglebutton.p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #81C784;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #81C784;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #81C784;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #17212f;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -2646,7 +2555,6 @@
     background: rgba(129, 199, 132, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -2815,12 +2723,12 @@
     background: #81C784;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2d40;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2d40;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-column-filter-overlay {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-paginator {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
   }
-
   .p-tree {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(84, 179, 88, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #81C784;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2d40;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #81C784;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #304562;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #304562;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2d40;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #304562;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #304562;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #304562;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #304562;
   }
-
   .p-sidebar {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #304562;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2d40;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1f2d40;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #a7d8a9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -5277,7 +5145,6 @@
     border-color: #81C784;
     color: #81C784;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #304562;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2d40;
   }
-
   .p-chip {
     background-color: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #81C784;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #a7d8a9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #81C784;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #81C784;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #81C784;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #81C784;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #81C784;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #81C784;
   }

--- a/public/themes/vela-orange/theme.css
+++ b/public/themes/vela-orange/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1f2d40;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2d40;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #FFD54F;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #304562;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #304562;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #ffc50c;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2d40;
     border: 1px solid #304562;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #17212f;
     border: 1px solid #304562;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #304562;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #304562;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #304562;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #304562;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-multiselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #304562;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1f2d40;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #304562;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #ffc50c;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #212529;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #304562;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #FFD54F;
     border-color: #FFD54F;
   }
-
   .p-treeselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #304562;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-togglebutton.p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #212529;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #212529;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #212529;
     background: #FFD54F;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #FFD54F;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #FFD54F;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #17212f;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -2646,7 +2555,6 @@
     background: rgba(255, 213, 79, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -2815,12 +2723,12 @@
     background: #FFD54F;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2d40;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2d40;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-column-filter-overlay {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-paginator {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
   }
-
   .p-tree {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(255, 197, 12, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #FFD54F;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2d40;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #FFD54F;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #304562;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #304562;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2d40;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #304562;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #304562;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #304562;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #304562;
   }
-
   .p-sidebar {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #304562;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2d40;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1f2d40;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #ffe284;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -5277,7 +5145,6 @@
     border-color: #FFD54F;
     color: #FFD54F;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #304562;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2d40;
   }
-
   .p-chip {
     background-color: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #FFD54F;
     color: #212529;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #ffe284;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #212529;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #FFD54F;
     color: #212529;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #FFD54F;
     color: #212529;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #FFD54F;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #FFD54F;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #FFD54F;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #FFD54F;
   }

--- a/public/themes/vela-purple/theme.css
+++ b/public/themes/vela-purple/theme.css
@@ -274,40 +274,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.2s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #ef9a9a;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -319,15 +311,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -344,7 +333,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.5rem;
   }
@@ -388,7 +376,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-autocomplete-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -423,11 +410,9 @@
     background: #1f2d40;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #1f2d40;
@@ -454,7 +439,7 @@
     border-top-left-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -464,13 +449,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -479,14 +464,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #BA68C8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -635,7 +620,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -678,7 +662,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-cascadeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -720,7 +703,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #304562;
   }
@@ -730,7 +712,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -779,7 +760,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #ef9a9a;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #304562;
   }
@@ -792,7 +772,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #a241b2;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.5rem;
     gap: 0.5rem;
@@ -830,25 +809,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #1f2d40;
     border: 1px solid #304562;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #17212f;
     border: 1px solid #304562;
@@ -892,7 +867,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-dropdown-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -956,7 +930,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #304562;
   }
@@ -969,7 +942,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -982,68 +954,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 1px solid #304562;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.357rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1085,7 +1049,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #ef9a9a;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1118,59 +1081,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-float-label > label {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
-
   .p-float-label > label.p-error {
     color: #ef9a9a;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #304562;
   }
@@ -1180,17 +1131,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #304562;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.4375rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
-
   .p-listbox {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1252,7 +1200,6 @@
   .p-listbox.p-invalid {
     border-color: #ef9a9a;
   }
-
   .p-mention-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1280,7 +1227,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-multiselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1330,7 +1276,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.5rem;
   }
@@ -1340,7 +1285,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.5rem;
   }
-
   .p-multiselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1426,7 +1370,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #304562;
   }
@@ -1436,11 +1379,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #ef9a9a;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #1f2d40;
@@ -1462,7 +1403,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #C5E1A5;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1506,7 +1446,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #304562;
   }
@@ -1519,7 +1458,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #a241b2;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1549,7 +1487,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #F48FB1;
   }
-
   .p-selectbutton .p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1557,7 +1494,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1566,7 +1503,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1575,7 +1512,7 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1584,13 +1521,12 @@
     color: #ffffff;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-slider {
     background: #304562;
     border: 0 none;
@@ -1630,7 +1566,6 @@
     background: #BA68C8;
     border-color: #BA68C8;
   }
-
   .p-treeselect {
     background: #17212f;
     border: 1px solid #304562;
@@ -1677,11 +1612,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #ef9a9a;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.5rem;
   }
-
   .p-treeselect-panel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -1741,7 +1674,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #304562;
   }
@@ -1751,7 +1683,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #304562;
   }
-
   .p-togglebutton.p-button {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -1759,7 +1690,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1768,7 +1699,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1777,7 +1708,7 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1786,13 +1717,12 @@
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #ffffff;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #ef9a9a;
   }
-
   .p-button {
     color: #ffffff;
     background: #BA68C8;
@@ -1904,7 +1834,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1940,7 +1870,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1953,7 +1882,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #78909C;
@@ -2002,7 +1930,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #121212;
     background: #81D4FA;
@@ -2051,7 +1978,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #121212;
     background: #C5E1A5;
@@ -2100,7 +2026,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #121212;
     background: #FFE082;
@@ -2149,7 +2074,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #121212;
     background: #CE93D8;
@@ -2198,7 +2122,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #121212;
     background: #F48FB1;
@@ -2247,7 +2170,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-button.p-button-link {
     color: #BA68C8;
     background: transparent;
@@ -2271,7 +2193,6 @@
     color: #BA68C8;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 3px;
   }
@@ -2353,12 +2274,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #78909C;
@@ -2387,7 +2307,6 @@
     border-color: transparent;
     color: #78909C;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #81D4FA;
@@ -2416,7 +2335,6 @@
     border-color: transparent;
     color: #81D4FA;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #C5E1A5;
@@ -2445,7 +2363,6 @@
     border-color: transparent;
     color: #C5E1A5;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #FFE082;
@@ -2474,7 +2391,6 @@
     border-color: transparent;
     color: #FFE082;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #CE93D8;
@@ -2503,7 +2419,6 @@
     border-color: transparent;
     color: #CE93D8;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #F48FB1;
@@ -2532,7 +2447,6 @@
     border-color: transparent;
     color: #F48FB1;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2544,7 +2458,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2555,55 +2471,48 @@
     background: rgba(255, 255, 255, 0.6);
     color: #17212f;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 3px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2614,13 +2523,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -2646,7 +2555,6 @@
     background: rgba(186, 104, 200, 0.16);
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-datatable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2740,9 +2648,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2752,17 +2660,17 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -2815,12 +2723,12 @@
     background: #BA68C8;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #1f2d40;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #1f2d40;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2930,11 +2838,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -2978,7 +2884,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3015,12 +2920,10 @@
     border-bottom-left-radius: 3px;
     border-bottom-right-radius: 3px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3048,7 +2951,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3068,7 +2970,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-column-filter-overlay {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3106,7 +3007,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1rem;
     border-bottom: 0 none;
@@ -3135,7 +3035,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3200,7 +3099,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(255, 255, 255, 0.03);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     color: rgba(255, 255, 255, 0.87);
@@ -3239,7 +3137,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-paginator {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
@@ -3249,9 +3146,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3262,9 +3159,9 @@
     border-radius: 3px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3320,7 +3217,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3379,7 +3275,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
   }
-
   .p-tree {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3435,11 +3330,11 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3477,7 +3372,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(162, 65, 178, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 1px 0 1px 0;
     border-radius: 0;
@@ -3613,7 +3507,7 @@
     background: #BA68C8;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #1f2d40;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3690,7 +3584,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #BA68C8;
     border-radius: 50%;
@@ -3702,20 +3595,19 @@
     background-color: #304562;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 1px solid #304562;
@@ -3789,7 +3681,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-card {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -3815,7 +3706,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3856,7 +3746,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #1f2d40;
   }
@@ -3880,7 +3769,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 1px solid #304562;
     padding: 1rem;
@@ -3930,7 +3818,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 1px solid #304562;
     background: #1f2d40;
@@ -3947,12 +3834,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #304562;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #304562;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -4012,7 +3897,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-toolbar {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4023,7 +3907,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4071,7 +3954,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 3px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4147,7 +4029,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4189,7 +4070,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #304562;
   }
-
   .p-sidebar {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -4200,7 +4080,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4210,13 +4090,13 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(255, 255, 255, 0.03);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
@@ -4227,7 +4107,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -4247,7 +4126,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #304562;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #1f2d40;
     padding: 1rem;
@@ -4278,7 +4156,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #1f2d40;
     border: 1px solid #304562;
@@ -4310,7 +4187,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4382,7 +4258,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4397,32 +4272,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4439,22 +4313,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4505,19 +4379,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4687,7 +4561,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -4748,7 +4621,6 @@
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #1f2d40;
@@ -4826,19 +4698,19 @@
     box-shadow: inset 0 0 0 0.15rem #cf95d9;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #17212f;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4868,7 +4740,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5113,7 +4984,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
   }
-
   .p-slidemenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5191,7 +5061,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.2s;
@@ -5236,7 +5105,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
@@ -5277,7 +5145,6 @@
     border-color: #BA68C8;
     color: #BA68C8;
   }
-
   .p-tieredmenu {
     padding: 0.25rem 0;
     background: #1f2d40;
@@ -5352,7 +5219,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.5rem;
     margin: 0;
@@ -5408,7 +5274,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 3px;
@@ -5497,7 +5362,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5508,7 +5372,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5548,7 +5411,7 @@
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5558,7 +5421,7 @@
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5568,7 +5431,7 @@
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5578,10 +5441,9 @@
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #73000c;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5612,11 +5474,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5670,7 +5532,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5680,7 +5542,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5692,15 +5554,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5710,15 +5569,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5742,7 +5598,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #304562;
     border-radius: 3px;
@@ -5763,15 +5618,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #1f2d40;
   }
-
   .p-chip {
     background-color: #304562;
     color: rgba(255, 255, 255, 0.87);
@@ -5805,7 +5657,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5827,7 +5678,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 3px;
@@ -5835,7 +5685,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #BA68C8;
     color: #ffffff;
@@ -5868,7 +5717,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.5rem;
     border-radius: 3px;
@@ -5883,7 +5731,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #cf95d9;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5899,7 +5746,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
@@ -5911,7 +5757,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #BA68C8;
     color: #ffffff;
@@ -5953,7 +5798,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #BA68C8;
     color: #ffffff;
@@ -5984,14 +5828,12 @@
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #BA68C8;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #BA68C8;
   }
   .p-galleria.p-galleria-indicator-onitem .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background: #BA68C8;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #BA68C8;
   }

--- a/public/themes/viva-dark/theme.css
+++ b/public/themes/viva-dark/theme.css
@@ -53,32 +53,28 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 300;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-300.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-300.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-regular - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 400;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-600 - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 600;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-600.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-600.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-600.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-600.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-700 - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 700;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f6fbfd;
@@ -306,40 +302,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.3s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.4;
   }
-
   .p-error {
     color: #f78c79;
   }
-
   .p-text-secondary {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -351,15 +339,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -376,7 +361,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -420,7 +404,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f78c79;
   }
-
   .p-autocomplete-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -455,11 +438,9 @@
     background: #161d21;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f78c79;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #161d21;
@@ -486,7 +467,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -496,13 +477,13 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(158, 173, 230, 0.08);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
@@ -511,14 +492,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: rgba(255, 255, 255, 0.87);
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #9eade6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -667,7 +648,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -710,7 +690,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f78c79;
   }
-
   .p-cascadeselect-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -752,7 +731,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #263238;
   }
@@ -762,7 +740,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #263238;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -811,7 +788,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f78c79;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #263238;
   }
@@ -824,7 +800,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #7f93de;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -862,25 +837,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f78c79;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #161d21;
     border: 1px solid #263238;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: rgba(255, 255, 255, 0.87);
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #0e1315;
     border: 2px solid #263238;
@@ -924,7 +895,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f78c79;
   }
-
   .p-dropdown-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -988,7 +958,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #263238;
   }
@@ -1001,7 +970,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
@@ -1014,68 +982,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 2px solid #263238;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.857rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f78c79;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1117,7 +1077,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f78c79;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1150,59 +1109,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.3s;
   }
-
   .p-float-label > label.p-error {
     color: #f78c79;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   ::-moz-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   :-ms-input-placeholder {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-input-filled .p-inputtext {
     background-color: #263238;
   }
@@ -1212,17 +1159,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #263238;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -1284,7 +1228,6 @@
   .p-listbox.p-invalid {
     border-color: #f78c79;
   }
-
   .p-mention-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -1312,7 +1255,6 @@
     color: #9eade6;
     background: rgba(158, 173, 230, 0.16);
   }
-
   .p-multiselect {
     background: #0e1315;
     border: 2px solid #263238;
@@ -1362,7 +1304,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f78c79;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1372,7 +1313,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -1458,7 +1398,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #263238;
   }
@@ -1468,11 +1407,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #263238;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f78c79;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #161d21;
@@ -1494,7 +1431,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #cede9c;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1538,7 +1474,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #263238;
   }
@@ -1551,7 +1486,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #7f93de;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1581,7 +1515,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f88c79;
   }
-
   .p-selectbutton .p-button {
     background: #161d21;
     border: 2px solid #263238;
@@ -1589,7 +1522,7 @@
     transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1598,7 +1531,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1607,7 +1540,7 @@
     color: #9eade6;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #9eade6;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1616,13 +1549,12 @@
     color: #9eade6;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #9eade6;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f78c79;
   }
-
   .p-slider {
     background: #263238;
     border: 0 none;
@@ -1662,7 +1594,6 @@
     background: #9eade6;
     border-color: #9eade6;
   }
-
   .p-treeselect {
     background: #0e1315;
     border: 2px solid #263238;
@@ -1709,11 +1640,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f78c79;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -1773,7 +1702,6 @@
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #263238;
   }
@@ -1783,7 +1711,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #263238;
   }
-
   .p-togglebutton.p-button {
     background: #161d21;
     border: 2px solid #263238;
@@ -1791,7 +1718,7 @@
     transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1800,7 +1727,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: rgba(255, 255, 255, 0.6);
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1809,7 +1736,7 @@
     color: #9eade6;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #9eade6;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1818,13 +1745,12 @@
     color: #9eade6;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #9eade6;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f78c79;
   }
-
   .p-button {
     color: #121212;
     background: #9eade6;
@@ -1936,7 +1862,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1972,7 +1898,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1985,7 +1910,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #0e1315;
     background: #b4bfcd;
@@ -2034,7 +1958,6 @@
     border-color: transparent;
     color: #b4bfcd;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #35a4cc;
@@ -2083,7 +2006,6 @@
     border-color: transparent;
     color: #35a4cc;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #0e1315;
     background: #cede9c;
@@ -2132,7 +2054,6 @@
     border-color: transparent;
     color: #cede9c;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #0e1315;
     background: #ffe08a;
@@ -2181,7 +2102,6 @@
     border-color: transparent;
     color: #ffe08a;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #0e1315;
     background: #b09ce5;
@@ -2230,7 +2150,6 @@
     border-color: transparent;
     color: #b09ce5;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #0e1315;
     background: #e693a9;
@@ -2279,7 +2198,6 @@
     border-color: transparent;
     color: #e693a9;
   }
-
   .p-button.p-button-link {
     color: #7f93de;
     background: transparent;
@@ -2303,7 +2221,6 @@
     color: #7f93de;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2385,12 +2302,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #b4bfcd;
@@ -2419,7 +2335,6 @@
     border-color: transparent;
     color: #b4bfcd;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #35a4cc;
@@ -2448,7 +2363,6 @@
     border-color: transparent;
     color: #35a4cc;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #cede9c;
@@ -2477,7 +2391,6 @@
     border-color: transparent;
     color: #cede9c;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ffe08a;
@@ -2506,7 +2419,6 @@
     border-color: transparent;
     color: #ffe08a;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #b09ce5;
@@ -2535,7 +2447,6 @@
     border-color: transparent;
     color: #b09ce5;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #e693a9;
@@ -2564,7 +2475,6 @@
     border-color: transparent;
     color: #e693a9;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2576,7 +2486,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2587,55 +2499,48 @@
     background: #263238;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2646,13 +2551,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(158, 173, 230, 0.08);
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
@@ -2678,7 +2583,6 @@
     background: rgba(158, 173, 230, 0.16);
     color: #9eade6;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -2772,9 +2676,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -2784,17 +2688,17 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(158, 173, 230, 0.08);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
@@ -2847,12 +2751,12 @@
     background: #9eade6;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #161d21;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #161d21;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2962,11 +2866,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(158, 173, 230, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3010,7 +2912,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3047,12 +2948,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3100,7 +2998,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-column-filter-overlay {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -3138,7 +3035,6 @@
     border-top: 1px solid #263238;
     margin: 4px 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1.5rem;
     border-bottom: 0 none;
@@ -3167,7 +3063,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3232,7 +3127,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: rgba(158, 173, 230, 0.08);
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: rgba(158, 173, 230, 0.08);
     color: rgba(255, 255, 255, 0.87);
@@ -3271,7 +3165,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-paginator {
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
@@ -3281,9 +3174,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: rgba(255, 255, 255, 0.6);
@@ -3294,9 +3187,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: rgba(158, 173, 230, 0.08);
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
@@ -3352,7 +3245,6 @@
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3411,7 +3303,6 @@
     color: #9eade6;
     background: rgba(158, 173, 230, 0.16);
   }
-
   .p-tree {
     border: 2px solid #263238;
     background: #161d21;
@@ -3467,11 +3358,11 @@
     color: #9eade6;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #9eade6;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #9eade6;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3509,7 +3400,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: rgba(96, 121, 214, 0.16);
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3645,7 +3535,7 @@
     background: #9eade6;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #161d21;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3722,7 +3612,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #9eade6;
     border-radius: 50%;
@@ -3734,20 +3623,19 @@
     background-color: #263238;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 2px solid #263238;
@@ -3821,7 +3709,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-card {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -3847,7 +3734,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 2px solid #263238;
     background: #161d21;
@@ -3888,7 +3774,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #161d21;
   }
@@ -3912,7 +3797,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 2px solid #263238;
     padding: 1rem;
@@ -3962,7 +3846,6 @@
     color: rgba(255, 255, 255, 0.87);
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 2px solid #263238;
     background: #161d21;
@@ -3979,12 +3862,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #263238;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #263238;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #263238;
@@ -4044,7 +3925,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #161d21;
     border: 2px solid #263238;
@@ -4055,7 +3935,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -4103,7 +3982,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4179,7 +4057,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -4221,7 +4098,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #263238;
   }
-
   .p-sidebar {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -4232,7 +4108,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -4242,13 +4118,13 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
     border-color: transparent;
     background: rgba(158, 173, 230, 0.08);
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
@@ -4259,7 +4135,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #263238;
     color: rgba(255, 255, 255, 0.87);
@@ -4279,7 +4154,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #263238;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #161d21;
     padding: 1rem;
@@ -4310,7 +4184,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #161d21;
     border: 2px solid #263238;
@@ -4342,7 +4215,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
   }
-
   .p-contextmenu {
     padding: 0.5rem 0.5rem;
     background: #161d21;
@@ -4414,7 +4286,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4429,32 +4300,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4471,22 +4341,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4537,19 +4407,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(158, 173, 230, 0.08);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-megamenu .p-menuitem-link {
@@ -4719,7 +4589,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0.5rem;
     background: #161d21;
@@ -4780,7 +4649,6 @@
     border-top: 1px solid #263238;
     margin: 4px 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #161d21;
@@ -4858,19 +4726,19 @@
     box-shadow: inset 0 0 0 0.15rem #9eade6;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: rgba(158, 173, 230, 0.08);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
   .p-menubar .p-submenu-list {
@@ -4900,7 +4768,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.87);
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5145,7 +5012,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0.5rem;
     background: #161d21;
@@ -5223,7 +5089,6 @@
     padding: 0.75rem 1rem;
     color: rgba(255, 255, 255, 0.87);
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.3s;
@@ -5268,7 +5133,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #263238;
@@ -5309,7 +5173,6 @@
     border-color: #9eade6;
     color: #9eade6;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0.5rem;
     background: #161d21;
@@ -5384,7 +5247,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5440,7 +5302,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5529,7 +5390,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5540,7 +5400,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5580,7 +5439,7 @@
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5590,7 +5449,7 @@
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5600,7 +5459,7 @@
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5610,10 +5469,9 @@
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #0e1315;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5644,11 +5502,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5702,7 +5560,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f8f9fa;
@@ -5712,7 +5570,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f8f9fa;
   }
@@ -5724,15 +5582,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5742,15 +5597,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5774,7 +5626,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #263238;
     border-radius: 6px;
@@ -5795,15 +5646,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #161d21;
   }
-
   .p-chip {
     background-color: #263238;
     color: rgba(255, 255, 255, 0.87);
@@ -5837,7 +5685,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5859,7 +5706,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: rgba(255, 255, 255, 0.06);
     border-radius: 6px;
@@ -5867,7 +5713,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #9eade6;
     color: #121212;
@@ -5900,7 +5745,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 6px;
@@ -5915,7 +5759,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 1px #9eade6;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5931,7 +5774,6 @@
     color: #121212;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
@@ -5943,7 +5785,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #9eade6;
     color: #121212;
@@ -5985,7 +5826,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #9eade6;
     color: #121212;
@@ -6017,20 +5857,16 @@
   .p-button .p-button-label {
     font-weight: 600;
   }
-
   .p-buttonset .p-button-label,
-.p-togglebutton .p-button-label {
+  .p-togglebutton .p-button-label {
     font-weight: 400;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #9eade6;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #9eade6;
   }
-
   .p-panel {
     border: 2px solid #263238;
     border-radius: 6px;
@@ -6041,11 +5877,9 @@
   .p-panel .p-panel-content {
     border: 0 none;
   }
-
   .p-fieldset .p-fieldset-legend {
     border-color: transparent;
   }
-
   .p-accordion .p-accordion-toggle-icon {
     order: 10;
     margin-left: auto;
@@ -6063,7 +5897,6 @@
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-bottom: 0 none;
   }
-
   .p-inline-message.p-inline-message-info {
     border-color: #a3d7e6;
   }
@@ -6076,39 +5909,30 @@
   .p-inline-message.p-inline-message-error {
     border-color: #e6a3b2;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: none;
   }
-
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-autocomplete.p-autocomplete-multiple:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-orderlist .p-orderlist-list {
     border-top: 0 none;
   }
-
   .p-picklist .p-picklist-list {
     border-top: 0 none;
   }
-
   .p-panelmenu .p-panelmenu-icon.pi-chevron-right, .p-panelmenu .p-panelmenu-icon.pi-chevron-down {
     order: 10;
     margin-left: auto;
@@ -6127,7 +5951,6 @@
     padding-bottom: calc(1rem + 2px);
     border-bottom: 0 none;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #9eade6;
   }

--- a/public/themes/viva-light/theme.css
+++ b/public/themes/viva-light/theme.css
@@ -53,32 +53,28 @@
   font-family: "Poppins";
   font-style: normal;
   font-weight: 300;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-300.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-300.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-300.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-regular - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 400;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-regular.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-regular.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-600 - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 600;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-600.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-600.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-600.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-600.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* poppins-700 - latin-ext_latin */
 @font-face {
   font-family: "Poppins";
   font-style: normal;
   font-weight: 700;
-  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-700.woff") format("woff");
-  /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+  src: local(""), url("./fonts/poppins-v15-latin-ext_latin-700.woff2") format("woff2"), url("./fonts/poppins-v15-latin-ext_latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 :root {
   --blue-50:#f6fbfd;
@@ -306,40 +302,32 @@
   * {
     box-sizing: border-box;
   }
-
   .p-component {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
     font-weight: normal;
   }
-
   .p-component-overlay {
     background-color: rgba(0, 0, 0, 0.4);
     transition-duration: 0.3s;
   }
-
   .p-disabled, .p-component:disabled {
     opacity: 0.6;
   }
-
   .p-error {
     color: #f88c79;
   }
-
   .p-text-secondary {
     color: #898989;
   }
-
   .pi {
     font-size: 1rem;
   }
-
   .p-icon {
     width: 1rem;
     height: 1rem;
   }
-
   .p-link {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -351,15 +339,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-component-overlay-enter {
     animation: p-component-overlay-enter-animation 150ms forwards;
   }
-
   .p-component-overlay-leave {
     animation: p-component-overlay-leave-animation 150ms forwards;
   }
-
   @keyframes p-component-overlay-enter-animation {
     from {
       background-color: transparent;
@@ -376,7 +361,6 @@
       background-color: transparent;
     }
   }
-
   .p-autocomplete .p-autocomplete-loader {
     right: 0.75rem;
   }
@@ -420,7 +404,6 @@
   .p-autocomplete.p-invalid.p-component > .p-inputtext {
     border-color: #f88c79;
   }
-
   .p-autocomplete-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -455,11 +438,9 @@
     background: #ffffff;
     font-weight: 600;
   }
-
   .p-calendar.p-invalid.p-component > .p-inputtext {
     border-color: #f88c79;
   }
-
   .p-datepicker {
     padding: 0.5rem;
     background: #ffffff;
@@ -486,7 +467,7 @@
     border-top-left-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
-.p-datepicker .p-datepicker-header .p-datepicker-next {
+  .p-datepicker .p-datepicker-header .p-datepicker-next {
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -496,13 +477,13 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:enabled:hover {
     color: #6c6c6c;
     border-color: transparent;
     background: #edf0fA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev:focus-visible,
-.p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
+  .p-datepicker .p-datepicker-header .p-datepicker-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
@@ -511,14 +492,14 @@
     line-height: 2rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
     color: #6c6c6c;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
     font-weight: 600;
     padding: 0.5rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-year:enabled:hover,
-.p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
+  .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month:enabled:hover {
     color: #5472d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
@@ -667,7 +648,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   @media screen and (max-width: 769px) {
     .p-datepicker table th, .p-datepicker table td {
       padding: 0;
@@ -710,7 +690,6 @@
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f88c79;
   }
-
   .p-cascadeselect-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -752,7 +731,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-input-filled .p-cascadeselect {
     background: #f2f2f2;
   }
@@ -762,7 +740,6 @@
   .p-input-filled .p-cascadeselect:not(.p-disabled).p-focus {
     background-color: #f2f2f2;
   }
-
   .p-checkbox {
     width: 20px;
     height: 20px;
@@ -811,7 +788,6 @@
   .p-checkbox.p-invalid > .p-checkbox-box {
     border-color: #f88c79;
   }
-
   .p-input-filled .p-checkbox .p-checkbox-box {
     background-color: #f2f2f2;
   }
@@ -824,7 +800,6 @@
   .p-input-filled .p-checkbox:not(.p-checkbox-disabled) .p-checkbox-box.p-highlight:hover {
     background: #3c5ece;
   }
-
   .p-chips .p-chips-multiple-container {
     padding: 0.25rem 0.75rem;
     gap: 0.5rem;
@@ -862,25 +837,21 @@
   .p-chips.p-invalid.p-component > .p-inputtext {
     border-color: #f88c79;
   }
-
   .p-colorpicker-preview {
     width: 2rem;
     height: 2rem;
   }
-
   .p-colorpicker-panel {
     background: #585858;
     border: 1px solid #585858;
   }
   .p-colorpicker-panel .p-colorpicker-color-handle,
-.p-colorpicker-panel .p-colorpicker-hue-handle {
+  .p-colorpicker-panel .p-colorpicker-hue-handle {
     border-color: #ffffff;
   }
-
   .p-colorpicker-overlay-panel {
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
-
   .p-dropdown {
     background: #ffffff;
     border: 2px solid #e1e1e1;
@@ -924,7 +895,6 @@
   .p-dropdown.p-invalid.p-component {
     border-color: #f88c79;
   }
-
   .p-dropdown-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -988,7 +958,6 @@
     color: #6c6c6c;
     background: transparent;
   }
-
   .p-input-filled .p-dropdown {
     background: #f2f2f2;
   }
@@ -1001,7 +970,6 @@
   .p-input-filled .p-dropdown:not(.p-disabled).p-focus .p-inputtext {
     background-color: transparent;
   }
-
   .p-inputgroup-addon {
     background: #f5f5f5;
     color: #898989;
@@ -1014,68 +982,60 @@
   .p-inputgroup-addon:last-child {
     border-right: 2px solid #e1e1e1;
   }
-
   .p-inputgroup > .p-component,
-.p-inputgroup > .p-inputwrapper > .p-inputtext,
-.p-inputgroup > .p-float-label > .p-component {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext,
+  .p-inputgroup > .p-float-label > .p-component {
     border-radius: 0;
     margin: 0;
   }
   .p-inputgroup > .p-component + .p-inputgroup-addon,
-.p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
-.p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
+  .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
     border-left: 0 none;
   }
   .p-inputgroup > .p-component:focus,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
-.p-inputgroup > .p-float-label > .p-component:focus {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
+  .p-inputgroup > .p-float-label > .p-component:focus {
     z-index: 1;
   }
   .p-inputgroup > .p-component:focus ~ label,
-.p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
-.p-inputgroup > .p-float-label > .p-component:focus ~ label {
+  .p-inputgroup > .p-inputwrapper > .p-inputtext:focus ~ label,
+  .p-inputgroup > .p-float-label > .p-component:focus ~ label {
     z-index: 1;
   }
-
   .p-inputgroup-addon:first-child,
-.p-inputgroup button:first-child,
-.p-inputgroup input:first-child,
-.p-inputgroup > .p-inputwrapper:first-child,
-.p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
+  .p-inputgroup button:first-child,
+  .p-inputgroup input:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child,
+  .p-inputgroup > .p-inputwrapper:first-child > .p-inputtext {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:first-child input {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-inputgroup-addon:last-child,
-.p-inputgroup button:last-child,
-.p-inputgroup input:last-child,
-.p-inputgroup > .p-inputwrapper:last-child,
-.p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
+  .p-inputgroup button:last-child,
+  .p-inputgroup input:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child,
+  .p-inputgroup > .p-inputwrapper:last-child > .p-inputtext {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-inputgroup .p-float-label:last-child input {
     border-top-right-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-fluid .p-inputgroup .p-button {
     width: auto;
   }
   .p-fluid .p-inputgroup .p-button.p-button-icon-only {
     width: 2.857rem;
   }
-
   .p-inputnumber.p-invalid.p-component > .p-inputtext {
     border-color: #f88c79;
   }
-
   .p-inputswitch {
     width: 3rem;
     height: 1.75rem;
@@ -1117,7 +1077,6 @@
   .p-inputswitch.p-invalid .p-inputswitch-slider {
     border-color: #f88c79;
   }
-
   .p-inputtext {
     font-family: var(--font-family);
     font-feature-settings: var(--font-feature-settings, normal);
@@ -1150,59 +1109,47 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-float-label > label {
     left: 0.75rem;
     color: #898989;
     transition-duration: 0.3s;
   }
-
   .p-float-label > label.p-error {
     color: #f88c79;
   }
-
   .p-input-icon-left > i:first-of-type,
-.p-input-icon-left > svg:first-of-type,
-.p-input-icon-left > .p-input-prefix {
+  .p-input-icon-left > svg:first-of-type,
+  .p-input-icon-left > .p-input-prefix {
     left: 0.75rem;
     color: #898989;
   }
-
   .p-input-icon-left > .p-inputtext {
     padding-left: 2.5rem;
   }
-
   .p-input-icon-left.p-float-label > label {
     left: 2.5rem;
   }
-
   .p-input-icon-right > i:last-of-type,
-.p-input-icon-right > svg:last-of-type,
-.p-input-icon-right > .p-input-suffix {
+  .p-input-icon-right > svg:last-of-type,
+  .p-input-icon-right > .p-input-suffix {
     right: 0.75rem;
     color: #898989;
   }
-
   .p-input-icon-right > .p-inputtext {
     padding-right: 2.5rem;
   }
-
   ::-webkit-input-placeholder {
     color: #898989;
   }
-
   :-moz-placeholder {
     color: #898989;
   }
-
   ::-moz-placeholder {
     color: #898989;
   }
-
   :-ms-input-placeholder {
     color: #898989;
   }
-
   .p-input-filled .p-inputtext {
     background-color: #f2f2f2;
   }
@@ -1212,17 +1159,14 @@
   .p-input-filled .p-inputtext:enabled:focus {
     background-color: #f2f2f2;
   }
-
   .p-inputtext-sm .p-inputtext {
     font-size: 0.875rem;
     padding: 0.4375rem 0.65625rem;
   }
-
   .p-inputtext-lg .p-inputtext {
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
-
   .p-listbox {
     background: #ffffff;
     color: #6c6c6c;
@@ -1284,7 +1228,6 @@
   .p-listbox.p-invalid {
     border-color: #f88c79;
   }
-
   .p-mention-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -1312,7 +1255,6 @@
     color: #585858;
     background: #ced6f1;
   }
-
   .p-multiselect {
     background: #ffffff;
     border: 2px solid #e1e1e1;
@@ -1362,7 +1304,6 @@
   .p-multiselect.p-invalid.p-component {
     border-color: #f88c79;
   }
-
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
     padding: 0.25rem 0.75rem;
   }
@@ -1372,7 +1313,6 @@
   .p-inputwrapper-filled.p-multiselect.p-multiselect-clearable .p-multiselect-label {
     padding-right: 1.75rem;
   }
-
   .p-multiselect-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -1458,7 +1398,6 @@
     color: #6c6c6c;
     background: transparent;
   }
-
   .p-input-filled .p-multiselect {
     background: #f2f2f2;
   }
@@ -1468,11 +1407,9 @@
   .p-input-filled .p-multiselect:not(.p-disabled).p-focus {
     background-color: #f2f2f2;
   }
-
   .p-password.p-invalid.p-component > .p-inputtext {
     border-color: #f88c79;
   }
-
   .p-password-panel {
     padding: 1rem;
     background: #ffffff;
@@ -1494,7 +1431,6 @@
   .p-password-panel .p-password-meter .p-password-strength.strong {
     background: #8bae2c;
   }
-
   .p-radiobutton {
     width: 20px;
     height: 20px;
@@ -1538,7 +1474,6 @@
   .p-radiobutton:focus {
     outline: 0 none;
   }
-
   .p-input-filled .p-radiobutton .p-radiobutton-box {
     background-color: #f2f2f2;
   }
@@ -1551,7 +1486,6 @@
   .p-input-filled .p-radiobutton .p-radiobutton-box.p-highlight:not(.p-disabled):hover {
     background: #3c5ece;
   }
-
   .p-rating {
     gap: 0.5rem;
   }
@@ -1581,7 +1515,6 @@
   .p-rating:not(.p-disabled):not(.p-readonly) .p-rating-item:hover .p-rating-icon.p-rating-cancel {
     color: #f88c79;
   }
-
   .p-selectbutton .p-button {
     background: #ffffff;
     border: 2px solid #e1e1e1;
@@ -1589,7 +1522,7 @@
     transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
   }
   .p-selectbutton .p-button .p-button-icon-left,
-.p-selectbutton .p-button .p-button-icon-right {
+  .p-selectbutton .p-button .p-button-icon-right {
     color: #898989;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1598,7 +1531,7 @@
     color: #6c6c6c;
   }
   .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-selectbutton .p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #898989;
   }
   .p-selectbutton .p-button.p-highlight {
@@ -1607,7 +1540,7 @@
     color: #585858;
   }
   .p-selectbutton .p-button.p-highlight .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight .p-button-icon-right {
     color: #585858;
   }
   .p-selectbutton .p-button.p-highlight:hover {
@@ -1616,13 +1549,12 @@
     color: #585858;
   }
   .p-selectbutton .p-button.p-highlight:hover .p-button-icon-left,
-.p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
+  .p-selectbutton .p-button.p-highlight:hover .p-button-icon-right {
     color: #585858;
   }
   .p-selectbutton.p-invalid > .p-button {
     border-color: #f88c79;
   }
-
   .p-slider {
     background: #ebebeb;
     border: 0 none;
@@ -1662,7 +1594,6 @@
     background: #5472d4;
     border-color: #5472d4;
   }
-
   .p-treeselect {
     background: #ffffff;
     border: 2px solid #e1e1e1;
@@ -1709,11 +1640,9 @@
   .p-treeselect.p-invalid.p-component {
     border-color: #f88c79;
   }
-
   .p-inputwrapper-filled.p-treeselect.p-treeselect-chip .p-treeselect-label {
     padding: 0.25rem 0.75rem;
   }
-
   .p-treeselect-panel {
     background: #ffffff;
     color: #6c6c6c;
@@ -1773,7 +1702,6 @@
     color: #6c6c6c;
     background: transparent;
   }
-
   .p-input-filled .p-treeselect {
     background: #f2f2f2;
   }
@@ -1783,7 +1711,6 @@
   .p-input-filled .p-treeselect:not(.p-disabled).p-focus {
     background-color: #f2f2f2;
   }
-
   .p-togglebutton.p-button {
     background: #ffffff;
     border: 2px solid #e1e1e1;
@@ -1791,7 +1718,7 @@
     transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s;
   }
   .p-togglebutton.p-button .p-button-icon-left,
-.p-togglebutton.p-button .p-button-icon-right {
+  .p-togglebutton.p-button .p-button-icon-right {
     color: #898989;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover {
@@ -1800,7 +1727,7 @@
     color: #6c6c6c;
   }
   .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-left,
-.p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
+  .p-togglebutton.p-button:not(.p-disabled):not(.p-highlight):hover .p-button-icon-right {
     color: #898989;
   }
   .p-togglebutton.p-button.p-highlight {
@@ -1809,7 +1736,7 @@
     color: #585858;
   }
   .p-togglebutton.p-button.p-highlight .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight .p-button-icon-right {
     color: #585858;
   }
   .p-togglebutton.p-button.p-highlight:hover {
@@ -1818,13 +1745,12 @@
     color: #585858;
   }
   .p-togglebutton.p-button.p-highlight:hover .p-button-icon-left,
-.p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
+  .p-togglebutton.p-button.p-highlight:hover .p-button-icon-right {
     color: #585858;
   }
   .p-togglebutton.p-button.p-invalid > .p-button {
     border-color: #f88c79;
   }
-
   .p-button {
     color: #ffffff;
     background: #5472d4;
@@ -1936,7 +1862,7 @@
     padding: 0.5rem 0;
   }
   .p-button.p-button-icon-only .p-button-icon-left,
-.p-button.p-button-icon-only .p-button-icon-right {
+  .p-button.p-button-icon-only .p-button-icon-right {
     margin: 0;
   }
   .p-button.p-button-icon-only.p-button-rounded {
@@ -1972,7 +1898,6 @@
   .p-button.p-button-loading-label-only .p-button-loading-icon {
     margin: 0;
   }
-
   .p-fluid .p-button {
     width: 100%;
   }
@@ -1985,7 +1910,6 @@
   .p-fluid .p-buttonset .p-button {
     flex: 1;
   }
-
   .p-button.p-button-secondary, .p-buttonset.p-button-secondary > .p-button, .p-splitbutton.p-button-secondary > .p-button, .p-fileupload-choose.p-button-secondary {
     color: #ffffff;
     background: #8191a6;
@@ -2034,7 +1958,6 @@
     border-color: transparent;
     color: #8191a6;
   }
-
   .p-button.p-button-info, .p-buttonset.p-button-info > .p-button, .p-splitbutton.p-button-info > .p-button, .p-fileupload-choose.p-button-info {
     color: #ffffff;
     background: #35a4cc;
@@ -2083,7 +2006,6 @@
     border-color: transparent;
     color: #35a4cc;
   }
-
   .p-button.p-button-success, .p-buttonset.p-button-success > .p-button, .p-splitbutton.p-button-success > .p-button, .p-fileupload-choose.p-button-success {
     color: #ffffff;
     background: #8bae2c;
@@ -2132,7 +2054,6 @@
     border-color: transparent;
     color: #8bae2c;
   }
-
   .p-button.p-button-warning, .p-buttonset.p-button-warning > .p-button, .p-splitbutton.p-button-warning > .p-button, .p-fileupload-choose.p-button-warning {
     color: #ffffff;
     background: #ff922a;
@@ -2181,7 +2102,6 @@
     border-color: transparent;
     color: #ff922a;
   }
-
   .p-button.p-button-help, .p-buttonset.p-button-help > .p-button, .p-splitbutton.p-button-help > .p-button, .p-fileupload-choose.p-button-help {
     color: #ffffff;
     background: #7654d4;
@@ -2230,7 +2150,6 @@
     border-color: transparent;
     color: #7654d4;
   }
-
   .p-button.p-button-danger, .p-buttonset.p-button-danger > .p-button, .p-splitbutton.p-button-danger > .p-button, .p-fileupload-choose.p-button-danger {
     color: #ffffff;
     background: #d45472;
@@ -2279,7 +2198,6 @@
     border-color: transparent;
     color: #d45472;
   }
-
   .p-button.p-button-link {
     color: #3c5ece;
     background: transparent;
@@ -2303,7 +2221,6 @@
     color: #3c5ece;
     border-color: transparent;
   }
-
   .p-splitbutton {
     border-radius: 6px;
   }
@@ -2385,12 +2302,11 @@
     font-size: 1.25rem;
   }
   .p-splitbutton .p-splitbutton-menubutton,
-.p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
-.p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
+  .p-splitbutton .p-splitbutton.p-button-rounded > .p-splitbutton-menubutton.p-button,
+  .p-splitbutton .p-splitbutton.p-button-outlined > .p-splitbutton-menubutton.p-button {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-
   .p-splitbutton.p-button-secondary.p-button-outlined > .p-button {
     background-color: transparent;
     color: #8191a6;
@@ -2419,7 +2335,6 @@
     border-color: transparent;
     color: #8191a6;
   }
-
   .p-splitbutton.p-button-info.p-button-outlined > .p-button {
     background-color: transparent;
     color: #35a4cc;
@@ -2448,7 +2363,6 @@
     border-color: transparent;
     color: #35a4cc;
   }
-
   .p-splitbutton.p-button-success.p-button-outlined > .p-button {
     background-color: transparent;
     color: #8bae2c;
@@ -2477,7 +2391,6 @@
     border-color: transparent;
     color: #8bae2c;
   }
-
   .p-splitbutton.p-button-warning.p-button-outlined > .p-button {
     background-color: transparent;
     color: #ff922a;
@@ -2506,7 +2419,6 @@
     border-color: transparent;
     color: #ff922a;
   }
-
   .p-splitbutton.p-button-help.p-button-outlined > .p-button {
     background-color: transparent;
     color: #7654d4;
@@ -2535,7 +2447,6 @@
     border-color: transparent;
     color: #7654d4;
   }
-
   .p-splitbutton.p-button-danger.p-button-outlined > .p-button {
     background-color: transparent;
     color: #d45472;
@@ -2564,7 +2475,6 @@
     border-color: transparent;
     color: #d45472;
   }
-
   .p-speeddial-button.p-button.p-button-icon-only {
     width: 4rem;
     height: 4rem;
@@ -2576,7 +2486,9 @@
     width: 1.3rem;
     height: 1.3rem;
   }
-
+  .p-speeddial-list {
+    outline: 0 none;
+  }
   .p-speeddial-action {
     width: 3rem;
     height: 3rem;
@@ -2587,55 +2499,48 @@
     background: #585858;
     color: #fff;
   }
-
   .p-speeddial-direction-up .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-up .p-speeddial-item:first-child {
     margin-bottom: 0.5rem;
   }
-
   .p-speeddial-direction-down .p-speeddial-item {
     margin: 0.25rem;
   }
   .p-speeddial-direction-down .p-speeddial-item:first-child {
     margin-top: 0.5rem;
   }
-
   .p-speeddial-direction-left .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
     margin-right: 0.5rem;
   }
-
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
     margin-left: 0.5rem;
   }
-
   .p-speeddial-circle .p-speeddial-item,
-.p-speeddial-semi-circle .p-speeddial-item,
-.p-speeddial-quarter-circle .p-speeddial-item {
+  .p-speeddial-semi-circle .p-speeddial-item,
+  .p-speeddial-quarter-circle .p-speeddial-item {
     margin: 0;
   }
   .p-speeddial-circle .p-speeddial-item:first-child, .p-speeddial-circle .p-speeddial-item:last-child,
-.p-speeddial-semi-circle .p-speeddial-item:first-child,
-.p-speeddial-semi-circle .p-speeddial-item:last-child,
-.p-speeddial-quarter-circle .p-speeddial-item:first-child,
-.p-speeddial-quarter-circle .p-speeddial-item:last-child {
+  .p-speeddial-semi-circle .p-speeddial-item:first-child,
+  .p-speeddial-semi-circle .p-speeddial-item:last-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:first-child,
+  .p-speeddial-quarter-circle .p-speeddial-item:last-child {
     margin: 0;
   }
-
   .p-speeddial-mask {
     background-color: rgba(0, 0, 0, 0.4);
     border-radius: 6px;
   }
-
   .p-carousel .p-carousel-content .p-carousel-prev,
-.p-carousel .p-carousel-content .p-carousel-next {
+  .p-carousel .p-carousel-content .p-carousel-next {
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -2646,13 +2551,13 @@
     margin: 0.5rem;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:enabled:hover,
-.p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
+  .p-carousel .p-carousel-content .p-carousel-next:enabled:hover {
     color: #6c6c6c;
     border-color: transparent;
     background: #edf0fA;
   }
   .p-carousel .p-carousel-content .p-carousel-prev:focus-visible,
-.p-carousel .p-carousel-content .p-carousel-next:focus-visible {
+  .p-carousel .p-carousel-content .p-carousel-next:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
@@ -2678,7 +2583,6 @@
     background: #ced6f1;
     color: #585858;
   }
-
   .p-datatable .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -2772,9 +2676,9 @@
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel {
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -2784,17 +2688,17 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:enabled:hover,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:enabled:hover {
     color: #6c6c6c;
     border-color: transparent;
     background: #edf0fA;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
-.p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-init:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save:focus-visible,
+  .p-datatable .p-datatable-tbody > tr > td .p-row-editor-cancel:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
@@ -2847,12 +2751,12 @@
     background: #5472d4;
   }
   .p-datatable .p-datatable-scrollable-header,
-.p-datatable .p-datatable-scrollable-footer {
+  .p-datatable .p-datatable-scrollable-footer {
     background: #ffffff;
   }
   .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
-.p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tfoot, .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-thead,
+  .p-datatable.p-datatable-scrollable > .p-datatable-wrapper > .p-virtualscroller > .p-datatable-table > .p-datatable-tfoot {
     background-color: #ffffff;
   }
   .p-datatable .p-datatable-loading-icon {
@@ -2962,11 +2866,9 @@
   .p-datatable.p-datatable-lg .p-datatable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-datatable-drag-selection-helper {
     background: rgba(84, 114, 212, 0.16);
   }
-
   .p-dataview .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3010,7 +2912,6 @@
     width: 2rem;
     height: 2rem;
   }
-
   .p-datascroller .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3047,12 +2948,10 @@
     border-bottom-left-radius: 6px;
     border-bottom-right-radius: 6px;
   }
-
   .p-column-filter-row .p-column-filter-menu-button,
-.p-column-filter-row .p-column-filter-clear-button {
+  .p-column-filter-row .p-column-filter-clear-button {
     margin-left: 0.5rem;
   }
-
   .p-column-filter-menu-button {
     width: 2rem;
     height: 2rem;
@@ -3080,7 +2979,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-column-filter-clear-button {
     width: 2rem;
     height: 2rem;
@@ -3100,7 +2998,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-column-filter-overlay {
     background: #ffffff;
     color: #6c6c6c;
@@ -3138,7 +3035,6 @@
     border-top: 1px solid #ebebeb;
     margin: 4px 0;
   }
-
   .p-column-filter-overlay-menu .p-column-filter-operator {
     padding: 0.5rem 1.5rem;
     border-bottom: 0 none;
@@ -3167,7 +3063,6 @@
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
     padding: 1rem;
   }
-
   .p-orderlist .p-orderlist-controls {
     padding: 1rem;
   }
@@ -3232,7 +3127,6 @@
   .p-orderlist.p-orderlist-striped .p-orderlist-list .p-orderlist-item:nth-child(even):hover {
     background: #edf0fA;
   }
-
   .p-organizationchart .p-organizationchart-node-content.p-organizationchart-selectable-node:not(.p-highlight):hover {
     background: #edf0fA;
     color: #6c6c6c;
@@ -3271,7 +3165,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-paginator {
     background: #ffffff;
     color: #898989;
@@ -3281,9 +3174,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first,
-.p-paginator .p-paginator-prev,
-.p-paginator .p-paginator-next,
-.p-paginator .p-paginator-last {
+  .p-paginator .p-paginator-prev,
+  .p-paginator .p-paginator-next,
+  .p-paginator .p-paginator-last {
     background-color: transparent;
     border: 0 none;
     color: #898989;
@@ -3294,9 +3187,9 @@
     border-radius: 6px;
   }
   .p-paginator .p-paginator-first:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
-.p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
+  .p-paginator .p-paginator-prev:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-next:not(.p-disabled):not(.p-highlight):hover,
+  .p-paginator .p-paginator-last:not(.p-disabled):not(.p-highlight):hover {
     background: #edf0fA;
     border-color: transparent;
     color: #6c6c6c;
@@ -3352,7 +3245,6 @@
     border-color: transparent;
     color: #6c6c6c;
   }
-
   .p-picklist .p-picklist-buttons {
     padding: 1rem;
   }
@@ -3411,7 +3303,6 @@
     color: #585858;
     background: #ced6f1;
   }
-
   .p-tree {
     border: 2px solid #ebebeb;
     background: #ffffff;
@@ -3467,11 +3358,11 @@
     color: #585858;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon {
     color: #585858;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-tree-toggler:hover,
-.p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
+  .p-tree .p-tree-container .p-treenode .p-treenode-content.p-highlight .p-treenode-icon:hover {
     color: #585858;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content.p-treenode-selectable:not(.p-highlight):hover {
@@ -3509,7 +3400,6 @@
   .p-tree .p-treenode-droppoint.p-treenode-droppoint-active {
     background: #889cdd;
   }
-
   .p-treetable .p-paginator-top {
     border-width: 0 0 2px 0;
     border-radius: 0;
@@ -3645,7 +3535,7 @@
     background: #5472d4;
   }
   .p-treetable .p-treetable-scrollable-header,
-.p-treetable .p-treetable-scrollable-footer {
+  .p-treetable .p-treetable-scrollable-footer {
     background: #ffffff;
   }
   .p-treetable .p-treetable-loading-icon {
@@ -3722,7 +3612,6 @@
   .p-treetable.p-treetable-lg .p-treetable-footer {
     padding: 1.25rem 1.25rem;
   }
-
   .p-timeline .p-timeline-event-marker {
     border: 2px solid #5472d4;
     border-radius: 50%;
@@ -3734,20 +3623,19 @@
     background-color: #ebebeb;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-opposite,
-.p-timeline.p-timeline-vertical .p-timeline-event-content {
+  .p-timeline.p-timeline-vertical .p-timeline-event-content {
     padding: 0 1rem;
   }
   .p-timeline.p-timeline-vertical .p-timeline-event-connector {
     width: 2px;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-opposite,
-.p-timeline.p-timeline-horizontal .p-timeline-event-content {
+  .p-timeline.p-timeline-horizontal .p-timeline-event-content {
     padding: 1rem 0;
   }
   .p-timeline.p-timeline-horizontal .p-timeline-event-connector {
     height: 2px;
   }
-
   .p-accordion .p-accordion-header .p-accordion-header-link {
     padding: 1rem;
     border: 2px solid #ebebeb;
@@ -3821,7 +3709,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-card {
     background: #ffffff;
     color: #6c6c6c;
@@ -3847,7 +3734,6 @@
   .p-card .p-card-footer {
     padding: 1rem 0 0 0;
   }
-
   .p-fieldset {
     border: 2px solid #ebebeb;
     background: #ffffff;
@@ -3888,7 +3774,6 @@
   .p-fieldset .p-fieldset-content {
     padding: 1rem;
   }
-
   .p-divider .p-divider-content {
     background-color: #ffffff;
   }
@@ -3912,7 +3797,6 @@
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
   }
-
   .p-panel .p-panel-header {
     border: 2px solid #ebebeb;
     padding: 1rem;
@@ -3962,7 +3846,6 @@
     color: #6c6c6c;
     border-top: 0 none;
   }
-
   .p-splitter {
     border: 2px solid #ebebeb;
     background: #ffffff;
@@ -3979,12 +3862,10 @@
   .p-splitter .p-splitter-gutter-resizing {
     background: #ebebeb;
   }
-
   .p-scrollpanel .p-scrollpanel-bar {
     background: #f5f5f5;
     border: 0 none;
   }
-
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #ebebeb;
@@ -4044,7 +3925,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-toolbar {
     background: #ffffff;
     border: 2px solid #ebebeb;
@@ -4055,7 +3935,6 @@
   .p-toolbar .p-toolbar-separator {
     margin: 0 0.5rem;
   }
-
   .p-confirm-popup {
     background: #ffffff;
     color: #6c6c6c;
@@ -4103,7 +3982,6 @@
   .p-confirm-popup .p-confirm-popup-message {
     margin-left: 1rem;
   }
-
   .p-dialog {
     border-radius: 6px;
     box-shadow: 0px 11px 15px -7px rgba(0, 0, 0, 0.2), 0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
@@ -4179,7 +4057,6 @@
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
     margin-left: 1rem;
   }
-
   .p-overlaypanel {
     background: #ffffff;
     color: #6c6c6c;
@@ -4221,7 +4098,6 @@
   .p-overlaypanel.p-overlaypanel-flipped:before {
     border-top-color: #ffffff;
   }
-
   .p-sidebar {
     background: #ffffff;
     color: #6c6c6c;
@@ -4232,7 +4108,7 @@
     padding: 1rem;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close,
-.p-sidebar .p-sidebar-header .p-sidebar-icon {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon {
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -4242,13 +4118,13 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:enabled:hover,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:enabled:hover {
     color: #6c6c6c;
     border-color: transparent;
     background: #edf0fA;
   }
   .p-sidebar .p-sidebar-header .p-sidebar-close:focus-visible,
-.p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
+  .p-sidebar .p-sidebar-header .p-sidebar-icon:focus-visible {
     outline: 0 none;
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
@@ -4259,7 +4135,6 @@
   .p-sidebar .p-sidebar-content {
     padding: 1rem;
   }
-
   .p-tooltip .p-tooltip-text {
     background: #585858;
     color: #ffffff;
@@ -4279,7 +4154,6 @@
   .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
     border-bottom-color: #585858;
   }
-
   .p-fileupload .p-fileupload-buttonbar {
     background: #ffffff;
     padding: 1rem;
@@ -4310,7 +4184,6 @@
   .p-fileupload.p-fileupload-advanced .p-message {
     margin-top: 0;
   }
-
   .p-breadcrumb {
     background: #ffffff;
     border: 2px solid #ebebeb;
@@ -4342,7 +4215,6 @@
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-icon {
     color: #898989;
   }
-
   .p-contextmenu {
     padding: 0.5rem 0.5rem;
     background: #ffffff;
@@ -4414,7 +4286,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-dock .p-dock-list {
     background: rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.2);
@@ -4429,32 +4300,31 @@
     height: 4rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next {
     margin: 0 0.9rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next {
     margin: 0 1.3rem;
   }
   .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current {
     margin: 0 1.5rem;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next {
     margin: 0.9rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
+  .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+  .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next {
     margin: 1.3rem 0;
   }
   .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
     margin: 1.5rem 0;
   }
-
   @media screen and (max-width: 960px) {
     .p-dock.p-dock-top .p-dock-container, .p-dock.p-dock-bottom .p-dock-container {
       overflow-x: auto;
@@ -4471,22 +4341,22 @@
       margin: auto 0;
     }
     .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
-.p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-top .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-bottom .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-left .p-dock-item-current, .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-second-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-prev,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-next,
+    .p-dock.p-dock-magnification.p-dock-right .p-dock-item-current {
       transform: none;
       margin: 0;
     }
@@ -4537,19 +4407,19 @@
     margin-left: auto;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #edf0fA;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #6c6c6c;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #898989;
   }
   .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-megamenu .p-megamenu-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #898989;
   }
   .p-megamenu .p-menuitem-link {
@@ -4719,7 +4589,6 @@
     width: 100%;
     position: static;
   }
-
   .p-menu {
     padding: 0.5rem 0.5rem;
     background: #ffffff;
@@ -4780,7 +4649,6 @@
     border-top: 1px solid #ebebeb;
     margin: 4px 0;
   }
-
   .p-menubar {
     padding: 0.5rem;
     background: #f5f5f5;
@@ -4858,19 +4726,19 @@
     box-shadow: inset 0 0 0 0.15rem #bbc7ee;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover {
     background: #edf0fA;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-text,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-text {
     color: #6c6c6c;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-menuitem-icon {
     color: #898989;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon,
-.p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
+  .p-menubar .p-menubar-root-list > .p-menuitem.p-menuitem-active > .p-menuitem-link:not(.p-disabled):hover .p-submenu-icon {
     color: #898989;
   }
   .p-menubar .p-submenu-list {
@@ -4900,7 +4768,6 @@
   .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-menuitem-icon, .p-menubar .p-menuitem.p-menuitem-active > .p-menuitem-link .p-submenu-icon {
     color: #898989;
   }
-
   @media screen and (max-width: 960px) {
     .p-menubar {
       position: relative;
@@ -5145,7 +5012,6 @@
     border-bottom-right-radius: 6px;
     border-bottom-left-radius: 6px;
   }
-
   .p-slidemenu {
     padding: 0.5rem 0.5rem;
     background: #ffffff;
@@ -5223,7 +5089,6 @@
     padding: 0.75rem 1rem;
     color: #6c6c6c;
   }
-
   .p-steps .p-steps-item .p-menuitem-link {
     background: transparent;
     transition: box-shadow 0.3s;
@@ -5268,7 +5133,6 @@
     position: absolute;
     margin-top: -1rem;
   }
-
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #ebebeb;
@@ -5309,7 +5173,6 @@
     border-color: #5472d4;
     color: #5472d4;
   }
-
   .p-tieredmenu {
     padding: 0.5rem 0.5rem;
     background: #ffffff;
@@ -5384,7 +5247,6 @@
     width: 0.875rem;
     height: 0.875rem;
   }
-
   .p-inline-message {
     padding: 0.5rem 0.75rem;
     margin: 0;
@@ -5440,7 +5302,6 @@
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
     margin-right: 0;
   }
-
   .p-message {
     margin: 1rem 0;
     border-radius: 6px;
@@ -5529,7 +5390,6 @@
   .p-message .p-message-detail {
     margin-left: 0.5rem;
   }
-
   .p-toast {
     opacity: 0.9;
   }
@@ -5540,7 +5400,6 @@
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
     margin: 0 0 0 1rem;
@@ -5580,7 +5439,7 @@
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-info .p-toast-icon-close {
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-success {
@@ -5590,7 +5449,7 @@
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-success .p-toast-icon-close {
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-warn {
@@ -5600,7 +5459,7 @@
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-warn .p-toast-icon-close {
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-error {
@@ -5610,10 +5469,9 @@
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
-.p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
+  .p-toast .p-toast-message.p-toast-message-error .p-toast-icon-close {
     color: #585858;
   }
-
   .p-galleria .p-galleria-close {
     margin: 0.5rem;
     background: transparent;
@@ -5644,11 +5502,11 @@
     margin: 0 0.5rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon {
     font-size: 2rem;
   }
   .p-galleria .p-galleria-item-nav .p-galleria-item-prev-icon.p-icon,
-.p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
+  .p-galleria .p-galleria-item-nav .p-galleria-item-next-icon.p-icon {
     width: 2rem;
     height: 2rem;
   }
@@ -5702,7 +5560,7 @@
     padding: 1rem 0.25rem;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next {
     margin: 0.5rem;
     background-color: transparent;
     color: #f5f5f5;
@@ -5712,7 +5570,7 @@
     border-radius: 50%;
   }
   .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-prev:hover,
-.p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
+  .p-galleria .p-galleria-thumbnail-container .p-galleria-thumbnail-next:hover {
     background: rgba(255, 255, 255, 0.1);
     color: #f5f5f5;
   }
@@ -5724,15 +5582,12 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-galleria-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-mask {
     --maskbg: rgba(0, 0, 0, 0.9);
   }
-
   .p-image-preview-indicator {
     background-color: transparent;
     color: #f8f9fa;
@@ -5742,15 +5597,12 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-image-preview-container:hover > .p-image-preview-indicator {
     background-color: rgba(0, 0, 0, 0.5);
   }
-
   .p-image-toolbar {
     padding: 1rem;
   }
-
   .p-image-action.p-link {
     color: #f8f9fa;
     background-color: transparent;
@@ -5774,7 +5626,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-avatar {
     background-color: #ebebeb;
     border-radius: 6px;
@@ -5795,15 +5646,12 @@
   .p-avatar.p-avatar-xl .p-avatar-icon {
     font-size: 2rem;
   }
-
   .p-avatar-circle {
     border-radius: 50%;
   }
-
   .p-avatar-group .p-avatar {
     border: 2px solid #ffffff;
   }
-
   .p-chip {
     background-color: #ebebeb;
     color: #6c6c6c;
@@ -5837,7 +5685,6 @@
   .p-chip .p-chip-remove-icon:focus {
     outline: 0 none;
   }
-
   .p-scrolltop {
     width: 3rem;
     height: 3rem;
@@ -5859,7 +5706,6 @@
     width: 1.5rem;
     height: 1.5rem;
   }
-
   .p-skeleton {
     background-color: #ebebeb;
     border-radius: 6px;
@@ -5867,7 +5713,6 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
-
   .p-tag {
     background: #5472d4;
     color: #ffffff;
@@ -5900,7 +5745,6 @@
     width: 0.75rem;
     height: 0.75rem;
   }
-
   .p-inplace .p-inplace-display {
     padding: 0.5rem 0.75rem;
     border-radius: 6px;
@@ -5915,7 +5759,6 @@
     outline-offset: 0;
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
-
   .p-progressbar {
     border: 0 none;
     height: 1.5rem;
@@ -5931,7 +5774,6 @@
     color: #ffffff;
     line-height: 1.5rem;
   }
-
   .p-terminal {
     background: #ffffff;
     color: #6c6c6c;
@@ -5943,7 +5785,6 @@
     font-feature-settings: var(--font-feature-settings, normal);
     font-size: 1rem;
   }
-
   .p-badge {
     background: #5472d4;
     color: #ffffff;
@@ -5985,7 +5826,6 @@
     height: 3rem;
     line-height: 3rem;
   }
-
   .p-tag {
     background: #5472d4;
     color: #ffffff;
@@ -6017,20 +5857,16 @@
   .p-button .p-button-label {
     font-weight: 600;
   }
-
   .p-buttonset .p-button-label,
-.p-togglebutton .p-button-label {
+  .p-togglebutton .p-button-label {
     font-weight: 400;
   }
-
   .p-carousel .p-carousel-indicators .p-carousel-indicator.p-highlight button {
     background-color: #5472d4;
   }
-
   .p-galleria .p-galleria-indicators .p-galleria-indicator.p-highlight button {
     background-color: #5472d4;
   }
-
   .p-panel {
     border: 2px solid #ebebeb;
     border-radius: 6px;
@@ -6041,11 +5877,9 @@
   .p-panel .p-panel-content {
     border: 0 none;
   }
-
   .p-fieldset .p-fieldset-legend {
     border-color: transparent;
   }
-
   .p-accordion .p-accordion-toggle-icon {
     order: 10;
     margin-left: auto;
@@ -6063,7 +5897,6 @@
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-bottom: 0 none;
   }
-
   .p-inline-message.p-inline-message-info {
     border-color: #e1f2f7;
   }
@@ -6076,39 +5909,30 @@
   .p-inline-message.p-inline-message-error {
     border-color: #f7e1e6;
   }
-
   .p-inputtext:enabled:focus {
     box-shadow: none;
   }
-
   .p-dropdown:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-multiselect:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-cascadeselect:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-autocomplete.p-autocomplete-multiple:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: none;
   }
-
   .p-orderlist .p-orderlist-list {
     border-top: 0 none;
   }
-
   .p-picklist .p-picklist-list {
     border-top: 0 none;
   }
-
   .p-panelmenu .p-panelmenu-icon.pi-chevron-right, .p-panelmenu .p-panelmenu-icon.pi-chevron-down {
     order: 10;
     margin-left: auto;
@@ -6127,7 +5951,6 @@
     padding-bottom: calc(1rem + 2px);
     border-bottom: 0 none;
   }
-
   .p-datatable .p-datatable-tbody > tr.p-datatable-dragpoint-top > td {
     box-shadow: inset 0 2px 0 0 #5472d4;
   }


### PR DESCRIPTION
Fix #5631

This is all the themes updated removing only the `border-with` in component `Toast`
You can read more about the problem here:

ISSUE: https://github.com/primefaces/primereact-sass-theme/issues/45
PR: https://github.com/primefaces/primereact-sass-theme/pull/46