### PR TITLE
Fix #6657 BodyRow tab key handling

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -269,7 +269,7 @@ export const BodyRow = React.memo((props) => {
                 focusedItem && focusedItem !== firstSelectedRow && (focusedItem.tabIndex = '-1');
             } else {
                 rows[0].tabIndex = '0';
-                focusedItem !== rows[0] && (rows[rowIndex].tabIndex = '-1');
+                focusedItem !== rows[0] && (rows[props.rowIndex].tabIndex = '-1');
             }
         }
     };


### PR DESCRIPTION
Fix [#6657](https://github.com/primefaces/primereact/issues/6657) by adding the missing "props"