### PR TITLE
Avoid droppoints within undroppable node, not around

### DIFF
--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -977,7 +977,7 @@ export const UITreeNode = React.memo((props) => {
 
     const node = createNode();
 
-    if (props.dragdropScope && !props.disabled && props.node.droppable) {
+    if (props.dragdropScope && !props.disabled && (!props.parent || props.parent.droppable)) {
         const beforeDropPoint = createDropPoint(-1);
         const afterDropPoint = props.last ? createDropPoint(1) : null;
 


### PR DESCRIPTION
### Defect Fixes
Fix #6988, which incorrectly disabled drop points around a node with `droppable: true` instead of within. 

Fix #6976
