### PR TITLE
FileUpload: add missing type definition for cancelIcon

### DIFF
--- a/components/lib/fileupload/fileupload.d.ts
+++ b/components/lib/fileupload/fileupload.d.ts
@@ -66,6 +66,10 @@ export interface FileUploadPassThroughOptions {
      */
     cancelButton?: ButtonPassThroughOptions;
     /**
+     * Uses to pass attributes to the cancel icon's DOM element.
+     */
+    cancelIcon?: FileUploadPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    /**
      * Uses to pass attributes to the content's DOM element.
      */
     content?: FileUploadPassThroughType<React.HTMLAttributes<HTMLDivElement>>;


### PR DESCRIPTION
Adds missing `cancelIcon` definition for FileUpload.