### PR TITLE
Fix #6095 'dialog focus display none'  

### DIFF
--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -127,17 +127,12 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         if (event.key === 'Tab') {
             event.preventDefault();
             const focusableElements = DomHandler.getFocusableElements(dialog);
-            console.log(focusableElements)
-
 
             if (focusableElements && focusableElements.length > 0) {
                 if (!document.activeElement) {
                     focusableElements[0].focus();
                 } else {
                     const focusedIndex = focusableElements.indexOf(document.activeElement);
-
-                    console.log(focusedIndex)
-                    console.log('shift key')
 
                     if (event.shiftKey) {
                         if (focusedIndex === -1 || focusedIndex === 0) {
@@ -152,11 +147,11 @@ export const Dialog = React.forwardRef((inProps, ref) => {
                         shouldBeFocused.focus()
                         let activeEl = document.activeElement;
 
-                        let passedElemetns = 0
+                        let passedElemetns = 1
 
                         //find next focusable element
                         while (activeEl !== shouldBeFocused && passedElemetns < focusableElements.length) {
-                            let nextIndex = focusedIndex + passedElemetns + 1
+                            let nextIndex = focusedIndex + passedElemetns
                             if (nextIndex > focusableElements.length - 1) {
                                 nextIndex = 0
                             }

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -143,25 +143,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
                     } else if (focusedIndex === -1 || focusedIndex === focusableElements.length - 1) {
                         focusableElements[0].focus();
                     } else {
-                        let shouldBeFocused = focusableElements[focusedIndex + 1]
-                        shouldBeFocused.focus()
-                        let activeEl = document.activeElement;
-
-                        let passedElemetns = 1
-
-                        //find next focusable element
-                        while (activeEl !== shouldBeFocused && passedElemetns < focusableElements.length) {
-                            let nextIndex = focusedIndex + passedElemetns
-                            if (nextIndex > focusableElements.length - 1) {
-                                nextIndex = 0
-                            }
-
-                            shouldBeFocused = focusableElements[nextIndex]
-                            shouldBeFocused.focus()
-                            activeEl = document.activeElement
-
-                            passedElemetns += 1
-                        }
+                        focusableElements[focusedIndex + 1].focus();
                     }
                 }
             }

--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -127,12 +127,17 @@ export const Dialog = React.forwardRef((inProps, ref) => {
         if (event.key === 'Tab') {
             event.preventDefault();
             const focusableElements = DomHandler.getFocusableElements(dialog);
+            console.log(focusableElements)
+
 
             if (focusableElements && focusableElements.length > 0) {
                 if (!document.activeElement) {
                     focusableElements[0].focus();
                 } else {
                     const focusedIndex = focusableElements.indexOf(document.activeElement);
+
+                    console.log(focusedIndex)
+                    console.log('shift key')
 
                     if (event.shiftKey) {
                         if (focusedIndex === -1 || focusedIndex === 0) {
@@ -143,7 +148,25 @@ export const Dialog = React.forwardRef((inProps, ref) => {
                     } else if (focusedIndex === -1 || focusedIndex === focusableElements.length - 1) {
                         focusableElements[0].focus();
                     } else {
-                        focusableElements[focusedIndex + 1].focus();
+                        let shouldBeFocused = focusableElements[focusedIndex + 1]
+                        shouldBeFocused.focus()
+                        let activeEl = document.activeElement;
+
+                        let passedElemetns = 0
+
+                        //find next focusable element
+                        while (activeEl !== shouldBeFocused && passedElemetns < focusableElements.length) {
+                            let nextIndex = focusedIndex + passedElemetns + 1
+                            if (nextIndex > focusableElements.length - 1) {
+                                nextIndex = 0
+                            }
+
+                            shouldBeFocused = focusableElements[nextIndex]
+                            shouldBeFocused.focus()
+                            activeEl = document.activeElement
+
+                            passedElemetns += 1
+                        }
                     }
                 }
             }

--- a/components/lib/utils/DomHandler.js
+++ b/components/lib/utils/DomHandler.js
@@ -932,7 +932,7 @@ export default class DomHandler {
         let visibleFocusableElements = [];
 
         for (let focusableElement of focusableElements) {
-            if (getComputedStyle(focusableElement).display !== 'none' && getComputedStyle(focusableElement).visibility !== 'hidden') {
+            if (getComputedStyle(focusableElement).display !== 'none' && focusableElement.offsetParent !== null && getComputedStyle(focusableElement).visibility !== 'hidden') {
                 visibleFocusableElements.push(focusableElement);
             }
         }


### PR DESCRIPTION
### Defect Fixes
Fix #6095
## Focus Loop

PR implements a loop that iterates through an array of focusable elements. It keeps trying to focus on the next element until:

* **Focus successful:** The loop successfully focuses on an element.
* **Array ends:** There are no more elements in the array.

## Note 
Works fine with deep nested focusable elements in display none parent
Without 'onKeyDown' method tab pressing functions well

## Video description: 

https://github.com/primefaces/primereact/assets/118115736/fbac77b8-1edc-4cae-90d7-edd6364a5215

