### PR TITLE
fix #6984: calendar does not displays up-to-date value if date is manually entered

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -148,7 +148,6 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
-                    isTypingRef.current = true;
                     updateModel(event, value);
                     updateViewDate(event, value.length ? value[0] : value);
                 }
@@ -3074,11 +3073,12 @@ export const Calendar = React.memo(
             const newDate = props.value;
 
             if (previousValue !== newDate) {
-                if (!isTypingRef.current) {
+                const isInputFocused = document.activeElement === inputRef.current;
+
+                // Do not update value in input if user types something in it:
+                if (!isInputFocused) {
                     updateInputfield(newDate);
                 }
-
-                isTypingRef.current = false;
 
                 // #3516 view date not updated when value set programatically
                 if (!newDate) return;

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -24,7 +24,6 @@ export const Calendar = React.memo(
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
         const [idState, setIdState] = React.useState(props.id);
-        const isTypingRef = React.useRef(false);
 
         const metaData = {
             props,


### PR DESCRIPTION
Fix #6984 
Fix #4134