### PR TITLE
Fix(ColorPicker): apply s and b of previous hsb to hsbValue

### DIFF
--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -99,7 +99,7 @@ export const ColorPicker = React.memo(
 
         const getPositionY = (event) => {
             if (event.pageY !== undefined) return event.pageY;
-            else if (event.touches !== undefined) return event.touches[0].pageY;
+            else if (event.changedTouches !== undefined) return event.changedTouches[0].pageY;
             else return 0;
         };
 

--- a/components/lib/colorpicker/ColorPicker.js
+++ b/components/lib/colorpicker/ColorPicker.js
@@ -97,13 +97,21 @@ export const ColorPicker = React.memo(
             !isUnstyled && DomHandler.addClass(elementRef.current, 'p-colorpicker-dragging');
         };
 
+        const getPositionY = (event) => {
+            if (event.pageY !== undefined) return event.pageY;
+            else if (event.touches !== undefined) return event.touches[0].pageY;
+            else return 0;
+        };
+
         const pickHue = (event) => {
-            const top = hueViewRef.current.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0);
+            const top = hueViewRef.current.getBoundingClientRect().top + (window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0);
+            const yPos = getPositionY(event);
+            const hue = Math.floor((360 * (150 - Math.max(0, Math.min(150, yPos - top)))) / 150);
 
             hsbValue.current = validateHSB({
-                h: Math.floor((360 * (150 - Math.max(0, Math.min(150, (event.pageY || event.changedTouches[0].pageY) - top)))) / 150),
-                s: 100,
-                b: 100
+                h: hue,
+                s: hsbValue.current.s,
+                b: hsbValue.current.b
             });
 
             updateColorSelector();


### PR DESCRIPTION
### Defect Fixes

- fix #6787 

<br/>

### modified list
1. `pageYOffset` is deprecated, So I changed `pageYOffset` to `scrollY` 
```js
// before
const top = hueViewRef.current.getBoundingClientRect().top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0);
```
```js
// after
const top = hueViewRef.current.getBoundingClientRect().top + (window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0);
```

<br/>

2. check undefined in Y position.
```js
const getPositionY = (event) => {
  if (event.pageY !== undefined) return event.pageY;
  else if (event.touches !== undefined) return event.touches[0].pageY;
  else return 0;
};
```

<br/>

3. **apply `s` and `b` of previous hsb to `this.hsbValue`**
```js
// before
hsbValue.current = validateHSB({
    h: Math.floor((360 * (150 - Math.max(0, Math.min(150, (event.pageY || event.changedTouches[0].pageY) - top)))) / 150),
    s: 100, // this!
    b: 100, // this!
});
```
```js
// after
hsbValue.current = validateHSB({
    h: hue,
    s: hsbValue.current.s, // changed code
    b: hsbValue.current.b // changed code
});
```

<br/>

### result


https://github.com/primefaces/primereact/assets/37934668/597c6ba5-d7d3-4c79-bf55-4f0fc8c53a1a





