### PR TITLE
Fix #6876: hide clear button when options is empty in Dropdown

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1138,7 +1138,7 @@ export const Dropdown = React.memo(
         };
 
         const createClearIcon = () => {
-            if (props.value != null && props.showClear && !props.disabled) {
+            if (props.value != null && props.showClear && !props.disabled && !ObjectUtils.isEmpty(props.options)) {
                 const clearIconProps = mergeProps(
                     {
                         className: cx('clearIcon'),


### PR DESCRIPTION
### Defect Fixes
Fix #6876

<br/>

### how to resolve
- when the options is empty, not rendering the clear icon.

#### result


https://github.com/user-attachments/assets/f920a191-047e-41e9-bf32-7bd881bb9e4f



