### PR TITLE
fix: highlight range of year in datePicker

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2342,17 +2342,18 @@ export const Calendar = React.memo(
         };
 
         const isYearSelected = (year) => {
-            if (isComparable()) {
-                let value = isRangeSelection() ? props.value[0] : props.value;
+            if (!isComparable()) return false;
 
-                if (isMultipleSelection()) {
-                    return value.some((currentValue) => currentValue.getFullYear() === year);
-                }
+            if (isMultipleSelection()) {
+                return props.value.some((v) => v.getFullYear() === year);
+            } else if (isRangeSelection()) {
+                const start = props.value[0] ? props.value[0].getFullYear() : null;
+                const end = props.value[1] ? props.value[1].getFullYear() : null;
 
-                return value.getFullYear() === year;
+                return start === year || end === year || (start < year && end > year);
+            } else {
+                return props.value.getFullYear() === year;
             }
-
-            return false;
         };
 
         const switchViewButtonDisabled = () => {


### PR DESCRIPTION
### Describe the bug

 fix #6653

> Context: When the selectionMode of the datapicker is set to range and the view is set to year:

- There is an issue where the years within the selected start and end range are not being highlighted.


https://github.com/primefaces/primereact/assets/37934668/9997d91e-1cdf-4d33-aa21-9a771c8b9368


<br/>



### Reproducer

https://stackblitz.com/edit/hyhoxe-ttg6dh?file=src%2FApp.jsx

<br/>

### Expected behavior

|current|expect|
|---|---|
|<img width="180" alt="스크린샷 2024-06-14 오후 3 54 42" src="https://github.com/primefaces/primereact/assets/37934668/859d3465-8f84-4446-992c-71a6efd9b2bd">|<img width="167" alt="스크린샷 2024-06-14 오후 3 54 21" src="https://github.com/primefaces/primereact/assets/37934668/07509770-ab7a-406c-ad5e-7eaea6dcb10e">|


<br/>

### How to resolve
- To resolve this, the condition for highlighting years has been modified.