### PR TITLE
BodyRows merge rowClassName properly #5983

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -468,7 +468,7 @@ export const BodyRow = React.memo((props) => {
         {
             role: 'row',
             tabIndex: tabIndex,
-            className: classNames(rowClassName, cx('bodyRow', { rowProps: props })),
+            className: classNames(cx('bodyRow', { rowProps: props })),
             style: style,
             onMouseDown: (e) => onMouseDown(e),
             onMouseUp: (e) => onMouseUp(e),
@@ -491,7 +491,10 @@ export const BodyRow = React.memo((props) => {
             'data-p-highlight': props.selected,
             'data-p-highlight-contextmenu': props.contextMenuSelected
         },
-        getBodyRowPTOptions('bodyRow')
+        getBodyRowPTOptions('bodyRow'),
+        {
+            className: classNames(rowClassName)
+        }
     );
 
     return <tr {...rowProps}>{content}</tr>;

--- a/components/lib/hooks/useMergeProps.js
+++ b/components/lib/hooks/useMergeProps.js
@@ -10,7 +10,7 @@ export const useMergeProps = () => {
 
     return (...props) => {
         const options = {
-            ...(context?.ptOptions?.classNameMergeFunction && { classNameMergeFunction: context.ptOptions.classNameMergeFunction })
+            classNameMergeFunction: context?.ptOptions?.classNameMergeFunction
         };
 
         return _mergeProps(props, options);

--- a/components/lib/hooks/useMergeProps.js
+++ b/components/lib/hooks/useMergeProps.js
@@ -10,7 +10,7 @@ export const useMergeProps = () => {
 
     return (...props) => {
         const options = {
-            ...(context?.ptOptions?.classNameMergeFunction && { classNameMergeFunction: context.classNameMergeFunction })
+            ...(context?.ptOptions?.classNameMergeFunction && { classNameMergeFunction: context.ptOptions.classNameMergeFunction })
         };
 
         return _mergeProps(props, options);


### PR DESCRIPTION
Fix #5983

Thanks for your quick reply and code indication @melloware,

[Even though it works](https://github.com/primefaces/primereact/issues/5983#issuecomment-1946902417)! I digged a bit and found the issue to happened elsewhere (the `mergeProps` function).

What is done in this PR:
- add the `classNameMergeFunction` props because `context.classNameMergeFunction` was undefined (and from docs it seems to be a left over of an old doc where it wasn't nested)
- re-order class by customisation: custom last so tailwind-merge works. I could keep the old line instead of `classNames(cx('bodyRow', { rowProps: props }), rowClassName)` but I think it could allow to override `bg-row-odd` but I am not sure.

This PR doesn't have test because I don't know how to write them (I am not a front end guy). I just tested by modifying the documentation example and see if it works.

before/after:
```diff
-bg-white text-gray-600 dark:bg-gray-900 transition duration-200 focus:outline focus:outline-[0.15rem] focus:outline-blue-200 focus:outline-offset-[-0.15rem] dark:text-white/80 dark:focus:outline dark:focus:outline-[0.15rem] dark:focus:outline-blue-300 dark:focus:outline-offset-[-0.15rem]`
+         text-gray-600 dark:bg-gray-900 transition duration-200 focus:outline focus:outline-[0.15rem] focus:outline-blue-200 focus:outline-offset-[-0.15rem] dark:text-white/80 dark:focus:outline dark:focus:outline-[0.15rem] dark:focus:outline-blue-300 dark:focus:outline-offset-[-0.15rem] bg-primary
```

PS: you know you can copy permalink so you can directly jumps to code
https://github.com/primefaces/primereact/blob/0083b8dea35159f6338e9cc003b4f991a067e555/components/lib/datatable/BodyRow.js#L471