### PR TITLE
fix:#6791:DataTable with Virtual Scroller and Multiselect; onSelectio…

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -334,29 +334,15 @@ export const TableBody = React.memo(
         const selectRange = (event) => {
             let rangeStart;
             let rangeEnd;
-            let selectedSize;
 
             const isAllowCellSelection = allowCellSelection();
-            const index = ObjectUtils.findIndexInList(event.data, props.value, props.dataKey);
 
             if (rangeRowIndex.current > anchorRowIndex.current) {
                 rangeStart = anchorRowIndex.current;
                 rangeEnd = rangeRowIndex.current;
-
-                if (!isAllowCellSelection) {
-                    selectedSize = rangeEnd - rangeStart;
-                    rangeEnd = index;
-                    rangeStart = index - selectedSize;
-                }
             } else if (rangeRowIndex.current < anchorRowIndex.current) {
                 rangeStart = rangeRowIndex.current;
                 rangeEnd = anchorRowIndex.current;
-
-                if (!isAllowCellSelection) {
-                    selectedSize = rangeEnd - rangeStart;
-                    rangeStart = index;
-                    rangeEnd = index + selectedSize;
-                }
             } else {
                 rangeStart = rangeEnd = rangeRowIndex.current;
             }
@@ -365,7 +351,7 @@ export const TableBody = React.memo(
         };
 
         const selectRangeOnRow = (event, rowRangeStart, rowRangeEnd) => {
-            const value = props.value;
+            const value = props.tableProps.value;
             let selection = [];
 
             for (let i = rowRangeStart; i <= rowRangeEnd; i++) {


### PR DESCRIPTION
Fix #6791 
Related #6211  #5870 

previously, when selecting, the data was always within the visible area. However, when using Shift, there may be data outside the visible area. should use `props.tableProps.value` to search

@nikcich  @sja-cslab @SolidAnonDev

- shfit key

https://github.com/user-attachments/assets/5c6a0b47-559a-416e-8c18-9e7efdea5953


- ctrl key

https://github.com/user-attachments/assets/4c6d0c37-4a3e-4930-942c-7a44614544f3

- drag

https://github.com/user-attachments/assets/5d964578-149d-473d-b1bb-3c080469c5bc


