### PR TITLE
Related to PR #6896

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -1096,7 +1096,7 @@ export const MultiSelect = React.memo(
                 'aria-expanded': overlayVisibleState,
                 disabled: props.disabled,
                 tabIndex: !props.disabled ? props.tabIndex : -1,
-                value: props.value,
+                value: JSON.stringify(props.value),
                 ...ariaProps
             },
             ptm('input')

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -1096,6 +1096,7 @@ export const MultiSelect = React.memo(
                 'aria-expanded': overlayVisibleState,
                 disabled: props.disabled,
                 tabIndex: !props.disabled ? props.tabIndex : -1,
+                value: props.value,
                 ...ariaProps
             },
             ptm('input')


### PR DESCRIPTION
### Defect Fixes
(Fix #6895)
Due to we are storing objects in value input attribute we need to serialize the value. So instead of this:
![image](https://github.com/user-attachments/assets/9b9cdf29-7546-431b-a24f-f6ed8f19a8dd)

We have this:
![image](https://github.com/user-attachments/assets/d1b91ca1-a8ef-4130-b5fc-973e96334b67)
