### PR TITLE
Re-fix primefaces#6561: Return scalar values directly as a label for Dropdown

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -886,7 +886,11 @@ export const Dropdown = React.memo(
         };
 
         const getOptionLabel = (option) => {
-            const optionLabel = props.optionLabel ? ObjectUtils.resolveFieldData(option, props.optionLabel) : option ? option['label'] : ObjectUtils.resolveFieldData(option, 'label');
+            if (ObjectUtils.isScalar(option)) {
+                return `${option}`;
+            }
+
+            const optionLabel = props.optionLabel ? ObjectUtils.resolveFieldData(option, props.optionLabel) : option['label'];
 
             return `${optionLabel}`;
         };

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -386,6 +386,15 @@ export default class ObjectUtils {
         return /^[a-zA-Z\u00C0-\u017F]$/.test(char);
     }
 
+    static isScalar(value) {
+        return value != null && (
+            typeof value === 'string' ||
+            typeof value === 'number' ||
+            typeof value === 'bigint' ||
+            typeof value === 'boolean'
+        );
+    }
+
     /**
      * Firefox-v103 does not currently support the "findLast" method. It is stated that this method will be supported with Firefox-v104.
      * https://caniuse.com/mdn-javascript_builtins_array_findlast

--- a/components/lib/utils/ObjectUtils.js
+++ b/components/lib/utils/ObjectUtils.js
@@ -387,12 +387,7 @@ export default class ObjectUtils {
     }
 
     static isScalar(value) {
-        return value != null && (
-            typeof value === 'string' ||
-            typeof value === 'number' ||
-            typeof value === 'bigint' ||
-            typeof value === 'boolean'
-        );
+        return value != null && (typeof value === 'string' || typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean');
     }
 
     /**

--- a/components/lib/utils/utils.d.ts
+++ b/components/lib/utils/utils.d.ts
@@ -146,6 +146,7 @@ export declare class ObjectUtils {
     static isString(value: any): boolean;
     static isPrintableCharacter(char: string): boolean;
     static isLetter(char: string): boolean;
+    static isScalar(value: any): boolean;
     static findLast(value: any[], callback: () => any): any;
     static findLastIndex(value: any[], callback: () => any): number;
     static sort(value1: any, value2: any, order: number, locale: string | string[]): number;


### PR DESCRIPTION
Fix #6858 

While fixing #6858 (#6871) I apparently broke #6561 (Support for an array of simple values as options for Dropdown). This should fix it for good :)