### PR TITLE
Fix #5872: hideOverlaysOnDocumentScrolling docs

### DIFF
--- a/components/doc/configuration/hideoverlaysdoc.js
+++ b/components/doc/configuration/hideoverlaysdoc.js
@@ -19,6 +19,14 @@ export default function MyApp({ Component }) {
         </PrimeReactProvider>
     );
 }
+
+//_app.css
+body {
+  margin: 0px;
+  min-height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
         `
     };
 
@@ -27,7 +35,7 @@ export default function MyApp({ Component }) {
             <DocSectionText {...props}>
                 <p>
                     Define behavior if the browser window is scrolled while displaying an overlay panel like a Dropdown or Calendar. Depending on your organization's accessibility needs some prefer panels to be closed on scrolling and some prefer the
-                    overlay follow the scroll. Default value is false.
+                    overlay follow the scroll. Default value is false. IMPORTANT: Your <i>document.body</i> must have <i>overflow</i> CSS on this to work properly.
                 </p>
             </DocSectionText>
             <DocSectionCode code={code} hideToggleCode import hideCodeSandbox hideStackBlitz />


### PR DESCRIPTION
Fix #5872: hideOverlaysOnDocumentScrolling docs