### PR TITLE
AutoComplete: Fix the issue of passing an undefined key while rendering lists.

### DIFF
--- a/components/lib/autocomplete/AutoCompletePanel.js
+++ b/components/lib/autocomplete/AutoCompletePanel.js
@@ -33,6 +33,10 @@ export const AutoCompletePanel = React.memo(
             return ObjectUtils.resolveFieldData(optionGroup, props.optionGroupLabel);
         };
 
+        const getOptionRenderKey = (option) => {
+            return ObjectUtils.resolveFieldData(option, props.field);
+        };
+
         const createFooter = () => {
             if (props.panelFooterTemplate) {
                 const content = ObjectUtils.getJSXElement(props.panelFooterTemplate, props, props.onOverlayHide);
@@ -145,6 +149,7 @@ export const AutoCompletePanel = React.memo(
                 );
             }
 
+            const key = `${index}_${typeof suggestion === 'object' ? getOptionRenderKey(suggestion) : suggestion}`;
             const itemProps = mergeProps(
                 {
                     style,
@@ -153,7 +158,7 @@ export const AutoCompletePanel = React.memo(
                 getPTOptions(suggestion, 'item')
             );
 
-            return createListItem(suggestion, undefined, index, itemProps);
+            return createListItem(suggestion, key, index, itemProps);
         };
 
         const createItems = () => {

--- a/components/lib/autocomplete/AutoCompletePanel.js
+++ b/components/lib/autocomplete/AutoCompletePanel.js
@@ -149,7 +149,7 @@ export const AutoCompletePanel = React.memo(
                 );
             }
 
-            const key = `${index}_${typeof suggestion === 'object' ? getOptionRenderKey(suggestion) : suggestion}`;
+            const key = `${index}_${ObjectUtils.isObject(suggestion) ? getOptionRenderKey(suggestion) : suggestion}`;
             const itemProps = mergeProps(
                 {
                     style,


### PR DESCRIPTION
It fixes the issue of key unique error. Currently, all list items are rendering with key as undefined. 

![Screenshot from 2024-04-10 10-59-34](https://github.com/primefaces/primereact/assets/23724920/8b5ed8b6-2dbe-4988-98c2-93bebda0c1b5)

Fixes https://github.com/primefaces/primereact/issues/6277
Fix #6317
Fix #6394