### PR TITLE
Fix #5743: TabView default scrollbutton state

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -293,6 +293,7 @@ export const TabView = React.forwardRef((inProps, ref) => {
 
     React.useEffect(() => {
         updateInkBar();
+        updateButtonState();
     });
 
     useMountEffect(() => {


### PR DESCRIPTION
Fix #5743: TabView default scrollbutton state