### PR TITLE
Accept array as PT value

### DIFF
--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -519,13 +519,10 @@ export const ComponentBase = {
 
             const getPTClassValue = (...args) => {
                 const value = getOptionValue(...args);
-                if (Array.isArray(value)) return { className: classNames(...value) }
+                if (Array.isArray(value)) return { className: classNames(...value) };
                 if (ObjectUtils.isString(value)) return { className: value };
-                if (value?.hasOwnProperty('className') && ObjectUtils.isString(value.className)) {
-                    return { className: classNames(value.className)}
-                }
                 if (value?.hasOwnProperty('className') && Array.isArray(value.className)) {
-                    return { className: classNames(...value.className)}
+                    return { className: classNames(...value.className) };
                 }
                 return value;
             };

--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -1,7 +1,7 @@
 import PrimeReact from '../api/Api';
 import { useMountEffect, useStyle, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { mergeProps } from '../utils/MergeProps';
-import { ObjectUtils } from '../utils/Utils';
+import { ObjectUtils, classNames } from '../utils/Utils';
 
 const baseStyle = `
 .p-hidden-accessible {
@@ -519,8 +519,9 @@ export const ComponentBase = {
 
             const getPTClassValue = (...args) => {
                 const value = getOptionValue(...args);
-
-                return ObjectUtils.isString(value) ? { className: value } : value;
+                if (Array.isArray(value)) return { className: classNames(value) }
+                if (ObjectUtils.isString(value)) return { className: value };
+                return value;
             };
 
             const globalPT = searchInDefaultPT ? (isNestedParam ? _useGlobalPT(getPTClassValue, originalkey, params) : _useDefaultPT(getPTClassValue, originalkey, params)) : undefined;

--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -519,8 +519,14 @@ export const ComponentBase = {
 
             const getPTClassValue = (...args) => {
                 const value = getOptionValue(...args);
-                if (Array.isArray(value)) return { className: classNames(value) }
+                if (Array.isArray(value)) return { className: classNames(...value) }
                 if (ObjectUtils.isString(value)) return { className: value };
+                if (value?.hasOwnProperty('className') && ObjectUtils.isString(value.className)) {
+                    return { className: classNames(value.className)}
+                }
+                if (value?.hasOwnProperty('className') && Array.isArray(value.className)) {
+                    return { className: classNames(...value.className)}
+                }
                 return value;
             };
 


### PR DESCRIPTION
### Defect Fixes
PrimeReact required the use of an internal `classNames` utility for array class joining. Hoist this out so it matches the Vue implementation. Remains backwards compatible.

https://github.com/primefaces/primereact/blob/master/components/lib/passthrough/tailwind/index.js#L613
https://github.com/primefaces/primevue/blob/master/components/lib/passthrough/tailwind/index.js#L741

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
