### PR TITLE
Fix: #6820 updating activeStep does not actually change the active step

### DIFF
--- a/components/lib/stepper/Stepper.js
+++ b/components/lib/stepper/Stepper.js
@@ -30,7 +30,9 @@ export const Stepper = React.memo(
         });
 
         useUpdateEffect(() => {
-            setActiveStepState(props.activeStep);
+            if (props.activeStep >= 0 && props.activeStep <= stepperPanels().length - 1) {
+                updateActiveStep(undefined, props.activeStep);
+            }
         }, [props.activeStep]);
 
         const getStepProp = (step, name) => {

--- a/components/lib/stepper/Stepper.js
+++ b/components/lib/stepper/Stepper.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
-import { useMergeProps, useMountEffect } from '../hooks/Hooks';
+import { useMergeProps, useMountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { UniqueComponentId, classNames } from '../utils/Utils';
 import { StepperBase } from './StepperBase';
 import { StepperContent } from './StepperContent';
@@ -28,6 +28,10 @@ export const Stepper = React.memo(
                 setIdState(UniqueComponentId());
             }
         });
+
+        useUpdateEffect(() => {
+            setActiveStepState(props.activeStep);
+        }, [props.activeStep]);
 
         const getStepProp = (step, name) => {
             return step?.props?.[name];


### PR DESCRIPTION
Fix https://github.com/primefaces/primereact/issues/6820

**Description**

Modifications to the activeStep prop had no effect on the currently active step.

**Changes**
- Subscribe (via useUpdateEffect) to activeStep changes.
- Check that the activeStep is "valid" (not less than 0 and not greater than the number of steps), and update the state.

**Pitfalls**

Event seems to need to be undefined (similar behaviour to prevCallback / nextCallback). 