### PR TITLE
Fix #6825: focusOnShow prop in Dialog component

### DIFF
--- a/components/lib/dialog/Dialog.js
+++ b/components/lib/dialog/Dialog.js
@@ -703,7 +703,7 @@ export const Dialog = React.forwardRef((inProps, ref) => {
             <div {...maskProps}>
                 <CSSTransition nodeRef={dialogRef} {...transitionProps}>
                     <div {...rootProps}>
-                        <FocusTrap autoFocus>{contentElement}</FocusTrap>
+                        <FocusTrap autoFocus={props.focusOnShow}>{contentElement}</FocusTrap>
                     </div>
                 </CSSTransition>
             </div>


### PR DESCRIPTION
### Defect Fixes
Fix #6825

This issue not only occurs when you have the showHeader={false} property, always occurs due to the autoFocus property in the FocusTrap component.


