### PR TITLE
Issue - #5540 -  Bugfix: fixed animations not working correctly on TRANSITION.toggleable with tailwind preset

### DIFF
--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -5,9 +5,9 @@ export const TRANSITIONS = {
         timeout: 500,
         classNames: {
             enter: 'max-h-0',
-            enterActive: '!max-h-40 overflow-hidden transition-all duration-500 ease-in-out',
-            exit: 'max-h-40',
-            exitActive: '!max-h-0 overflow-hidden transition-all duration-500 ease-in'
+            enterActive: '!max-h-[1000px] overflow-hidden transition-[max-height] duration-500 ease-in',
+            exit: 'max-h-[1000px]',
+            exitActive: '!max-h-0 overflow-hidden transition-[max-height] duration-500 ease-out'
         }
     },
     overlay: {


### PR DESCRIPTION
Fix #5540 
## Description
Tested locally with PanelMenu component, will attach a video of it working below, referenced the animation style from other components which did not use the tailwind preset, i suppose the h-40 was not enough to show more than 3 items in a list hence the cut-off in the animation. 
Also another issue that was mentioned inside the same ticket is that sometimes the close animation was a bit delayed, also fixed that with the ease-out classname for the exitActive

## Preview
https://github.com/primefaces/primereact/assets/71398993/2363d7eb-9768-4332-b263-a3ec1944387c



