### PR TITLE
Fix #6774: Rename previousButton to prevButton

### DIFF
--- a/components/lib/tabview/tabview.d.ts
+++ b/components/lib/tabview/tabview.d.ts
@@ -346,7 +346,7 @@ export interface TabViewPassThroughOptions {
     /**
      * Uses to pass attributes to the previous button's DOM element.
      */
-    previousButton?: TabViewPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
+    prevButton?: TabViewPassThroughType<React.HTMLAttributes<HTMLButtonElement>>;
     /**
      * Uses to pass attributes to the previous button icon's DOM element.
      */


### PR DESCRIPTION
Fix #6774: Rename previousButton to prevButton in TabViewPassThroughOptions
