### PR TITLE
Fix #5962: Datatable column reorder typescript def

### DIFF
--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -616,7 +616,7 @@ interface DataTableColReorderEvent {
     /**
      * Columns array after reorder.
      */
-    columns: React.ReactElement;
+    columns: Column[];
 }
 
 /**


### PR DESCRIPTION
Fix #5962: Datatable column reorder typescript def