### PR TITLE
Fix #6144: MultiStateCheckbox missing styles

### DIFF
--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -158,7 +158,7 @@ export const MultiStateCheckbox = React.memo(
             {
                 ref: elementRef,
                 id: props.id,
-                className: classNames(props.className, cx('root')),
+                className: classNames(props.className, cx('root', { focusedState, selectedOption })),
                 style: props.style,
                 onClick: onClick
             },

--- a/components/lib/multistatecheckbox/MultiStateCheckboxBase.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckboxBase.js
@@ -6,14 +6,19 @@ const classes = {
         classNames('p-checkbox-icon p-c', {
             [`${icon}`]: true
         }),
-    root: ({ props }) => classNames('p-multistatecheckbox p-checkbox p-component', props.className, { 'p-checkbox-disabled': props.disabled }),
-    checkbox: ({ props, selectedOption, focusedState }) =>
+    root: ({ props, selectedOption, focusedState }) =>
+        classNames('p-multistatecheckbox p-checkbox p-component', props.className, {
+            'p-disabled': props.disabled,
+            'p-highlight': !!selectedOption,
+            'p-focus': focusedState,
+            'p-invalid': props.invalid,
+            'p-variant-filled': props.variant === 'filled'
+        }),
+    checkbox: ({ props, selectedOption }) =>
         classNames(
             'p-checkbox-box',
             {
-                'p-highlight': !!selectedOption,
-                'p-disabled': props.disabled,
-                'p-focus': focusedState
+                'p-disabled': props.disabled
             },
             selectedOption && selectedOption.className
         )


### PR DESCRIPTION
Fix #6144: MultiStateCheckbox missing styles

Focus and checked states needed to be moved up to the wrapper