### PR TITLE
Fix/date picker value entering

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -24,7 +24,7 @@ export const Calendar = React.memo(
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
         const [idState, setIdState] = React.useState(props.id);
-        const isTypingRef = React.useRef(null);
+        const isTypingRef = React.useRef(false);
 
         const metaData = {
             props,

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -96,7 +96,7 @@ export const Calendar = React.memo(
         };
 
         const onInputBlur = (event) => {
-            !props.keepInvalid && updateInputfield(props.value);
+            updateInputfield(props.value,true)
             props.onBlur && props.onBlur(event);
             setFocusedState(false);
         };
@@ -3033,9 +3033,6 @@ export const Calendar = React.memo(
 
         useUpdateEffect(() => {
             const newDate = props.value;
-
-            console.log('newDate',props.value)
-            console.log('previous',previousValue)
 
             if (previousValue !== newDate) {
                 updateInputfield(newDate);

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -146,7 +146,6 @@ export const Calendar = React.memo(
             try {
                 
                 const value = parseValueFromString(rawValue);
-                console.log('parsed',value)
 
                 if (isValidSelection(value)) {
                     updateModel(event, value);
@@ -1787,8 +1786,6 @@ export const Calendar = React.memo(
 
                 viewStateChanged.current = true;
 
-                console.log(newValue, typeof newValue)
-
                 onChangeRef.current({
                     originalEvent: event,
                     value: newValue,
@@ -2428,7 +2425,6 @@ export const Calendar = React.memo(
         };
 
         const updateInputfield = (value,formatAlways) => {
-            console.log('updateInputfield', )
             if (!inputRef.current) {
                 return;
             }

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -144,7 +144,7 @@ export const Calendar = React.memo(
 
         const updateValueOnInput = (event, rawValue, invalidCallback) => {
             try {
-                const value = parseValueFromString(props.timeOnly ? rawValue.replace('_','') : rawValue);
+                const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
                     updateModel(event, value);
@@ -2460,7 +2460,7 @@ export const Calendar = React.memo(
             if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
                 return;
             }
-            
+
             inputRef.current.value = formattedValue;
         };
 

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -144,9 +144,10 @@ export const Calendar = React.memo(
 
         const updateValueOnInput = (event, rawValue, invalidCallback) => {
             try {
-                const value = parseValueFromString(rawValue);
+                const value = parseValueFromString(props.timeOnly ? rawValue.replace('_','') : rawValue);
 
                 if (isValidSelection(value)) {
+                    console.log('valid')
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -2464,7 +2465,8 @@ export const Calendar = React.memo(
             if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
                 return;
             }
-
+            console.log(inputRef.current.value, formattedValue)
+            
             inputRef.current.value = formattedValue;
         };
 

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -24,6 +24,7 @@ export const Calendar = React.memo(
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
         const [idState, setIdState] = React.useState(props.id);
+        const typeUpdate = React.useRef(null)
 
         const metaData = {
             props,
@@ -147,6 +148,7 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
+                    typeUpdate.current = true
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -2457,10 +2459,6 @@ export const Calendar = React.memo(
                 }
             }
 
-            if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
-                return;
-            }
-
             inputRef.current.value = formattedValue;
         };
 
@@ -3023,7 +3021,11 @@ export const Calendar = React.memo(
             const newDate = props.value;
 
             if (previousValue !== newDate) {
-                updateInputfield(newDate);
+                if (!typeUpdate.current) {
+                    updateInputfield(newDate);
+                }
+                
+                typeUpdate.current = false
 
                 // #3516 view date not updated when value set programatically
                 if (!visible && newDate) {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -147,7 +147,6 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_','') : rawValue);
 
                 if (isValidSelection(value)) {
-                    console.log('valid')
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -1779,8 +1778,6 @@ export const Calendar = React.memo(
 
         const updateModel = (event, value) => {
             if (props.onChange) {
-                const originInputValue = event.target.value;
-
                 const newValue = cloneDate(value);
 
                 viewStateChanged.current = true;
@@ -1800,8 +1797,6 @@ export const Calendar = React.memo(
                         value: newValue
                     }
                 });
-
-                event.target.value = originInputValue;
             }
         };
 
@@ -2465,7 +2460,6 @@ export const Calendar = React.memo(
             if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
                 return;
             }
-            console.log(inputRef.current.value, formattedValue)
             
             inputRef.current.value = formattedValue;
         };

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -144,7 +144,9 @@ export const Calendar = React.memo(
 
         const updateValueOnInput = (event, rawValue, invalidCallback) => {
             try {
+                
                 const value = parseValueFromString(rawValue);
+                console.log('parsed',value)
 
                 if (isValidSelection(value)) {
                     updateModel(event, value);
@@ -1778,9 +1780,14 @@ export const Calendar = React.memo(
 
         const updateModel = (event, value) => {
             if (props.onChange) {
+                
+                const originInputValue = event.target.value
+
                 const newValue = cloneDate(value);
 
                 viewStateChanged.current = true;
+
+                console.log(newValue, typeof newValue)
 
                 onChangeRef.current({
                     originalEvent: event,
@@ -1797,6 +1804,8 @@ export const Calendar = React.memo(
                         value: newValue
                     }
                 });
+
+                event.target.value = originInputValue
             }
         };
 
@@ -2418,7 +2427,8 @@ export const Calendar = React.memo(
             return true;
         };
 
-        const updateInputfield = (value) => {
+        const updateInputfield = (value,formatAlways) => {
+            console.log('updateInputfield', )
             if (!inputRef.current) {
                 return;
             }
@@ -2455,6 +2465,10 @@ export const Calendar = React.memo(
                 } catch (err) {
                     formattedValue = value;
                 }
+            }
+
+            if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
+                return
             }
 
             inputRef.current.value = formattedValue;
@@ -2997,6 +3011,7 @@ export const Calendar = React.memo(
         }, [currentView]);
 
         useUpdateEffect(() => {
+
             if (!props.onViewDateChange && !viewStateChanged.current) {
                 setValue(props.value);
             }
@@ -3004,6 +3019,7 @@ export const Calendar = React.memo(
             if (props.viewDate) {
                 updateViewDate(null, getViewDate(props.viewDate));
             }
+
         }, [props.onViewDateChange, props.value, props.viewDate]);
 
         useUpdateEffect(() => {
@@ -3017,6 +3033,9 @@ export const Calendar = React.memo(
 
         useUpdateEffect(() => {
             const newDate = props.value;
+
+            console.log('newDate',props.value)
+            console.log('previous',previousValue)
 
             if (previousValue !== newDate) {
                 updateInputfield(newDate);

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -24,7 +24,7 @@ export const Calendar = React.memo(
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
         const [idState, setIdState] = React.useState(props.id);
-        const typeUpdate = React.useRef(null);
+        const isTypingRef = React.useRef(null);
 
         const metaData = {
             props,
@@ -148,7 +148,7 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
-                    typeUpdate.current = true;
+                    isTypingRef.current = true;
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -3021,11 +3021,11 @@ export const Calendar = React.memo(
             const newDate = props.value;
 
             if (previousValue !== newDate) {
-                if (!typeUpdate.current) {
+                if (!isTypingRef.current) {
                     updateInputfield(newDate);
                 }
 
-                typeUpdate.current = false;
+                isTypingRef.current = false;
 
                 // #3516 view date not updated when value set programatically
                 if (!visible && newDate) {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -96,7 +96,7 @@ export const Calendar = React.memo(
         };
 
         const onInputBlur = (event) => {
-            updateInputfield(props.value,true)
+            updateInputfield(props.value, true);
             props.onBlur && props.onBlur(event);
             setFocusedState(false);
         };
@@ -144,7 +144,6 @@ export const Calendar = React.memo(
 
         const updateValueOnInput = (event, rawValue, invalidCallback) => {
             try {
-                
                 const value = parseValueFromString(rawValue);
 
                 if (isValidSelection(value)) {
@@ -1779,8 +1778,7 @@ export const Calendar = React.memo(
 
         const updateModel = (event, value) => {
             if (props.onChange) {
-                
-                const originInputValue = event.target.value
+                const originInputValue = event.target.value;
 
                 const newValue = cloneDate(value);
 
@@ -1802,7 +1800,7 @@ export const Calendar = React.memo(
                     }
                 });
 
-                event.target.value = originInputValue
+                event.target.value = originInputValue;
             }
         };
 
@@ -2424,7 +2422,7 @@ export const Calendar = React.memo(
             return true;
         };
 
-        const updateInputfield = (value,formatAlways) => {
+        const updateInputfield = (value, formatAlways) => {
             if (!inputRef.current) {
                 return;
             }
@@ -2464,7 +2462,7 @@ export const Calendar = React.memo(
             }
 
             if (inputRef.current.value.length === formattedValue.length - 1 && !formatAlways) {
-                return
+                return;
             }
 
             inputRef.current.value = formattedValue;
@@ -3007,7 +3005,6 @@ export const Calendar = React.memo(
         }, [currentView]);
 
         useUpdateEffect(() => {
-
             if (!props.onViewDateChange && !viewStateChanged.current) {
                 setValue(props.value);
             }
@@ -3015,7 +3012,6 @@ export const Calendar = React.memo(
             if (props.viewDate) {
                 updateViewDate(null, getViewDate(props.viewDate));
             }
-
         }, [props.onViewDateChange, props.value, props.viewDate]);
 
         useUpdateEffect(() => {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -24,7 +24,7 @@ export const Calendar = React.memo(
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
         const [idState, setIdState] = React.useState(props.id);
-        const typeUpdate = React.useRef(null)
+        const typeUpdate = React.useRef(null);
 
         const metaData = {
             props,
@@ -97,7 +97,7 @@ export const Calendar = React.memo(
         };
 
         const onInputBlur = (event) => {
-            updateInputfield(props.value, true);
+            updateInputfield(props.value);
             props.onBlur && props.onBlur(event);
             setFocusedState(false);
         };
@@ -148,7 +148,7 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
-                    typeUpdate.current = true
+                    typeUpdate.current = true;
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -2420,7 +2420,7 @@ export const Calendar = React.memo(
             return true;
         };
 
-        const updateInputfield = (value, formatAlways) => {
+        const updateInputfield = (value) => {
             if (!inputRef.current) {
                 return;
             }
@@ -3024,8 +3024,8 @@ export const Calendar = React.memo(
                 if (!typeUpdate.current) {
                     updateInputfield(newDate);
                 }
-                
-                typeUpdate.current = false
+
+                typeUpdate.current = false;
 
                 // #3516 view date not updated when value set programatically
                 if (!visible && newDate) {


### PR DESCRIPTION
Fix #6099
## Description
Now calendar can work with short date format like 2024.03.1, and on blur it will roll back to standard  date format '2024.03.01'. Similar to vueprime behaviour.