### PR TITLE
Fix #5147: Check meta key for MacOS

### DIFF
--- a/components/lib/keyfilter/KeyFilter.js
+++ b/components/lib/keyfilter/KeyFilter.js
@@ -34,7 +34,7 @@ export const KeyFilter = {
             return;
         }
 
-        if (e.ctrlKey || e.altKey) {
+        if (e.ctrlKey || e.altKey || e.metaKey) {
             return;
         }
 


### PR DESCRIPTION
### Defect Fixes

Fix #5147: We should check e.metaKey for MacOS to unlock copy/cut/paste/select all by pressing combinations with command (like `⌘+C`, `⌘+X`, `⌘+V`, `⌘+A` etc).

MDN: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey