### PR TITLE
Fix #6061: MultiStateCheckbox className on root element

### DIFF
--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -158,7 +158,7 @@ export const MultiStateCheckbox = React.memo(
             {
                 ref: elementRef,
                 id: props.id,
-                className: cx('root'),
+                className: classNames(props.className, cx('root')),
                 style: props.style,
                 onClick: onClick
             },


### PR DESCRIPTION
Fix #6061: MultiStateCheckbox className on root element