### PR TITLE
Fix: #6796 check for visibleOptions existing before looking up the index

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -656,7 +656,7 @@ export const Dropdown = React.memo(
         const onEditableInputChange = (event) => {
             let searchIndex = null;
 
-            if (event.target.value) {
+            if (event.target.value && visibleOptions) {
                 searchIndex = visibleOptions.findIndex((item) => getOptionLabel(item).toLocaleLowerCase().startsWith(event.target.value.toLocaleLowerCase()));
             }
 


### PR DESCRIPTION
Prevent "Uncaught TypeError: Cannot read properties of undefined (reading 'findIndex')" error from being thrown when visibleOptions is null or undefined.

Fix [#6796](https://github.com/primefaces/primereact/issues/6796)

**Description**

Because options is an optional prop, visibleOptions can potentially be undefined. If visibleOptions is not verified as existing first, calling findIndex results in an "Uncaught TypeError: Cannot read properties of undefined (reading 'findIndex')".

**Changes**

- Check that visibleOptions exists before trying to search the options.
