### PR TITLE
Fix #6333: ButtonGroup add children to Typescript

### DIFF
--- a/components/lib/buttongroup/buttongroup.d.ts
+++ b/components/lib/buttongroup/buttongroup.d.ts
@@ -55,6 +55,11 @@ export interface ButtonGroupPassThroughAttributes {
  */
 export interface ButtonGroupProps {
     /**
+     * Used to get the child elements of the component.
+     * @readonly
+     */
+    children?: React.ReactNode | undefined;
+    /**
      * Used to pass attributes to DOM elements inside the component.
      * @type {ButtonGroupPassThroughOptions}
      */


### PR DESCRIPTION
Fix #6333: ButtonGroup add children to Typescript