### PR TITLE
Set key to undefined so index get correct value when creating list items

### DIFF
--- a/components/lib/autocomplete/AutoCompletePanel.js
+++ b/components/lib/autocomplete/AutoCompletePanel.js
@@ -153,7 +153,7 @@ export const AutoCompletePanel = React.memo(
                 getPTOptions(suggestion, 'item')
             );
 
-            return createListItem(suggestion, index, itemProps);
+            return createListItem(suggestion, undefined, index, itemProps);
         };
 
         const createItems = () => {


### PR DESCRIPTION
### Defect Fixes
Fix  #6308 
Set key to undefined so index get correct values in AutocompletePanel

