### PR TITLE
Fix #6165: TabView refactor closeIcon like other icons

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -338,9 +338,15 @@ export const TabView = React.forwardRef((inProps, ref) => {
         );
         const titleElement = <span {...headerTitleProps}>{header}</span>;
         const rightIconElement = rightIcon && IconUtils.getJSXIcon(rightIcon, undefined, { props });
-        const iconClassName = 'p-tabview-close';
-        const icon = closeIcon || <TimesIcon className={iconClassName} onClick={(e) => onTabHeaderClose(e, index)} />;
-        const closableIconElement = closable ? IconUtils.getJSXIcon(icon, { className: iconClassName, onClick: (e) => onTabHeaderClose(e, index) }, { props }) : null;
+        const closeIconProps = mergeProps(
+            {
+                className: cx('tab.closeIcon'),
+                onClick: (e) => onTabHeaderClose(e, index)
+            },
+            getTabPT(tab, 'closeIcon', index)
+        );
+        const icon = closeIcon || <TimesIcon {...closeIconProps} />;
+        const closableIconElement = closable ? IconUtils.getJSXIcon(icon, { ...closeIconProps }, { props }) : null;
 
         const headerActionProps = mergeProps(
             {

--- a/components/lib/tabview/TabViewBase.js
+++ b/components/lib/tabview/TabViewBase.js
@@ -21,6 +21,7 @@ const classes = {
         header: ({ selected, disabled, headerClassName, _className }) => classNames('p-unselectable-text', { 'p-tabview-selected p-highlight': selected, 'p-disabled': disabled }, headerClassName, _className),
         headertitle: 'p-tabview-title',
         headeraction: 'p-tabview-nav-link',
+        closeIcon: 'p-tabview-close',
         content: ({ props, selected, getTabProp, tab, isSelected, shouldUseTab, index }) =>
             shouldUseTab(tab, index) && (!props.renderActiveOnly || isSelected(index)) ? classNames(getTabProp(tab, 'contentClassName'), getTabProp(tab, 'className'), 'p-tabview-panel', { 'p-hidden': !selected }) : undefined
     }


### PR DESCRIPTION
Fix #6165: TabView refactor closeIcon like other icons