### PR TITLE
Fix #6408: TreeSelect pass emptyMessage to Tree

### DIFF
--- a/components/lib/treeselect/TreeSelect.js
+++ b/components/lib/treeselect/TreeSelect.js
@@ -654,6 +654,7 @@ export const TreeSelect = React.memo(
                     <Tree
                         ref={treeRef}
                         id={listId.current}
+                        emptyMessage={props.emptyMessage}
                         expandedKeys={expandedKeys}
                         filter={props.filter}
                         filterBy={props.filterBy}


### PR DESCRIPTION
Fix #6408: TreeSelect pass emptyMessage to Tree