### PR TITLE
Fix #6733: add null check condition in getOptionValue(Dropdown)

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -893,6 +893,7 @@ export const Dropdown = React.memo(
                 return ObjectUtils.resolveFieldData(option, props.optionValue);
             } else {
                 const dataValue = ObjectUtils.resolveFieldData(option, 'value');
+
                 return dataValue !== null ? dataValue : option;
             }
         };

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -310,7 +310,7 @@ export const Dropdown = React.memo(
         };
 
         const findSelectedOptionIndex = () => {
-            return hasSelectedOption ? visibleOptions.findIndex((option) => isValidSelectedOption(option)) : -1;
+            return hasSelectedOption() ? visibleOptions.findIndex((option) => isValidSelectedOption(option)) : -1;
         };
 
         const findFirstFocusedOptionIndex = () => {
@@ -889,7 +889,12 @@ export const Dropdown = React.memo(
         };
 
         const getOptionValue = (option) => {
-            return props.optionValue ? ObjectUtils.resolveFieldData(option, props.optionValue) : ObjectUtils.resolveFieldData(option, 'value') || option;
+            if (props.optionValue) {
+                return ObjectUtils.resolveFieldData(option, props.optionValue);
+            } else {
+                const dataValue = ObjectUtils.resolveFieldData(option, 'value');
+                return dataValue !== null ? dataValue : option;
+            }
         };
 
         const getOptionRenderKey = (option) => {


### PR DESCRIPTION
### Defect Fixes
- fix #6733
- example: https://stackblitz.com/edit/vitejs-vite-5esx3k?file=src%2FApp.jsx,package.json&terminal=dev
<img width="879" alt="스크린샷 2024-07-01 15 18 42" src="https://github.com/primefaces/primereact/assets/37934668/5caadd56-00bf-42a3-9f8c-1ffde7a0c657">


<br/><br/>

### how to resolve
#### 1. add null check
- when default value is 0, the selected option is not selected
- the `resolveFieldData` function returns null if the value is not found, so we need to check if the value is not null :)
```js
// before
const getOptionValue = (option) => {
	return props.optionValue ? ObjectUtils.resolveFieldData(option, props.optionValue) : ObjectUtils.resolveFieldData(option, 'value') || option;
};
```
```js
// after

const getOptionValue = (option) => {
    if (props.optionValue) {
        return ObjectUtils.resolveFieldData(option, props.optionValue);
    } else {
        const dataValue = ObjectUtils.resolveFieldData(option, 'value');
        return dataValue !== null ? dataValue : option; // null checking!
    }
};
```

<br/>

#### 2. fix wrong check condition
- `hasSelectedOption` is function.
```js
const hasSelectedOption = () => {
    return ObjectUtils.isNotEmpty(props.value);
};
```

<br/>

- I changed `hasSelectedOption` to `hasSelectedOption()` to ensure the condition evaluates the result of the function call rather than a function reference.

```js
// before
const findSelectedOptionIndex = () => {
    return hasSelectedOption ? visibleOptions.findIndex((option) => isValidSelectedOption(option)) : -1;
};
```

```js
// after 
const findSelectedOptionIndex = () => {
    return hasSelectedOption() ? visibleOptions.findIndex((option) => isValidSelectedOption(option)) : -1;
};

```

<br/>

### result

https://github.com/primefaces/primereact/assets/37934668/3e4c5e13-0880-49e5-b6c1-e265cecfff3f





