### PR TITLE
Fixes to undroppable tree nodes

### DIFF
--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -609,19 +609,17 @@ export const UITreeNode = React.memo((props) => {
     const onDropPoint = (event, position) => {
         event.preventDefault();
 
-        if (props.node.droppable !== false) {
-            DomHandler.removeClass(event.target, 'p-treenode-droppoint-active');
+        DomHandler.removeClass(event.target, 'p-treenode-droppoint-active');
 
-            if (props.onDropPoint) {
-                const dropIndex = position === -1 ? props.index : props.index + 1;
+        if (props.onDropPoint) {
+            const dropIndex = position === -1 ? props.index : props.index + 1;
 
-                props.onDropPoint({
-                    originalEvent: event,
-                    path: props.path,
-                    index: dropIndex,
-                    position
-                });
-            }
+            props.onDropPoint({
+                originalEvent: event,
+                path: props.path,
+                index: dropIndex,
+                position
+            });
         }
     };
 
@@ -979,7 +977,7 @@ export const UITreeNode = React.memo((props) => {
 
     const node = createNode();
 
-    if (props.dragdropScope && !props.disabled) {
+    if (props.dragdropScope && !props.disabled && props.node.droppable) {
         const beforeDropPoint = createDropPoint(-1);
         const afterDropPoint = props.last ? createDropPoint(1) : null;
 


### PR DESCRIPTION
This PR fixes 2 issues with `Tree` nodes with `droppable === false`:

When there's a node with `droppable: false`:
  - The drop point before said node would render and be active, but if you dropped another node on said drop point, it would not call onDragDrop and the drop point will remain active. (#6976).
  - The drop points within said node would render, making it effectively possible to drop into it (despite it having `droppable: false`).

Fix #6976 