### PR TITLE
Fix #6173: TreeSelect emptyMessage allow JSX content

### DIFF
--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -634,6 +634,7 @@ export const TreeSelect = React.memo(
         };
 
         const createContent = () => {
+            const message = ObjectUtils.getJSXElement(props.emptyMessage, props) || localeOption('emptyMessage');
             const emptyMessageProps = mergeProps(
                 {
                     className: cx('emptyMessage')
@@ -671,7 +672,7 @@ export const TreeSelect = React.memo(
                         __parentMetadata={{ parent: metaData }}
                     ></Tree>
 
-                    {hasNoOptions && <div {...emptyMessageProps}>{props.emptyMessage || localeOption('emptyMessage')}</div>}
+                    {hasNoOptions && <div {...emptyMessageProps}>{message}</div>}
                 </>
             );
         };

--- a/components/lib/treeselect/treeselect.d.ts
+++ b/components/lib/treeselect/treeselect.d.ts
@@ -411,8 +411,9 @@ export interface TreeSelectProps extends Omit<React.DetailedHTMLProps<React.Inpu
     dropdownIcon?: IconType<TreeSelectProps> | undefined;
     /**
      * Text to display when there is no data.
+     * @defaultValue No available options
      */
-    emptyMessage?: string | undefined;
+    emptyMessage?: React.ReactNode | ((props: TreeSelectProps) => React.ReactNode) | undefined;
     /**
      * An array of keys to represent the state of the treeselect expansion state in controlled mode.
      */


### PR DESCRIPTION
Fix #6173: TreeSelect emptyMessage allow JSX content

This makes it like all other filters like in Dropdown and AutoComplete allowing JSX content for emptyMessage