### PR TITLE
Fixed dropdown filter reset when options array is empty

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -957,7 +957,6 @@ export const Dropdown = React.memo(
         }, [overlayVisibleState, filterState, props.filter]);
 
         useUpdateEffect(() => {
-          
             updateInputField();
 
             if (inputRef.current) {

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -957,10 +957,7 @@ export const Dropdown = React.memo(
         }, [overlayVisibleState, filterState, props.filter]);
 
         useUpdateEffect(() => {
-            if (filterState && (!props.options || props.options.length === 0)) {
-                setFilterState('');
-            }
-
+          
             updateInputField();
 
             if (inputRef.current) {


### PR DESCRIPTION
### Defect Fixes
Issue #6265 

Fixed Dropdown filter being reset to empty string when options array is empty after fetching data dynamically
