### PR TITLE
Fix #6845: TreeTableSelectionKeys type def

### DIFF
--- a/components/lib/treetable/treetable.d.ts
+++ b/components/lib/treetable/treetable.d.ts
@@ -514,7 +514,7 @@ interface TreeTableSelectionEvent {
     /**
      * Selected node key.
      */
-    value: TreeTableSelectionKeysType;
+    value: TreeTableSelectionKeysType | string;
 }
 
 /**


### PR DESCRIPTION
Fix #6845: TreeTableSelectionKeys type def