### PR TITLE
Fix #6111: ConfirmDialog/Popup 'content' not allowed on DIV

### DIFF
--- a/components/lib/confirmdialog/ConfirmDialogBase.js
+++ b/components/lib/confirmdialog/ConfirmDialogBase.js
@@ -23,6 +23,7 @@ export const ConfirmDialogBase = ComponentBase.extend({
         breakpoints: null,
         children: undefined,
         className: null,
+        content: null,
         defaultFocus: 'accept',
         footer: null,
         icon: null,

--- a/components/lib/confirmpopup/ConfirmPopupBase.js
+++ b/components/lib/confirmpopup/ConfirmPopupBase.js
@@ -82,6 +82,7 @@ export const ConfirmPopupBase = ComponentBase.extend({
         children: undefined,
         className: null,
         closeOnEscape: true,
+        content: null,
         defaultFocus: 'accept',
         dismissable: true,
         footer: null,


### PR DESCRIPTION
Fix #6111: ConfirmDialog 'content' not allowed on DIV