### PR TITLE
Fix #6101: Slider: event.value in onSlideEnd returns null on touch devices

### DIFF
--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -176,7 +176,7 @@ export const Slider = React.memo(
                     }
                 }
 
-                return false;
+                return {};
             }
 
             return {
@@ -188,13 +188,11 @@ export const Slider = React.memo(
         const setValue = (event) => {
             let handleValue;
 
-            const finger = trackFinger(event);
+            const { pageX, pageY } = trackFinger(event);
 
-            if (!finger) {
+            if (!pageX || !pageY) {
                 return;
             }
-
-            const { pageX, pageY } = finger;
 
             if (horizontal) handleValue = ((pageX - initX.current) * 100) / barWidth.current;
             else handleValue = ((initY.current + barHeight.current - pageY) * 100) / barHeight.current;

--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -163,32 +163,19 @@ export const Slider = React.memo(
             barHeight.current = elementRef.current.offsetHeight;
         };
 
-        const trackFinger = (event) => {
-            if (touchId.current !== undefined && ObjectUtils.isNotEmpty(event.changedTouches)) {
-                for (let i = 0; i < event.changedTouches.length; i += 1) {
-                    const touch = event.changedTouches[i];
-
-                    if (touch.identifier === touchId.current) {
-                        return {
-                            pageX: touch.pageX,
-                            pageY: touch.pageY
-                        };
-                    }
-                }
-
-                return {};
-            }
+        const trackTouch = (event) => {
+            const _event = Array.from(event.changedTouches ?? []).find((t) => t.identifier === touchId.current) || event;
 
             return {
-                pageX: event.pageX,
-                pageY: event.pageY
+                pageX: _event.pageX,
+                pageY: _event.pageY
             };
         };
 
         const setValue = (event) => {
             let handleValue;
 
-            const { pageX, pageY } = trackFinger(event);
+            const { pageX, pageY } = trackTouch(event);
 
             if (!pageX || !pageY) {
                 return;


### PR DESCRIPTION
Fix #6101

- The event of `touchend` does not contain `touches`
- Use `changedTouches` with reference to `MUI`
-  query via [caniuse](https://caniuse.com/?search=changedTouches) is not supported on `safari`
    -  but tested in iOS17 and iOS15.8, it worked