### PR TITLE
Fix #6287 - Tree: Checkboxes use wrong color in the check mark.

### DIFF
--- a/components/lib/tree/TreeBase.js
+++ b/components/lib/tree/TreeBase.js
@@ -31,7 +31,7 @@ const classes = {
     nodeIcon: 'p-treenode-icon',
     label: 'p-treenode-label',
     subgroup: 'p-treenode-children',
-
+    checkIcon: 'p-checkbox-icon',
     emptyMessage: 'p-treenode p-tree-empty-message',
     droppoint: 'p-treenode-droppoint',
     header: 'p-tree-header',

--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -681,8 +681,11 @@ export const UITreeNode = React.memo((props) => {
         if (isCheckboxSelectionMode() && props.node.selectable !== false) {
             const checked = isChecked();
             const partialChecked = isPartialChecked();
-            const icon = checked ? props.checkboxIcon || <CheckIcon /> : partialChecked ? props.checkboxIcon || <MinusIcon /> : null;
-            const checkboxIcon = IconUtils.getJSXIcon(icon, {}, props);
+            const checkboxIconProps = mergeProps({
+                className: cx('checkIcon')
+            });
+            const icon = checked ? props.checkboxIcon || <CheckIcon {...checkboxIconProps} /> : partialChecked ? props.checkboxIcon || <MinusIcon {...checkboxIconProps} /> : null;
+            const checkboxIcon = IconUtils.getJSXIcon(icon, { ...checkboxIconProps }, props);
             const checkboxProps = mergeProps(
                 {
                     className: cx('nodeCheckbox', { partialChecked }),


### PR DESCRIPTION
Fix #6287 - Tree: Checkboxes use wrong color in the check mark.