### PR TITLE
Fix #6285: Calendar multiple months with yearNavigator

### DIFF
--- a/components/doc/calendar/multiplemonthsdoc.js
+++ b/components/doc/calendar/multiplemonthsdoc.js
@@ -8,7 +8,7 @@ export function MultipleMonthsDoc(props) {
 
     const code = {
         basic: `
-<Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={2} />
+<Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={3} />
         `,
         javascript: `
 import React, { useState } from "react";
@@ -19,7 +19,7 @@ export default function MultipleMonthsDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={2} />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={3} />
         </div>
     )
 }
@@ -34,7 +34,7 @@ export default function MultipleMonthsDemo() {
 
     return (
         <div className="card flex justify-content-center">
-            <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={2} />
+            <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={3} />
         </div>
     )
 }
@@ -49,7 +49,7 @@ export default function MultipleMonthsDemo() {
                 </p>
             </DocSectionText>
             <div className="card flex justify-content-center">
-                <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={2} />
+                <Calendar value={date} onChange={(e) => setDate(e.value)} numberOfMonths={3} />
             </div>
             <DocSectionCode code={code} />
         </>

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3238,6 +3238,7 @@ export const Calendar = React.memo(
         const createTitleYearElement = (metaYear) => {
             const viewDate = getViewDate();
             const viewYear = viewDate.getFullYear();
+            const displayYear = props.numberOfMonths > 1 ? metaYear : currentYear;
 
             if (props.yearNavigator) {
                 let yearOptions = [];
@@ -3263,7 +3264,7 @@ export const Calendar = React.memo(
                     {
                         className: cx('select'),
                         onChange: (e) => onYearDropdownChange(e, e.target.value),
-                        value: viewYear
+                        value: displayYear
                     },
                     ptm('select')
                 );
@@ -3305,7 +3306,6 @@ export const Calendar = React.memo(
                 return content;
             }
 
-            const displayYear = props.numberOfMonths > 1 ? metaYear : currentYear;
             const yearTitleProps = mergeProps(
                 {
                     className: cx('yearTitle'),


### PR DESCRIPTION
Fix #6285: Calendar multiple months with yearNavigator

Now January has 2025

![image](https://github.com/primefaces/primereact/assets/4399574/88c57877-68c8-452e-8dca-c9c3f804e66b)
