### PR TITLE
Fix #6858: Dropdown crashes when label is an empty string

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -888,7 +888,7 @@ export const Dropdown = React.memo(
         const getOptionLabel = (option) => {
             const optionLabel = props.optionLabel ? ObjectUtils.resolveFieldData(option, props.optionLabel) : option ? option['label'] : ObjectUtils.resolveFieldData(option, 'label');
 
-            return ObjectUtils.isNotEmpty(optionLabel) ? optionLabel : option;
+            return `${optionLabel}`;
         };
 
         const getOptionValue = (option) => {


### PR DESCRIPTION
Fix #6858 - resolved a crash when passing an empty string as a label value for the Dropdown's options.

The solution was to make the `getOptionLabel` function in the Dropdown component always return a string. The return value of this function ends up in the `DropdownItem` component and it is used directly as a child of the `span` element (if no item template is provided):
> `components/lib/dropdown/DropdownItem.js:79`
```
<span {...itemGroupLabelProps}>{content}</span>
```
This clearly shows that there is no intention for the value here to be anything other than a `string` (it could also be a `ReactNode` of course, in the case of a custom item template being used). Well ok, it can _technically_ also be `null` or `undefined`, but that doesn't change the point. Further cementing the fact that the return value of the `getOptionLabel` function should always be a string is a call of `toLocaleLowerCase` method on the return value of this function. For example in the Dropdown search logic:
> `components/lib/dropdown/Dropdown.js:297`
```
return isValidOption(option) && getOptionLabel(option)?.toLocaleLowerCase(props.filterLocale).startsWith(searchValue.current.toLocaleLowerCase(props.filterLocale));
```

The current return value of the `getOptionLabel` function was pretty much `any`, meaning that an entire option object could have also been returned, which has no (apparent) use within the Dropdown component and simply crashes the component.

This change also resolves another possible crash when the `optionLabel` prop is provided to the Dropdown component with a custom key/path to a label value from the options object, but the actual key/path on the options object does not exist.

Another side effect of this change is that `boolean` values passed as option labels to the Dropdown component now actually get rendered as `true` or `false` (which is kind of nice, IMO).