### PR TITLE
Fix(InputNumber): remove styled true option in useHandleStyle

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -25,7 +25,7 @@ export const InputNumber = React.memo(
         };
         const { ptm, cx, isUnstyled } = InputNumberBase.setMetaData(metaData);
 
-        useHandleStyle(InputNumberBase.css.styles, isUnstyled, { name: 'inputnumber', styled: true });
+        useHandleStyle(InputNumberBase.css.styles, isUnstyled, { name: 'inputnumber' });
         const elementRef = React.useRef(null);
         const inputRef = React.useRef(null);
         const timer = React.useRef(null);


### PR DESCRIPTION
## Defect Fixes
- fix #6962 

<br/>

### how to resolve?
- The default CSS for inputNumber is currently not being applied. 
- The issue originated from a [previous PR](https://github.com/primefaces/primereact/pull/6930/files#diff-5d819163cb41900d134b3e9786cffe45c878ce242511be0dacaa51c41b4d13bc) where a bug with the unstyled option was fixed, resulting in `styled: true` being set, which prevented the default styles from being applied. 

<img width="1348" alt="스크린샷 2024-08-03 오후 9 05 48" src="https://github.com/user-attachments/assets/0cecfeb2-0766-4b8d-8b81-a3d6a1d951bb">

<br/>

- Therefore, I have removed the `styled: true` option :)

<br/>

### Test
#### 1. Check the style of inputNumber.

<img width="851" alt="스크린샷 2024-08-03 오후 9 13 20" src="https://github.com/user-attachments/assets/0fcfe33b-52e6-482a-948a-39d56cbff99c">

<img width="844" alt="스크린샷 2024-08-03 오후 9 13 09" src="https://github.com/user-attachments/assets/ae610c89-c743-4d71-9f30-163d51f09034">




#### 2. Check the unstyled option for inputNumber.
 
```html
<InputNumber
    unstyled    <!-- check -->
    inputId="horizontal-buttons"
    value={value2}
    onValueChange={(e) => setValue2(e.value)}
    showButtons
    buttonLayout="horizontal"
    step={0.25}
    decrementButtonClassName="p-button-danger"
    incrementButtonClassName="p-button-success"
    incrementButtonIcon="pi pi-plus"
    decrementButtonIcon="pi pi-minus"
    mode="currency"
    currency="EUR"
/>
```
<img width="828" alt="스크린샷 2024-08-03 오후 9 12 55" src="https://github.com/user-attachments/assets/8ba295f7-e515-4c18-8a42-7f3f4f087d90">

