### PR TITLE
fix(Tooltip): not dynamically update align when position is mouse

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -473,7 +473,9 @@ export const Tooltip = React.memo(
             if (visibleState) {
                 applyDelay('updateDelay', () => {
                     updateText(currentTargetRef.current, () => {
-                        align(currentTargetRef.current);
+                        const position = getPosition(currentTargetRef.current);
+
+                        if (position !== 'mouse') align(currentTargetRef.current);
                     });
                 });
             }

--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -470,12 +470,12 @@ export const Tooltip = React.memo(
         }, [visibleState]);
 
         useUpdateEffect(() => {
-            if (visibleState) {
+            const position = getPosition(currentTargetRef.current);
+
+            if (visibleState && position !== 'mouse') {
                 applyDelay('updateDelay', () => {
                     updateText(currentTargetRef.current, () => {
-                        const position = getPosition(currentTargetRef.current);
-
-                        if (position !== 'mouse') align(currentTargetRef.current);
+                        align(currentTargetRef.current);
                     });
                 });
             }


### PR DESCRIPTION
### Defect Fixes
> fix #6635
- the align function is update tooltip position.
- I think, the purpose of the align function is to update the fixed position(top, left, bottom etc) when the position of the target element changes.
- So, I modified the tooltip's position to remain when the position is "mouse"

<br/>

_fixed result_


https://github.com/primefaces/primereact/assets/37934668/f4775c5b-3f89-4103-99ae-c08f75064528



