### PR TITLE
Feat #6589 return option when optionValue is empty

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -890,7 +890,7 @@ export const Dropdown = React.memo(
         };
 
         const getOptionValue = (option) => {
-            return props.optionValue ? ObjectUtils.resolveFieldData(option, props.optionValue) : ObjectUtils.resolveFieldData(option, 'value') || option;
+            return props.optionValue ? ObjectUtils.resolveFieldData(option, props.optionValue) : option;
         };
 
         const getOptionRenderKey = (option) => {


### PR DESCRIPTION
### Defect Fixes
Fix #6589

Similar to primevue, returns the entire option object if the desired optionValue is missing