### PR TITLE
Fix #6663: Show how to preserve filter object when mixing column and …

### DIFF
--- a/components/doc/datatable/filter/advanceddoc.js
+++ b/components/doc/datatable/filter/advanceddoc.js
@@ -237,7 +237,7 @@ export function AdvancedFilterDoc(props) {
         basic: `
 <DataTable value={customers} paginator showGridlines rows={10} loading={loading} dataKey="id" 
         filters={filters} globalFilterFields={['name', 'country.name', 'representative.name', 'balance', 'status']} header={header}
-        emptyMessage="No customers found.">
+        emptyMessage="No customers found." onFilter={(e) => setFilters(e.filters)}>
     <Column field="name" header="Name" filter filterPlaceholder="Search by name" style={{ minWidth: '12rem' }} />
     <Column header="Country" filterField="country.name" style={{ minWidth: '12rem' }} body={countryBodyTemplate}
         filter filterPlaceholder="Search by country" filterClear={filterClearTemplate} 
@@ -488,7 +488,7 @@ export default function AdvancedFilterDemo() {
         <div className="card">
             <DataTable value={customers} paginator showGridlines rows={10} loading={loading} dataKey="id" 
                     filters={filters} globalFilterFields={['name', 'country.name', 'representative.name', 'balance', 'status']} header={header}
-                    emptyMessage="No customers found.">
+                    emptyMessage="No customers found." onFilter={(e) => setFilters(e.filters)}>
                 <Column field="name" header="Name" filter filterPlaceholder="Search by name" style={{ minWidth: '12rem' }} />
                 <Column header="Country" filterField="country.name" style={{ minWidth: '12rem' }} body={countryBodyTemplate}
                     filter filterPlaceholder="Search by country" filterClear={filterClearTemplate} 
@@ -784,7 +784,7 @@ export default function AdvancedFilterDemo() {
         <div className="card">
             <DataTable value={customers} paginator showGridlines rows={10} loading={loading} dataKey="id" 
                     filters={filters} globalFilterFields={['name', 'country.name', 'representative.name', 'balance', 'status']} header={header}
-                    emptyMessage="No customers found.">
+                    emptyMessage="No customers found." onFilter={(e) => setFilters(e.filters)}>
                 <Column field="name" header="Name" filter filterPlaceholder="Search by name" style={{ minWidth: '12rem' }} />
                 <Column header="Country" filterField="country.name" style={{ minWidth: '12rem' }} body={countryBodyTemplate}
                     filter filterPlaceholder="Search by country" filterClear={filterClearTemplate} 
@@ -844,6 +844,7 @@ export default function AdvancedFilterDemo() {
                         globalFilterFields={['name', 'country.name', 'representative.name', 'balance', 'status']}
                         header={header}
                         emptyMessage="No customers found."
+                        onFilter={(e) => setFilters(e.filters)}
                     >
                         <Column field="name" header="Name" filter filterPlaceholder="Search by name" style={{ minWidth: '12rem' }} />
                         <Column


### PR DESCRIPTION
…global filter

Fix #6663

Before the outerstate of DataTable was updated with the new global value and applied to column but local column state never bubbled to the outerstate and hence we loose information when global filter enter in action.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
