### PR TITLE
Added ((data: any) => string) to dataKey property definition

### DIFF
--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -1104,7 +1104,7 @@ interface DataTableBaseProps<TValue extends DataTableValueArray> extends Omit<Re
      * Name of the field that uniquely identifies a record in the data. Should be a unique business key to prevent re-rendering.
      * @defaultValue (&#123;currentPage&#125; of &#123;totalPages&#125;)
      */
-    dataKey?: string | undefined;
+    dataKey?: string | undefined | ((data: any) => string);
     /**
      * Default sort order of an unsorted column.
      * @defaultValue (&#123;currentPage&#125; of &#123;totalPages&#125;)


### PR DESCRIPTION
I'm using the dataKey with a function and the definition is missing that.

It's tested and working. The point here is, that objects may not have any unique identifier but one could be created with property combination.
