### PR TITLE
fix: emptyMessage prop and default label in unstyled mode

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1109,7 +1109,7 @@ export const Dropdown = React.memo(
                 return <input {...inputProps} />;
             }
 
-            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || 'empty';
+            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || props.emptyMessage || '';
             const inputProps = mergeProps(
                 {
                     ref: inputRef,
@@ -1119,7 +1119,7 @@ export const Dropdown = React.memo(
                 ptm('input')
             );
 
-            return <span {...inputProps}>{content}</span>;
+            return <span {...inputProps}>{content || <>&nbsp;</>}</span>;
         };
 
         const onClearIconKeyDown = (event) => {

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1119,7 +1119,7 @@ export const Dropdown = React.memo(
                 ptm('input')
             );
 
-            return <span {...inputProps}>{content || <>&nbsp;</>}</span>;
+            return <span {...inputProps}>{content}</span>;
         };
 
         const onClearIconKeyDown = (event) => {

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1109,7 +1109,7 @@ export const Dropdown = React.memo(
                 return <input {...inputProps} />;
             }
 
-            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || props.emptyMessage || '';
+            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || props.emptyMessage || <>&nbsp;</>;
             const inputProps = mergeProps(
                 {
                     ref: inputRef,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "primereact",
     "private": false,
-    "version": "10.6.5",
+    "version": "10.6.6",
     "scripts": {
         "dev": "next dev",
         "start": "next start",


### PR DESCRIPTION
### Defect Fixes
Fix #6671 

When no emptyMessage is defined and no option is selected the component internally use a `&nbsp;` so it not loses its height.

Without `&nbsp;`:
![without nbsp](https://github.com/primefaces/primereact/assets/17519714/9f5aeee4-c12b-4fae-ad4e-e93235189970)

With `&nbsp;`:
![with nbsp](https://github.com/primefaces/primereact/assets/17519714/2b01928d-1df6-4169-b936-9947c0f8b000)
