### PR TITLE
Fix: #6666 onMonthChange prop not being called when user increments / decrements month using arrow buttons.

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -361,11 +361,15 @@ export const Calendar = React.memo(
 
             if (currentView === 'date') {
                 if (newViewDate.getMonth() === 0) {
+                    const newYear = decrementYear();
+                    
                     newViewDate.setMonth(11);
-                    newViewDate.setFullYear(decrementYear());
+                    newViewDate.setFullYear(newYear);
+                    props.onMonthChange && props.onMonthChange({ month: 11, year: newYear });
                     setCurrentMonth(11);
                 } else {
                     newViewDate.setMonth(newViewDate.getMonth() - 1);
+                    props.onMonthChange && props.onMonthChange({ month: currentMonth - 1, year: currentYear });
                     setCurrentMonth((prevState) => prevState - 1);
                 }
             } else if (currentView === 'month') {
@@ -406,11 +410,15 @@ export const Calendar = React.memo(
 
             if (currentView === 'date') {
                 if (newViewDate.getMonth() === 11) {
+                    const newYear = incrementYear();
+                    
                     newViewDate.setMonth(0);
-                    newViewDate.setFullYear(incrementYear());
+                    newViewDate.setFullYear(newYear);
+                    props.onMonthChange && props.onMonthChange({ month: 0, year: newYear });
                     setCurrentMonth(0);
                 } else {
                     newViewDate.setMonth(newViewDate.getMonth() + 1);
+                    props.onMonthChange && props.onMonthChange({ month: currentMonth + 1, year: currentYear });
                     setCurrentMonth((prevState) => prevState + 1);
                 }
             } else if (currentView === 'month') {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -362,7 +362,7 @@ export const Calendar = React.memo(
             if (currentView === 'date') {
                 if (newViewDate.getMonth() === 0) {
                     const newYear = decrementYear();
-                    
+
                     newViewDate.setMonth(11);
                     newViewDate.setFullYear(newYear);
                     props.onMonthChange && props.onMonthChange({ month: 11, year: newYear });
@@ -411,7 +411,7 @@ export const Calendar = React.memo(
             if (currentView === 'date') {
                 if (newViewDate.getMonth() === 11) {
                     const newYear = incrementYear();
-                    
+
                     newViewDate.setMonth(0);
                     newViewDate.setFullYear(newYear);
                     props.onMonthChange && props.onMonthChange({ month: 0, year: newYear });


### PR DESCRIPTION
navForward / navBackward now calls onMonthChange (if defined).

Fix [#6666](https://github.com/primefaces/primereact/issues/6666)

**Description**

navForward / navBackward methods (called when user interacts with the increment / decrement month buttons) were not calling onMonthChange. 

**Changes**

- New variable to store incrementYear() / decrementYear() to avoid extra call.
- Check if onMonthChange prop is defined, and call with the month and year. 