### PR TITLE
Fix #6862: change the order of applying default values to props

### DIFF
--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -455,6 +455,7 @@ export const OrderList = React.memo(
                 <OrderListSubList
                     ref={listElementRef}
                     hostName="OrderList"
+                    {...props}
                     focused={focused}
                     ariaLabel={props.ariaLabel}
                     ariaLabelledBy={props.ariaLabelledBy}
@@ -484,7 +485,6 @@ export const OrderList = React.memo(
                     ptm={ptm}
                     cx={cx}
                     changeFocusedOptionIndex={changeFocusedOptionIndex}
-                    {...props}
                 />
             </div>
         );


### PR DESCRIPTION
### Defect Fixes

Fix #6862

<br/>

### how to resolve
- This issue occurred in the PR([link](https://github.com/primefaces/primereact/pull/6228/commits/cd2f68b0cf8a4577b973f16728f112f18cebb025)) where the focusOnHover option was added to the orderList. 
- The `{...props}` spread operator is used to assign default values to props. 
- However, due to the order of `{...props}`, the default prop values were applied instead of the declared prop values, resulting in unexpected behavior.


#### Result
- I tested two things in the modified code:

_1. Whether focusOnHover works_


https://github.com/user-attachments/assets/153715f1-58ea-48ec-9e61-bdd5ceb30cea



<br/>


_2. Whether the filter function operates correctly_

https://github.com/user-attachments/assets/163abe3f-e480-4e3e-b5cc-576b9c71151a


