### PR TITLE
fix: primereact #5905, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode

### DIFF
--- a/components/lib/componentbase/ComponentBase.js
+++ b/components/lib/componentbase/ComponentBase.js
@@ -262,6 +262,7 @@ const iconStyles = `
 
 svg.p-icon {
     pointer-events: auto;
+    cursor: pointer;
 }
 
 svg.p-icon g,


### PR DESCRIPTION

### Defect Fixes
fix #5905, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode

