### PR TITLE
Fix #6508: remove unused codes

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -452,10 +452,6 @@ export const AutoComplete = React.memo(
             return props.value ? props.value.some((v) => ObjectUtils.equals(v, val)) : false;
         };
 
-        const findOptionIndex = (option) => {
-            return props.suggestions ? props.suggestions.findIndex((s) => ObjectUtils.equals(s, option)) : -1;
-        };
-
         const getScrollableElement = () => {
             return overlayRef.current.firstChild;
         };

--- a/components/lib/autocomplete/AutoCompletePanel.js
+++ b/components/lib/autocomplete/AutoCompletePanel.js
@@ -98,7 +98,7 @@ export const AutoCompletePanel = React.memo(
             );
         };
 
-        const createGroupChildren = (optionGroup, i, style) => {
+        const createGroupChildren = (optionGroup, i) => {
             const groupChildren = props.getOptionGroupChildren(optionGroup);
 
             return groupChildren.map((item, j) => {


### PR DESCRIPTION
Fix #6508: remove unused codes

I formatted the `TemplateLicence.js` too.