### PR TITLE
Fix #6809: Make sure editable dropdown opens when user types

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,8 +23,9 @@ C:\primereact> npm run dev:link:windows
 
 This will alter the bundler to only emit non-minified esm modules. The aliasing plugin has also been disabled for components. Once everything has been bundled (this can take a few minutes) you should keep this command running. It will allow for incremental builds as you develop in the `primereact/` directory.
 
-> [!NOTE]
-> It will be finished when the terminal displays: `[20xx-xx-xx 00:00:00] waiting for changes...`.
+> Note: if you get "Error: JavaScript heap out of memory", it may help to set the following node variable: `export NODE_OPTIONS=--max-old-space-size=8192`.
+
+> Note: The build will be finished when the terminal displays: `[20xx-xx-xx 00:00:00] waiting for changes...`.
 
 You will now `cd` into the `primereact/dist` directory and run:
 

--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -562,9 +562,8 @@
                             "type": "PrimeReactProviderProps"
                         },
                         {
-                            "name": "deprecatedLegacyContext",
-                            "type": "any",
-                            "description": ""
+                            "name": "context",
+                            "type": "any"
                         }
                     ],
                     "returnType": "ReactNode"

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -654,6 +654,7 @@ export const Dropdown = React.memo(
         };
 
         const onEditableInputChange = (event) => {
+            !overlayVisibleState && show();
             let searchIndex = null;
 
             if (event.target.value && visibleOptions) {


### PR DESCRIPTION
Fix #6809. 

This bug did not always exist. It was first introduced in #6032.