### PR TITLE
Fix #6944: Improve Checkbox PT Options in MultiSelect

### DIFF
--- a/components/lib/multiselect/MultiSelectHeader.js
+++ b/components/lib/multiselect/MultiSelectHeader.js
@@ -117,7 +117,7 @@ export const MultiSelectHeader = React.memo((props) => {
         {
             className: cx('headerCheckboxIcon')
         },
-        getPTOptions('headerCheckboxIcon')
+        getPTOptions('headerCheckbox.icon')
     );
 
     const headerCheckboxContainerProps = mergeProps(

--- a/components/lib/multiselect/MultiSelectItem.js
+++ b/components/lib/multiselect/MultiSelectItem.js
@@ -46,7 +46,7 @@ export const MultiSelectItem = React.memo((props) => {
         {
             className: cx('checkboxIcon')
         },
-        getPTOptions('checkboxIcon')
+        getPTOptions('checkbox.icon')
     );
 
     const icon = props.checkboxIcon || <CheckIcon {...checkboxIconProps} />;

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -154,10 +154,6 @@ export interface MultiSelectPassThroughOptions {
      */
     checkbox?: CheckboxPassThroughOptions;
     /**
-     * Uses to pass attributes to the checkbox icon's DOM element.
-     */
-    checkboxIcon?: MultiSelectPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
-    /**
      * Uses to pass attributes to the emptyMessage's DOM element.
      */
     emptyMessage?: MultiSelectPassThroughType<React.HTMLAttributes<HTMLLIElement>>;

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -152,7 +152,7 @@ export interface MultiSelectPassThroughOptions {
     /**
      * Uses to pass attributes to the checkbox's DOM element.
      */
-    checkbox?: MultiSelectPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
+    checkbox?: CheckboxPassThroughOptions;
     /**
      * Uses to pass attributes to the checkbox icon's DOM element.
      */

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -97,10 +97,6 @@ export interface MultiSelectPassThroughOptions {
      */
     headerCheckboxContainer?: MultiSelectPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
-     * Uses to pass attributes to the header checkbox icon's DOM element.
-     */
-    headerCheckboxIcon?: MultiSelectPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
-    /**
      * Uses to pass attributes to the header checkbox's DOM element.
      */
     headerSelectAllLabel?: MultiSelectPassThroughType<React.HTMLAttributes<HTMLLabelElement>>;


### PR DESCRIPTION
First and foremost, fixes: #6944.  

Additionally, removes redundant pass through options "checkboxIcon" and "headerCheckboxIcon." These should simply be passed in through the "checkbox" and "headerCheckbox" pass through options. 

The single source of truth for how these are dealt with should be the checkbox component itself. 