### PR TITLE
Fix #6791: apply year change in Calendar when input changed

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3070,28 +3070,28 @@ export const Calendar = React.memo(
                 isTypingRef.current = false;
 
                 // #3516 view date not updated when value set programatically
-                if (!visible && newDate) {
-                    let viewDate = newDate;
+                if (!newDate) return;
 
-                    if (isMultipleSelection()) {
-                        if (newDate.length) {
-                            viewDate = newDate[newDate.length - 1];
-                        }
-                    } else if (isRangeSelection()) {
-                        if (newDate.length) {
-                            let startDate = newDate[0];
-                            let endDate = newDate[1];
+                let viewDate = newDate;
 
-                            viewDate = endDate || startDate;
-                        }
+                if (isMultipleSelection()) {
+                    if (newDate.length) {
+                        viewDate = newDate[newDate.length - 1];
                     }
+                } else if (isRangeSelection()) {
+                    if (newDate.length) {
+                        let startDate = newDate[0];
+                        let endDate = newDate[1];
 
-                    if (viewDate instanceof Date) {
-                        validateDate(viewDate);
-                        setViewDateState(viewDate);
-                        setCurrentMonth(viewDate.getMonth());
-                        setCurrentYear(viewDate.getFullYear());
+                        viewDate = endDate || startDate;
                     }
+                }
+
+                if (viewDate instanceof Date) {
+                    validateDate(viewDate);
+                    setViewDateState(viewDate);
+                    setCurrentMonth(viewDate.getMonth());
+                    setCurrentYear(viewDate.getFullYear());
                 }
             }
         }, [props.value, visible]);


### PR DESCRIPTION
## Defect Fixes
- fix #6781

<br/>

## how to resolve
### Related Issue and PR
- this issue is related this previous [PR](https://github.com/primefaces/primereact/pull/3517/files) and [issue 1](https://github.com/primefaces/primereact/issues/3515), [issue 2](https://github.com/primefaces/primereact/issues/3516).

_previous issue capture_

<img width="1677" alt="스크린샷 2024-06-26 오후 9 08 12" src="https://github.com/primefaces/primereact/assets/37934668/cab9a0b6-3c3f-4f8c-8ac9-f87672a34ad6">

<img width="1617" alt="스크린샷 2024-06-26 오후 9 08 05" src="https://github.com/primefaces/primereact/assets/37934668/9fafd345-f48e-402d-a77b-68b8614d98dc">

<br/>

_previous pr_
<img width="1104" alt="스크린샷 2024-06-26 오후 9 09 57" src="https://github.com/primefaces/primereact/assets/37934668/e21c0e43-ee0c-4837-89a5-9a287281a9ac">

<br/><br/>

### how to resolve
- Whether the calendar picker is visible or not, the date should be updated.
- So, I deleted `!visible` condition in `useUpdateEffect` hook. :)

```js
// before
useUpdateEffect(() => {
	if (!visible && newDate) { ... } 
    ...
})
``` 
```js
// after
useUpdateEffect(() => {
	if (!newDate) return;
    ...
})
``` 

<br/>

### result
1. you can change date value using external button.(_previous issue_)

https://github.com/primefaces/primereact/assets/37934668/a68d34d3-6c1a-498b-8a46-b25bd59d2324



2. you can change date value using date input.


https://github.com/primefaces/primereact/assets/37934668/6fd4a77a-3b83-4ab1-854d-63d9576be2e8

