### PR TITLE
Fix: Datatable radiobuttons and types

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -13155,7 +13155,7 @@
                             "name": "filterOperatorDropdown",
                             "optional": true,
                             "readonly": false,
-                            "type": "DropdownPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLDivElement>>",
                             "description": "Uses to pass attributes to the Dropdown component."
                         },
                         {
@@ -13176,7 +13176,7 @@
                             "name": "filterMatchModeDropdown",
                             "optional": true,
                             "readonly": false,
-                            "type": "DropdownPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLDivElement>>",
                             "description": "Uses to pass attributes to the Dropdown component."
                         },
                         {
@@ -13190,7 +13190,7 @@
                             "name": "filterRemoveButton",
                             "optional": true,
                             "readonly": false,
-                            "type": "DropdownPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLButtonElement>>",
                             "description": "Uses to pass attributes to the Button component."
                         },
                         {
@@ -13204,7 +13204,7 @@
                             "name": "filterAddRuleButton",
                             "optional": true,
                             "readonly": false,
-                            "type": "DropdownPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLButtonElement>>",
                             "description": "Uses to pass attributes to the Button component."
                         },
                         {
@@ -13218,14 +13218,14 @@
                             "name": "filterClearButton",
                             "optional": true,
                             "readonly": false,
-                            "type": "ButtonPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLButtonElement>>",
                             "description": "Uses to pass attributes to the Button component."
                         },
                         {
                             "name": "filterApplyButton",
                             "optional": true,
                             "readonly": false,
-                            "type": "ButtonPassThroughOptions",
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLButtonElement>>",
                             "description": "Uses to pass attributes to the Button component."
                         },
                         {
@@ -13234,6 +13234,13 @@
                             "readonly": false,
                             "type": "ColumnPassThroughType<HTMLAttributes<HTMLTableCellElement>>",
                             "description": "Uses to pass attributes to the body cell's DOM element."
+                        },
+                        {
+                            "name": "footerCell",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLTableCellElement>>",
+                            "description": "Uses to pass attributes to the footer cell's DOM element."
                         },
                         {
                             "name": "rowGroupToggler",
@@ -13325,6 +13332,41 @@
                             "readonly": false,
                             "type": "ColumnPassThroughType<HTMLAttributes<HTMLSpanElement> | SVGProps<SVGSVGElement>>",
                             "description": "Uses to pass attributes to the row editor cancel icon's DOM element."
+                        },
+                        {
+                            "name": "rowReorderIcon",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLSpanElement> | SVGProps<SVGSVGElement>>",
+                            "description": "Uses to pass attributes to the row reorder icon's DOM element."
+                        },
+                        {
+                            "name": "radioButton",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLDivElement>>",
+                            "description": "Uses to pass attributes to the row radiobutton wrapper's DOM element."
+                        },
+                        {
+                            "name": "radioButtonInput",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLInputElement>>",
+                            "description": "Uses to pass attributes to the row radiobutton input's DOM element."
+                        },
+                        {
+                            "name": "radioButtonBox",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLDivElement>>",
+                            "description": "Uses to pass attributes to the row radiobutton box's DOM element."
+                        },
+                        {
+                            "name": "radioButtonIcon",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "ColumnPassThroughType<HTMLAttributes<HTMLDivElement>>",
+                            "description": "Uses to pass attributes to the row radiobutton icon's DOM element."
                         },
                         {
                             "name": "hooks",

--- a/components/doc/datatable/theming/tailwinddoc.js
+++ b/components/doc/datatable/theming/tailwinddoc.js
@@ -219,25 +219,38 @@ const Tailwind = {
                     'dark:text-white/70' // Dark Mode
                 )
             },
-            radiobuttonwrapper: {
+            radioButton: {
                 className: classNames('relative inline-flex cursor-pointer select-none align-bottom', 'w-6 h-6')
             },
-            radiobutton: ({ context }) => ({
+            radioButtonInput: {
                 className: classNames(
-                    'flex justify-center items-center',
-                    'border-2 w-6 h-6 text-gray-700 rounded-full transition duration-200 ease-in-out',
-                    context.checked ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400' : 'border-gray-300 bg-white dark:border-blue-900/40 dark:bg-gray-900',
-                    {
-                        'hover:border-blue-500 dark:hover:border-blue-400 focus:outline-none focus:outline-offset-0 focus:shadow-[0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]': !context.disabled,
-                        'cursor-default opacity-60': context.disabled
-                    }
+                    'w-full h-full top-0 left-0 absolute appearance-none select-none',
+                    'p-0 m-0 opacity-0 z-[1] rounded-[50%] outline-none',
+                    'cursor-pointer peer'
                 )
+            },
+            radioButtonBox: ({ context }) => ({
+                className: classNames(
+                    'flex items-center justify-center',
+                    'h-6 w-6 rounded-full border-2 text-gray-700 transition duration-200 ease-in-out',
+                    context.checked
+                        ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400 peer-hover:bg-blue-700 peer-hover:border-blue-700'
+                        : 'border-gray-300 bg-white dark:border-blue-900/40 dark:bg-gray-900 peer-hover:border-blue-500',
+                    {
+                        'hover:border-blue-500 focus:shadow-input-focus focus:outline-none focus:outline-offset-0 dark:hover:border-blue-400 dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]': !context.disabled,
+                        'cursor-default opacity-60': context.disabled,
+                    },
+                ),
             }),
-            radiobuttonicon: ({ context }) => ({
-                className: classNames('transform rounded-full', 'block w-3 h-3 transition duration-200 bg-white dark:bg-gray-900', {
-                    'backface-hidden scale-10 invisible': context.checked === false,
-                    'transform scale-100 visible': context.checked === true
-                })
+            radioButtonIcon: ({ context }) => ({
+                className: classNames(
+                    'transform rounded-full',
+                    'block h-3 w-3 bg-white transition duration-200 dark:bg-gray-900',
+                    {
+                        'backface-hidden scale-10 invisible': context.checked === false,
+                        'visible scale-100 transform': context.checked === true,
+                    },
+                ),
             }),
             headercheckboxwrapper: {
                 className: classNames('cursor-pointer inline-flex relative select-none align-bottom', 'w-6 h-6')

--- a/components/lib/column/column.d.ts
+++ b/components/lib/column/column.d.ts
@@ -10,10 +10,8 @@
  */
 import * as React from 'react';
 import { FilterMatchMode } from '../api/api';
-import { ButtonPassThroughOptions } from '../button/button';
 import { ComponentHooks } from '../componentbase/componentbase';
 import { DataTablePassThroughOptions } from '../datatable/datatable';
-import { DropdownPassThroughOptions } from '../dropdown/dropdown';
 import { PassThroughOptions } from '../passthrough';
 import { TooltipOptions } from '../tooltip/tooltipoptions';
 import { IconType, PassThroughType } from '../utils/utils';
@@ -208,9 +206,8 @@ export interface ColumnPassThroughOptions {
     filterOperator?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the Dropdown component.
-     * @see {@link DropdownPassThroughOptions}
      */
-    filterOperatorDropdown?: DropdownPassThroughOptions;
+    filterOperatorDropdown?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the filter constraints' DOM element.
      */
@@ -221,45 +218,44 @@ export interface ColumnPassThroughOptions {
     filterConstraint?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the Dropdown component.
-     * @see {@link DropdownPassThroughOptions}
      */
-    filterMatchModeDropdown?: DropdownPassThroughOptions;
+    filterMatchModeDropdown?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the filter remove button container's DOM element.
      */
     filterRemove?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the Button component.
-     * @see {@link DropdownPassThroughOptions}
      */
-    filterRemoveButton?: DropdownPassThroughOptions;
+    filterRemoveButton?: ColumnPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
     /**
      * Uses to pass attributes to the filter add rule's DOM element.
      */
     filterAddRule?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the Button component.
-     * @see {@link DropdownPassThroughOptions}
      */
-    filterAddRuleButton?: DropdownPassThroughOptions;
+    filterAddRuleButton?: ColumnPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
     /**
      * Uses to pass attributes to the filter buttonbar's DOM element.
      */
     filterButtonbar?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Uses to pass attributes to the Button component.
-     * @see {@link ButtonPassThroughOptions}
      */
-    filterClearButton?: ButtonPassThroughOptions;
+    filterClearButton?: ColumnPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
     /**
      * Uses to pass attributes to the Button component.
-     * @see {@link ButtonPassThroughOptions}
      */
-    filterApplyButton?: ButtonPassThroughOptions;
+    filterApplyButton?: ColumnPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
     /**
      * Uses to pass attributes to the body cell's DOM element.
      */
     bodyCell?: ColumnPassThroughType<React.HTMLAttributes<HTMLTableCellElement>>;
+    /**
+     * Uses to pass attributes to the footer cell's DOM element.
+     */
+    footerCell?: ColumnPassThroughType<React.HTMLAttributes<HTMLTableCellElement>>;
     /**
      * Uses to pass attributes to the rowgroup toggler's DOM element.
      */
@@ -312,6 +308,26 @@ export interface ColumnPassThroughOptions {
      * Uses to pass attributes to the row editor cancel icon's DOM element.
      */
     rowEditorCancelIcon?: ColumnPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    /**
+     * Uses to pass attributes to the row reorder icon's DOM element.
+     */
+    rowReorderIcon?: ColumnPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    /**
+     * Uses to pass attributes to the row radiobutton wrapper's DOM element.
+     */
+    radioButton?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
+    /**
+     * Uses to pass attributes to the row radiobutton input's DOM element.
+     */
+    radioButtonInput?: ColumnPassThroughType<React.HTMLAttributes<HTMLInputElement>>;
+    /**
+     * Uses to pass attributes to the row radiobutton box's DOM element.
+     */
+    radioButtonBox?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
+    /**
+     * Uses to pass attributes to the row radiobutton icon's DOM element.
+     */
+    radioButtonIcon?: ColumnPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
      * Used to manage all lifecycle hooks
      * @see {@link ComponentHooks}

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -617,6 +617,7 @@ export const BodyCell = React.memo((props) => {
                             ariaLabel={label}
                             ptCallbacks={props.ptCallbacks}
                             metaData={props.metaData}
+                            unstyled={props.unstyled}
                         />
                     )}
                     {selectionMode === 'multiple' && (
@@ -631,6 +632,7 @@ export const BodyCell = React.memo((props) => {
                             checkIcon={props.checkIcon}
                             ptCallbacks={props.ptCallbacks}
                             metaData={props.metaData}
+                            unstyled={props.unstyled}
                         />
                     )}
                 </>

--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -456,6 +456,7 @@ export const BodyRow = React.memo((props) => {
                         virtualScrollerOptions={props.virtualScrollerOptions}
                         ptCallbacks={props.ptCallbacks}
                         metaData={props.metaData}
+                        unstyled={props.unstyled}
                     />
                 );
             }

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { getStorage } from '../../utils/utils';
 import PrimeReact, { FilterMatchMode, FilterOperator, FilterService, PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { useHandleStyle } from '../componentbase/ComponentBase';
@@ -13,7 +14,6 @@ import { DataTableBase } from './DataTableBase';
 import { TableBody } from './TableBody';
 import { TableFooter } from './TableFooter';
 import { TableHeader } from './TableHeader';
-import { getStorage } from '../../utils/utils';
 
 export const DataTable = React.forwardRef((inProps, ref) => {
     const context = React.useContext(PrimeReactContext);
@@ -1533,7 +1533,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 },
                 ptCallbacks.ptm('loadingIcon')
             );
-            const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin />;
+            const icon = props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin unstyled={props.unstyled} />;
             const loadingIcon = IconUtils.getJSXIcon(icon, { ...loadingIconProps }, { props });
             const loadingOverlayProps = mergeProps(
                 {
@@ -1707,6 +1707,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 virtualScrollerOptions={options}
                 ptCallbacks={ptCallbacks}
                 metaData={metaData}
+                unstyled={props.unstyled}
             />
         );
         const body = (
@@ -1792,10 +1793,11 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 virtualScrollerOptions={options}
                 ptCallbacks={ptCallbacks}
                 metaData={metaData}
+                unstyled={props.unstyled}
             />
         );
         const spacerBody = ObjectUtils.isNotEmpty(spacerStyle) ? (
-            <TableBody hostName="DataTable" style={{ height: `calc(${spacerStyle.height} - ${rows.length * itemSize}px)` }} className="p-datatable-virtualscroller-spacer" ptCallbacks={ptCallbacks} metaData={metaData} />
+            <TableBody hostName="DataTable" style={{ height: `calc(${spacerStyle.height} - ${rows.length * itemSize}px)` }} className="p-datatable-virtualscroller-spacer" ptCallbacks={ptCallbacks} metaData={metaData} unstyled={props.unstyled} />
         ) : null;
 
         return (
@@ -1810,7 +1812,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const createTableFooter = (options) => {
         const { columns } = options;
 
-        return <TableFooter hostName="DataTable" tableProps={props} columns={columns} footerColumnGroup={props.footerColumnGroup} ptCallbacks={ptCallbacks} metaData={metaData} />;
+        return <TableFooter hostName="DataTable" tableProps={props} columns={columns} footerColumnGroup={props.footerColumnGroup} ptCallbacks={ptCallbacks} metaData={metaData} unstyled={props.unstyled} />;
     };
 
     const createContent = (processedData, columns, selectionModeInColumn, empty) => {
@@ -1844,6 +1846,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                     pt={ptCallbacks.ptm('virtualScroller')}
                     __parentMetadata={{ parent: metaData }}
                     showSpacer={false}
+                    unstyled={props.unstyled}
                     contentTemplate={(options) => {
                         const ref = (el) => {
                             tableRef.current = el;

--- a/components/lib/datatable/HeaderCell.js
+++ b/components/lib/datatable/HeaderCell.js
@@ -303,7 +303,7 @@ export const HeaderCell = React.memo((props) => {
         if (props.showSelectAll && getColumnProp('selectionMode') === 'multiple' && props.filterDisplay !== 'row') {
             const allRowsSelected = props.allRowsSelected(props.value);
 
-            return <HeaderCheckbox hostName={props.hostName} checked={allRowsSelected} onChange={props.onColumnCheckboxChange} disabled={props.empty} ptCallbacks={ptCallbacks} metaData={parentMetaData} />;
+            return <HeaderCheckbox hostName={props.hostName} checked={allRowsSelected} onChange={props.onColumnCheckboxChange} disabled={props.empty} ptCallbacks={ptCallbacks} metaData={parentMetaData} unstyled={props.unstyled} />;
         }
 
         return null;

--- a/components/lib/datatable/RowRadioButton.js
+++ b/components/lib/datatable/RowRadioButton.js
@@ -37,7 +37,10 @@ export const RowRadioButton = React.memo((props) => {
             checked: props.checked,
             disabled: props.disabled,
             name: `${props.tableSelector}_dt_radio`,
-            onChange: onChange
+            onChange: onChange,
+            input: getColumnPTOptions('radiobuttoninput'),
+            box: getColumnPTOptions('radiobuttonbox'),
+            icon: getColumnPTOptions('radiobuttonicon'),
             unstyled: props.unstyled
         },
         getColumnPTOptions('radiobutton')

--- a/components/lib/datatable/RowRadioButton.js
+++ b/components/lib/datatable/RowRadioButton.js
@@ -38,6 +38,7 @@ export const RowRadioButton = React.memo((props) => {
             disabled: props.disabled,
             name: `${props.tableSelector}_dt_radio`,
             onChange: onChange
+            unstyled: props.unstyled
         },
         getColumnPTOptions('radiobutton')
     );

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -943,6 +943,7 @@ export const TableBody = React.memo(
                         collapsedRowIcon={props.collapsedRowIcon}
                         ptCallbacks={props.ptCallbacks}
                         metaData={props.metaData}
+                        unstyled={props.unstyled}
                     />
                 );
                 const options = { index: rowIndex, props: props.tableProps, customRendering: false };
@@ -1068,6 +1069,7 @@ export const TableBody = React.memo(
                         virtualScrollerOptions={props.virtualScrollerOptions}
                         ptCallbacks={props.ptCallbacks}
                         metaData={props.metaData}
+                        unstyled={props.unstyled}
                     />
                 );
             }

--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -3382,24 +3382,33 @@ const Tailwind = {
                     'dark:text-white/70' // Dark Mode
                 )
             },
-            radiobuttonwrapper: {
+            radioButton: {
                 className: classNames('relative inline-flex cursor-pointer select-none align-bottom', 'w-6 h-6')
             },
-            radiobutton: ({ context }) => ({
+            radioButtonInput: {
                 className: classNames(
-                    'flex justify-center items-center',
-                    'border-2 w-6 h-6 text-gray-700 rounded-full transition duration-200 ease-in-out',
-                    context.checked ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400' : 'border-gray-300 bg-white dark:border-blue-900/40 dark:bg-gray-900',
+                    'w-full h-full top-0 left-0 absolute appearance-none select-none',
+                    'p-0 m-0 opacity-0 z-[1] rounded-[50%] outline-none',
+                    'cursor-pointer peer'
+                )
+            },
+            radioButtonBox: ({ context }) => ({
+                className: classNames(
+                    'flex items-center justify-center',
+                    'h-6 w-6 rounded-full border-2 text-gray-700 transition duration-200 ease-in-out',
+                    context.checked
+                        ? 'border-blue-500 bg-blue-500 dark:border-blue-400 dark:bg-blue-400 peer-hover:bg-blue-700 peer-hover:border-blue-700'
+                        : 'border-gray-300 bg-white dark:border-blue-900/40 dark:bg-gray-900 peer-hover:border-blue-500',
                     {
-                        'hover:border-blue-500 dark:hover:border-blue-400 focus:outline-none focus:outline-offset-0 focus:shadow-[0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]': !context.disabled,
+                        'hover:border-blue-500 focus:shadow-input-focus focus:outline-none focus:outline-offset-0 dark:hover:border-blue-400 dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]': !context.disabled,
                         'cursor-default opacity-60': context.disabled
                     }
                 )
             }),
-            radiobuttonicon: ({ context }) => ({
-                className: classNames('transform rounded-full', 'block w-3 h-3 transition duration-200 bg-white dark:bg-gray-900', {
+            radioButtonIcon: ({ context }) => ({
+                className: classNames('transform rounded-full', 'block h-3 w-3 bg-white transition duration-200 dark:bg-gray-900', {
                     'backface-hidden scale-10 invisible': context.checked === false,
-                    'transform scale-100 visible': context.checked === true
+                    'visible scale-100 transform': context.checked === true
                 })
             }),
             headercheckboxwrapper: {

--- a/components/lib/radiobutton/RadioButton.js
+++ b/components/lib/radiobutton/RadioButton.js
@@ -116,9 +116,13 @@ export const RadioButton = React.memo(
                 style: props.style,
                 'data-p-checked': props.checked
             },
-            RadioButtonBase.getOtherProps(props),
+            otherProps,
             ptm('root')
         );
+
+        delete rootProps.input;
+        delete rootProps.box;
+        delete rootProps.icon;
 
         const createInputElement = () => {
             const ariaProps = ObjectUtils.reduceKeys(otherProps, DomHandler.ARIA_PROPS);
@@ -135,10 +139,11 @@ export const RadioButton = React.memo(
                     readOnly: props.readonly,
                     required: props.required,
                     tabIndex: props.tabIndex,
-                    className: cx('input'),
+                    className: cx('radiobuttoninput'),
                     ...ariaProps
                 },
-                ptm('input')
+                inProps.input,
+                ptm('radiobuttoninput')
             );
 
             return <input ref={inputRef} {...inputProps} />;
@@ -147,16 +152,18 @@ export const RadioButton = React.memo(
         const createBoxElement = () => {
             const boxProps = mergeProps(
                 {
-                    className: cx('box')
+                    className: cx('radiobuttonbox')
                 },
-                ptm('box')
+                inProps.box,
+                ptm('radiobuttonbox')
             );
 
             const iconProps = mergeProps(
                 {
-                    className: cx('icon')
+                    className: cx('radiobuttonicon')
                 },
-                ptm('icon')
+                inProps.icon,
+                ptm('radiobuttonicon')
             );
 
             return (

--- a/components/lib/radiobutton/RadioButtonBase.js
+++ b/components/lib/radiobutton/RadioButtonBase.js
@@ -9,9 +9,9 @@ const classes = {
             'p-invalid': props.invalid,
             'p-variant-filled': props.variant ? props.variant === 'filled' : context && context.inputStyle === 'filled'
         }),
-    box: 'p-radiobutton-box',
-    input: 'p-radiobutton-input',
-    icon: 'p-radiobutton-icon'
+    radiobuttonbox: 'p-radiobutton-box',
+    radiobuttoninput: 'p-radiobutton-input',
+    radiobuttonicon: 'p-radiobutton-icon'
 };
 
 export const RadioButtonBase = ComponentBase.extend({

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "primereact",
     "private": false,
-    "version": "10.6.5",
+    "version": "10.6.6",
     "scripts": {
         "dev": "next dev",
         "start": "next start",


### PR DESCRIPTION
### Defect Fixes
Fix #6697 

I fix the behavior of radiobuttons in datatable so they can be styled through PT, and although I don't even know what _ptm_, _ptmo_, _cx_, _sx_ functions mean and do... I figured out what they did and managed to make it work. So please, if there is a cleaner way or a 'Prime React' way you usually use, feel free to make the necessary changes.

Changes made:
- Types: Fix wrong defined types
- Types: Add missing types
- Types: Remvove types not used
- Datatable: Propagate unstyled prop inside Datatable internal components
- Radiobutton: Change prop input to radiobuttoninput
- Radiobutton: Change prop box to radiobuttonbox
- Radiobutton: Change prop icon to radiobuttonicon
- Update Tailwind PT
- Update Datatable doc unstyled example

Using the same example used to reproduce the bug you can see the result:

- Download stackblitz example to local
- Clone PrimeReact with changes from this pull request
- Build PrimeReact in local
- Link PrimeReact local library in Stackblitz local example
- Serve
- You will see 2 Datatables
- Styles in "Fixed unstyled values" Datatable should be correct.

[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/ivanpajon/datatable-radiobutton)


Table "Deafult unstyled values" not working:
![default_unstyled_values](https://github.com/primefaces/primereact/assets/17519714/02df61ed-c097-4e7c-bf5c-2ddb8581452d)

Fixed table "Fixed unstyled values":
![fixed_unstyled_values](https://github.com/primefaces/primereact/assets/17519714/40120047-68bc-4bfe-853d-ccf61eff0e19)

Example of PrimeReact [documentation](https://primereact.org/datatable/#radiobutton_row_selection):
![radiobutton_primereact_doc](https://github.com/primefaces/primereact/assets/17519714/d5f54d20-9534-4dc1-a3bf-4216a88dd77f)


### ONLY RADIOBUTTONS, DON'T COMPARE REST OF STYLES