### PR TITLE
Fix #6291 Checkbox: Component fail to render when

### DIFF
--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -12,8 +12,12 @@ export const Checkbox = React.memo(
         const mergeProps = useMergeProps();
         const context = React.useContext(PrimeReactContext);
         const props = CheckboxBase.getProps(inProps, context);
+        const [focusedState, setFocusedState] = React.useState(false);
         const { ptm, cx, isUnstyled } = CheckboxBase.setMetaData({
             props,
+            state: {
+                focused: focusedState
+            },
             context: {
                 checked: props.checked === props.trueValue,
                 disabled: props.disabled
@@ -68,10 +72,12 @@ export const Checkbox = React.memo(
         };
 
         const onFocus = () => {
+            setFocusedState(true);
             props?.onFocus?.();
         };
 
         const onBlur = () => {
+            setFocusedState(false);
             props?.onBlur?.();
         };
 

--- a/components/lib/checkbox/checkbox.d.ts
+++ b/components/lib/checkbox/checkbox.d.ts
@@ -23,6 +23,7 @@ export declare type CheckboxPassThroughType<T> = PassThroughType<T, CheckboxPass
 export interface CheckboxPassThroughMethodOptions {
     props: CheckboxProps;
     context: CheckboxContext;
+    state: CheckboxState;
 }
 
 /**
@@ -72,6 +73,17 @@ export interface CheckboxContext {
      * @defaultValue false
      */
     disabled: boolean;
+}
+
+/**
+ * Defines current inline state in Checkbox component.
+ */
+export interface CheckboxState {
+    /**
+     * Current focused state as a boolean.
+     * @defaultValue false
+     */
+    focused: boolean;    
 }
 
 /**


### PR DESCRIPTION
 Fix [#6291](https://github.com/primefaces/primereact/issues/6291) Checkbox: Component fail to render when using the state on pt property #6291 

This pull request addresses a bug in the component rendering process that was causing an exception and breaking the page when the “pt” property had any state related.