### PR TITLE
Fix #6610: MeterGroup render items in percentage

### DIFF
--- a/components/lib/metergroup/MeterGroup.js
+++ b/components/lib/metergroup/MeterGroup.js
@@ -126,12 +126,13 @@ export const MeterGroup = (inProps) => {
                     );
 
                     const labelIcon = item.icon ? <i {...labelIconProps} /> : <span {...labelListIconProps} />;
+                    const itemPercentage = calculatePercentage(item.value);
 
                     return (
                         <li key={index} {...labelItemProps}>
                             {labelIcon}
                             <span {...labelProps}>
-                                {item?.label} {item?.value && `(${item?.value}%)`}
+                                {item?.label} {`(${itemPercentage}%)`}
                             </span>
                         </li>
                     );


### PR DESCRIPTION
Fix #6610: MeterGroup render items in percentage