### PR TITLE
Fix #6194: Datatable rowClassName fixed

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -493,7 +493,7 @@ export const BodyRow = React.memo((props) => {
         },
         getBodyRowPTOptions('bodyRow'),
         {
-            className: rowClassName // #5983 must be last so all unstyled merging takes place first
+            className: classNames(rowClassName) // #5983 must be last so all unstyled merging takes place first
         }
     );
 


### PR DESCRIPTION
Fix #6194: Datatable rowClassName fixed