### PR TITLE
Add missing children prop in FloatLabel.d.ts

### DIFF
--- a/components/lib/floatlabel/FloatLabel.d.ts
+++ b/components/lib/floatlabel/FloatLabel.d.ts
@@ -50,6 +50,11 @@ export interface FloatLabelPassThroughOptions {
  */
 export interface FloatLabelProps {
     /**
+     * Used to get the child elements of the component.
+     * @readonly
+     */
+    children?: React.ReactNode | undefined;
+    /**
      * Used to pass attributes to DOM elements inside the component.
      * @type {FloatLabelPassThroughOptions}
      */


### PR DESCRIPTION
### Defect Fixes

Fixes #6387

I used the same description format as in the other components. I validated the change works by adding it to the local .d.ts file from my node_modules and it makes the example mentioned in the issue and my code compile again.