### PR TITLE
Fix #3155: DataTable Reset of vertical scroll position on select

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -296,8 +296,6 @@ export const TableBody = React.memo(
                 onSelect({ originalEvent, data, type });
             }
 
-            focusOnElement(originalEvent, true);
-
             if (props.onSelectionChange && selection !== props.selection) {
                 props.onSelectionChange({
                     originalEvent,
@@ -322,8 +320,6 @@ export const TableBody = React.memo(
 
             anchorRowIndex.current = rangeRowIndex.current;
             anchorCellIndex.current = event.cellIndex;
-
-            focusOnElement(event.originalEvent, false);
         };
 
         const selectRange = (event) => {


### PR DESCRIPTION
Fixes #3155
Fixes #5048
Fixes #6117
Fixed #4362
Fixes #3158

Removed additional line because we got the same behavior on range selection.
