### PR TITLE
fix #6936: Editor get focus on init and on every value change

### DIFF
--- a/components/lib/editor/Editor.js
+++ b/components/lib/editor/Editor.js
@@ -123,7 +123,12 @@ export const Editor = React.memo(
             quill.current = quillInstance;
 
             if (props.value) {
-                quill.current.clipboard.dangerouslyPasteHTML(props.value);
+                quillInstance.setContents(
+                    quillInstance.clipboard.convert({
+                        html: props.value,
+                        text: ''
+                    })
+                );
             }
 
             setQuillCreated(true);
@@ -151,7 +156,16 @@ export const Editor = React.memo(
 
         useUpdateEffect(() => {
             if (quill.current && !quill.current.hasFocus()) {
-                props.value ? quill.current.clipboard.dangerouslyPasteHTML(props.value) : quill.current.setText('');
+                if (props.value) {
+                    quill.current.setContents(
+                        quill.current.clipboard.convert({
+                            html: props.value,
+                            text: ''
+                        })
+                    );
+                } else {
+                    quill.current.setText('');
+                }
             }
         }, [props.value]);
 


### PR DESCRIPTION
Fix: #6936

Changes is this PR is based on the fact, that native `dangerouslyPasteHTML` function of Quill under the hood consists of 2 instructions:
1. [Set editor value](https://github.com/slab/quill/blob/b213e1073bac1478649f26e3c0dad50ad0eb2a49/packages/quill/src/modules/clipboard.ts#L159)
2. [Set selection](https://github.com/slab/quill/blob/b213e1073bac1478649f26e3c0dad50ad0eb2a49/packages/quill/src/modules/clipboard.ts#L160) (which leads to the focus change)

So, here I used only first part of `dangerouslyPasteHTML` that sets input value without affecting focus (`quill.setContents` + `quill.clipboard.convert`).

**WARNING**: this change is not backwards-compatible with Quill v1, as `quill.clipboard.convert` function in v1 has [different signature](https://github.com/slab/quill/blob/0148738cb22d52808f35873adb620ca56b1ae061/modules/clipboard.js#L75) (it expects html markup in first argument, rather than in `html` property of an object). I don't have any good ideas about how to make this backwards-compatible.