### PR TITLE
Fix #5802: Allows clear filter button to render without filterMenu button

### DIFF
--- a/components/lib/datatable/ColumnFilter.js
+++ b/components/lib/datatable/ColumnFilter.js
@@ -563,10 +563,6 @@ export const ColumnFilter = React.memo((props) => {
     };
 
     const createClearButton = () => {
-        if (!showMenuButton()) {
-            return null;
-        }
-
         const filterClearIconProps = mergeProps(
             {
                 'aria-hidden': true


### PR DESCRIPTION
Fix #5802

Fixes Issue where clear button will not be rendered if menu button is not rendered. In original issue fix listed below, I think that the check implemented in this issue was unintentionally placed in the createClearButton method

In reference to this issue:
https://github.com/primefaces/primereact/issues/4994

And this commit:
https://github.com/primefaces/primereact/commit/deec2b2db26ebcfc98f56ba6b9cd2c31d6ac3b69
