### PR TITLE
Fix #6842: TreeTable Typescript for page event

### DIFF
--- a/components/lib/treetable/treetable.d.ts
+++ b/components/lib/treetable/treetable.d.ts
@@ -478,7 +478,7 @@ interface TreeTablePageEvent {
     /**
      * Total number of pages.
      */
-    pageCount: number;
+    totalPages: number;
 }
 
 /**


### PR DESCRIPTION
Fix #6842: TreeTable Typescript for page event