### PR TITLE
Fix #6442: TabView round scrollLeft like PrimeVue

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -260,7 +260,7 @@ export const TabView = React.forwardRef((inProps, ref) => {
         const width = DomHandler.getWidth(contentRef.current);
 
         setBackwardIsDisabledState(scrollLeft === 0);
-        setForwardIsDisabledState(scrollLeft === scrollWidth - width);
+        setForwardIsDisabledState(parseInt(scrollLeft) === scrollWidth - width);
     };
 
     const onScroll = (event) => {


### PR DESCRIPTION
Fix #6442: TabView round scrollLeft like PrimeVue