### PR TITLE
Fix #6737 Calendar month navigator

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -477,8 +477,7 @@ export const Calendar = React.memo(
         };
 
         const onMonthDropdownChange = (event, value) => {
-            const currentViewDate = getViewDate();
-            let newViewDate = cloneDate(currentViewDate);
+            let newViewDate = new Date();
 
             newViewDate.setMonth(parseInt(value, 10));
 

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -477,8 +477,10 @@ export const Calendar = React.memo(
         };
 
         const onMonthDropdownChange = (event, value) => {
-            let newViewDate = new Date();
+            const currentViewDate = getViewDate();
+            let newViewDate = cloneDate(currentViewDate);
 
+            newViewDate.setDate(1);
             newViewDate.setMonth(parseInt(value, 10));
 
             updateViewDate(event, newViewDate);


### PR DESCRIPTION
### Defect Fixes
Fix #6737 Ensure the day of the date is reset before updating the calendar. The 'navBackward' and 'navForward' methods reset the date to the first day to prevent this bug. If the line 'newViewDate.setDate(1)' is removed, the same error observed with the options will occur.