### PR TITLE
Fix(Calendar): reset the isOverlayClicked value after overlayVisibleState is set to false.

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1723,6 +1723,7 @@ export const Calendar = React.memo(
                     if (props.hideOnRangeSelection && endDate !== null) {
                         setTimeout(() => {
                             setOverlayVisibleState(false);
+                            isOverlayClicked.current = false;
                         }, 150);
                     }
                 } else {


### PR DESCRIPTION
### Defect Fixes
- fix #6920 

### Result
- i modified to reset the isOverlayClicked value after overlayVisibleState is set to false. :)

https://github.com/user-attachments/assets/d9e1342c-e5ab-4e3f-a003-e8593cba1f7c

