### PR TITLE
Improve TypeScript typings for zIndex option

### DIFF
--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -206,10 +206,10 @@ export interface APIOptions {
      */
     ripple?: boolean;
     /**
-     * ZIndexes are managed automatically to make sure layering of overlay components work seamlessly when combining multiple components. When autoZIndex is false, each group increments its zIndex within itself.
+     * ZIndexes are managed automatically to make sure layering of overlay components work seamlessly when combining multiple components. When autoZIndex is false, each group increments its zIndex within itself. Each property is optional, so when autoZIndex is enabled you can set the z-index for any component type, and the rest will be calculated automatically.
      * @defaultValue { modal: 1100, overlay: 1000, menu: 1000, tooltip: 1100, toast: 1200}
      */
-    zIndex?: ZIndexOptions;
+    zIndex?: Partial<ZIndexOptions>;
     /**
      * This option allows to direct implementation of all relevant attributes (e.g., style, classnames) within the respective HTML tag.
      */


### PR DESCRIPTION
I'm not entirely sure this change is correct, but the idea here is to change the TypeScript typings for global `zIndex` option by making all properties optional. This way you can specify the z-index for just one component type (e.g., `modal`) if that's all you need to customize.