### PR TITLE
Fix primefaces#5863: Calendar enabledDates fixed

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2308,8 +2308,11 @@ export const Calendar = React.memo(
             // last check for enabled dates to force dates enabled
             if (props.enabledDates) {
                 const isEnabled = props.enabledDates.some((d) => d.getFullYear() === year && d.getMonth() === month && d.getDate() === day);
-
-                isDisabled = isDisabled ? !isEnabled : isEnabled;
+                if (isEnabled) {
+                    isDisabled = false
+                } else if (!props.disabledDays && !props.disabledDates) { // disable other dates when only enabledDates are present
+                    isDisabled = true
+                }
             }
 
             return isDisabled;
@@ -2406,14 +2409,14 @@ export const Calendar = React.memo(
             let iFormat;
 
             const lookAhead = (match) => {
-                    const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
+                const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
 
-                    if (matches) {
-                        iFormat++;
-                    }
+                if (matches) {
+                    iFormat++;
+                }
 
-                    return matches;
-                },
+                return matches;
+            },
                 formatNumber = (match, value, len) => {
                     let num = '' + value;
 


### PR DESCRIPTION
@melloware there was a bug when only ```enabledDates``` is present, it would *disable* them instead of only enabling them. If only ```enabledDates```  is present, then the first two if-branches would not be entered. ```isDisabled``` would be set to ```true``` if the date is in the list of enabled dates. This would ultimately set ```isDisabled``` to true which would disable the dates.
