### PR TITLE
Fix #6489: add menu context to menu

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -34421,7 +34421,7 @@
                             "name": "item",
                             "optional": false,
                             "readonly": false,
-                            "type": "any",
+                            "type": "MenuItem",
                             "description": "Current menuitem"
                         },
                         {

--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -34403,6 +34403,40 @@
                             "optional": false,
                             "readonly": false,
                             "type": "MenuState"
+                        },
+                        {
+                            "name": "context",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "MenuContext"
+                        }
+                    ],
+                    "callbacks": []
+                },
+                "MenuContext": {
+                    "description": "Defines current options in Menu component.",
+                    "relatedProp": "",
+                    "props": [
+                        {
+                            "name": "item",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "any",
+                            "description": "Current menuitem"
+                        },
+                        {
+                            "name": "index",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "number",
+                            "description": "Index of the menuitem"
+                        },
+                        {
+                            "name": "parentId",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "null | string",
+                            "description": "Id of the submenu header containing the menuitem"
                         }
                     ],
                     "callbacks": []

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -29,6 +29,16 @@ export const Menu = React.memo(
             }
         });
 
+        const getMenuItemPTOptions = (key, item, index, parentId) => {
+            return ptm(key, {
+                context: {
+                    item,
+                    index,
+                    parentId
+                }
+            });
+        };
+
         useHandleStyle(MenuBase.css.styles, isUnstyled, { name: 'menu' });
         const menuRef = React.useRef(null);
         const listRef = React.useRef(null);
@@ -335,14 +345,14 @@ export const Menu = React.memo(
                 {
                     className: cx('icon')
                 },
-                ptm('icon')
+                getMenuItemPTOptions('icon', item, index, parentId)
             );
             const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props });
             const labelProps = mergeProps(
                 {
                     className: cx('label')
                 },
-                ptm('label')
+                getMenuItemPTOptions('label', item, index, parentId)
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const key = item.id || (parentId || idState) + '_' + index;
@@ -351,7 +361,7 @@ export const Menu = React.memo(
                     onClick: (event) => onItemClick(event, item, key),
                     className: cx('content')
                 },
-                ptm('content')
+                getMenuItemPTOptions('content', item, index, parentId)
             );
 
             const actionProps = mergeProps(
@@ -366,7 +376,7 @@ export const Menu = React.memo(
                     'aria-disabled': item.disabled,
                     'data-p-disabled': item.disabled
                 },
-                ptm('action')
+                getMenuItemPTOptions('action', item, index, parentId)
             );
 
             let content = (
@@ -405,7 +415,7 @@ export const Menu = React.memo(
                     'data-p-focused': focusedOptionId() === key,
                     'data-p-disabled': item.disabled || false
                 },
-                ptm('menuitem')
+                getMenuItemPTOptions('menuitem', item, index, parentId)
             );
 
             return <li {...menuitemProps}>{content}</li>;

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -332,8 +332,8 @@ export const Menu = React.memo(
             if (item.visible === false) {
                 return null;
             }
-            
-            const menuContext = {item, index, parentId}
+
+            const menuContext = { item, index, parentId };
             const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -29,14 +29,8 @@ export const Menu = React.memo(
             }
         });
 
-        const getMenuItemPTOptions = (key, item, index, parentId) => {
-            return ptm(key, {
-                context: {
-                    item,
-                    index,
-                    parentId
-                }
-            });
+        const getMenuItemPTOptions = (key, menuContext) => {
+            return ptm(key, { context: menuContext });
         };
 
         useHandleStyle(MenuBase.css.styles, isUnstyled, { name: 'menu' });
@@ -338,21 +332,22 @@ export const Menu = React.memo(
             if (item.visible === false) {
                 return null;
             }
-
+            
+            const menuContext = {item, index, parentId}
             const linkClassName = classNames('p-menuitem-link', { 'p-disabled': item.disabled });
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const iconProps = mergeProps(
                 {
                     className: cx('icon')
                 },
-                getMenuItemPTOptions('icon', item, index, parentId)
+                getMenuItemPTOptions('icon', menuContext)
             );
             const icon = IconUtils.getJSXIcon(item.icon, { ...iconProps }, { props });
             const labelProps = mergeProps(
                 {
                     className: cx('label')
                 },
-                getMenuItemPTOptions('label', item, index, parentId)
+                getMenuItemPTOptions('label', menuContext)
             );
             const label = item.label && <span {...labelProps}>{item.label}</span>;
             const key = item.id || (parentId || idState) + '_' + index;
@@ -361,7 +356,7 @@ export const Menu = React.memo(
                     onClick: (event) => onItemClick(event, item, key),
                     className: cx('content')
                 },
-                getMenuItemPTOptions('content', item, index, parentId)
+                getMenuItemPTOptions('content', menuContext)
             );
 
             const actionProps = mergeProps(
@@ -376,7 +371,7 @@ export const Menu = React.memo(
                     'aria-disabled': item.disabled,
                     'data-p-disabled': item.disabled
                 },
-                getMenuItemPTOptions('action', item, index, parentId)
+                getMenuItemPTOptions('action', menuContext)
             );
 
             let content = (
@@ -415,7 +410,7 @@ export const Menu = React.memo(
                     'data-p-focused': focusedOptionId() === key,
                     'data-p-disabled': item.disabled || false
                 },
-                getMenuItemPTOptions('menuitem', item, index, parentId)
+                getMenuItemPTOptions('menuitem', menuContext)
             );
 
             return <li {...menuitemProps}>{content}</li>;

--- a/components/lib/menu/menu.d.ts
+++ b/components/lib/menu/menu.d.ts
@@ -24,6 +24,25 @@ export declare type MenuPassThroughTransitionType = ReactCSSTransitionProps | ((
 export interface MenuPassThroughMethodOptions {
     props: MenuProps;
     state: MenuState;
+    context: MenuContext;
+}
+
+/**
+ * Defines current options in Menu component.
+ */
+export interface MenuContext {
+    /**
+     * Current menuitem
+     */
+    item: any;
+    /**
+     * Index of the menuitem
+     */
+    index: number;
+    /**
+     * Id of the submenu header containing the menuitem
+     */
+    parentId: string | null;
 }
 
 /**

--- a/components/lib/menu/menu.d.ts
+++ b/components/lib/menu/menu.d.ts
@@ -34,7 +34,7 @@ export interface MenuContext {
     /**
      * Current menuitem
      */
-    item: any;
+    item: MenuItem;
     /**
      * Index of the menuitem
      */


### PR DESCRIPTION
As discussed [here](https://github.com/orgs/primefaces/discussions/1728), adds a MenuContext to the Menu so that individual menu items can be customized via the Pass Through options, mirroring the behavior of the Tab Menu. 

Can the maintainers take a look and open an issue for this feature?'

Fix #6489
