### PR TITLE
fix #6978: make sure header checkbox pt gets set properly in datable

### DIFF
--- a/components/lib/datatable/HeaderCheckbox.js
+++ b/components/lib/datatable/HeaderCheckbox.js
@@ -48,19 +48,17 @@ export const HeaderCheckbox = React.memo((props) => {
     const checkIcon = IconUtils.getJSXIcon(icon, { ...headerCheckboxIconProps }, { props });
     const tabIndex = props.disabled ? null : 0;
 
-    const headerCheckboxProps = mergeProps(
-        {
-            role: 'checkbox',
-            'aria-checked': props.checked,
-            'aria-label': props.checked ? ariaLabel('selectAll') : ariaLabel('unselectAll'),
-            tabIndex: tabIndex,
-            onChange: onChange,
-            icon: checkIcon,
-            checked: props.checked,
-            disabled: props.disabled
-        },
-        getColumnPTOptions('headerCheckbox')
-    );
+    const headerCheckboxProps = mergeProps({
+        role: 'checkbox',
+        'aria-checked': props.checked,
+        'aria-label': props.checked ? ariaLabel('selectAll') : ariaLabel('unselectAll'),
+        tabIndex: tabIndex,
+        onChange: onChange,
+        icon: checkIcon,
+        checked: props.checked,
+        disabled: props.disabled,
+        pt: getColumnPTOptions('headerCheckbox')
+    });
 
     return <Checkbox {...headerCheckboxProps} />;
 });


### PR DESCRIPTION
There was a similar issue that was fixed in #6939, but only for the rowCheckbox. This fixes the same issue for the header checkbox.

Fix: #6978