### PR TITLE
fix: #6942 Fix Datatable Reorderable Rows in Unstyled mode

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -609,6 +609,9 @@ export const TableBody = React.memo(
             if (!isUnstyled() && DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle')) {
                 event.currentTarget.draggable = true;
                 event.target.draggable = false;
+            } else if (isUnstyled() && DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon') {
+                event.currentTarget.draggable = true;
+                event.target.draggable = false;
             } else {
                 event.currentTarget.draggable = false;
             }


### PR DESCRIPTION
Fix for #6942 
- Add conditional to catch `onRowMouseDown` when using unstyled mode.
