### PR TITLE
feat #6772 : defaultVisible prop added

### DIFF
--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -67,7 +67,15 @@ export const Dialog = React.forwardRef((inProps, ref) => {
     const [bindDocumentDragEndListener, unbindDocumentDragEndListener] = useEventListener({ type: 'mouseup', target: () => window.document, listener: (event) => onDragEnd(event) });
 
     const onClose = (event) => {
-        props.onHide();
+        if (props.onHide) {
+            props.onHide();
+        }
+
+        if (props.defaultVisible && isCloseOnEscape) {
+            setVisibleState(false);
+            setMaskVisibleState(false);
+        }
+
         event.preventDefault();
     };
 
@@ -405,6 +413,13 @@ export const Dialog = React.forwardRef((inProps, ref) => {
             setVisibleState(true);
         }
     }, [maskVisibleState]);
+
+    useUpdateEffect(() => {
+        if (props.defaultVisible) {
+            setVisibleState(true);
+            setMaskVisibleState(true);
+        }
+    }, [props.defaultVisible]);
 
     useUpdateEffect(() => {
         updateGlobalDialogsRegistry(true);

--- a/components/lib/dialog/DialogBase.js
+++ b/components/lib/dialog/DialogBase.js
@@ -297,6 +297,7 @@ export const DialogBase = ComponentBase.extend({
         showHeader: true,
         style: null,
         transitionOptions: null,
+        defaultVisible: false,
         visible: false,
         children: undefined
     },

--- a/components/lib/dialog/dialog.d.ts
+++ b/components/lib/dialog/dialog.d.ts
@@ -354,6 +354,11 @@ export interface DialogProps {
      */
     transitionOptions?: CSSTransitionProps | undefined;
     /**
+     * Specifies the default visibility of the dialog.
+     * @defaultValue false
+     */
+    defaultVisible?: boolean | undefined;
+    /**
      * Specifies the visibility of the dialog.
      * @defaultValue false
      */
@@ -396,7 +401,7 @@ export interface DialogProps {
     /**
      * Callback to invoke when dialog is hidden (Required).
      */
-    onHide(): void;
+    onHide?(): void;
     /**
      * Callback to invoke when the mask is clicked.
      * @param {React.MouseEvent<HTMLElement>} event - Browser event.


### PR DESCRIPTION
####  `defaultVisible` Prop to Dialog Component

Fix #6772

This pull request introduces a new `defaultVisible` prop to the Dialog component in our UI library. The `defaultVisible` prop allows developers to control the initial visibility of the Dialog when the component mounts.

#### Description

The `defaultVisible` prop is a boolean that, when set to `true`, ensures that the Dialog is displayed immediately upon mounting. Conversely, setting this prop to `false` or omitting it entirely will maintain the default behavior, where the Dialog is hidden initially and requires a trigger to become visible.

#### Changes

- Added `defaultVisible` prop to the Dialog component's API.
- Updated the Dialog component's internal state management to account for the `defaultVisible` prop.
- Ensured backward compatibility by defaulting the `defaultVisible` prop to `false`.

#### Usage

```jsx
<Dialog defaultVisible={true}>
    <!-- Dialog content goes here -->
</Dialog>
```

