### PR TITLE
Fix #6795: Fix calendar overlay requiring double click on date to select a value when mask is present

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3046,8 +3046,10 @@ export const Calendar = React.memo(
         }, [props.view]);
 
         useUpdateEffect(() => {
-            focusToFirstCell();
-        }, [currentView]);
+            if (visible) {
+                focusToFirstCell();
+            }
+        }, [visible, currentView]);
 
         useUpdateEffect(() => {
             if (!props.onViewDateChange && !viewStateChanged.current) {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3046,10 +3046,10 @@ export const Calendar = React.memo(
         }, [props.view]);
 
         useUpdateEffect(() => {
-            if (visible) {
+            if (visible && !props.inline) {
                 focusToFirstCell();
             }
-        }, [visible, currentView]);
+        }, [visible, currentView, props.inline]);
 
         useUpdateEffect(() => {
             if (!props.onViewDateChange && !viewStateChanged.current) {


### PR DESCRIPTION
Fix #6795: Fix calendar overlay requiring double click on date to select a value when mask is present