### PR TITLE
fixes issue primefaces#7014: inserting mentions results in duplicated text

### DIFF
--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -208,8 +208,10 @@ export const Mention = React.memo(
         };
 
         const selectItem = (event, suggestion) => {
-            const value = inputRef.current.value;
-            const selectionStart = event.target.selectionStart;
+            const input = inputRef.current;
+            const value = input.value;
+            const selectionStart = input.selectionStart;
+
             const spaceIndex = value.indexOf(' ', triggerState.index);
             const currentText = value.substring(triggerState.index, spaceIndex > -1 ? spaceIndex : selectionStart);
             const selectedText = formatValue(suggestion).replace(/\s+/g, '');
@@ -218,7 +220,8 @@ export const Mention = React.memo(
                 const prevText = value.substring(0, triggerState.index);
                 const nextText = value.substring(spaceIndex > -1 ? selectionStart : triggerState.index + currentText.length);
 
-                inputRef.current.value = `${prevText}${selectedText} ${nextText}`;
+                inputRef.current.value = spaceIndex > -1 ? `${prevText}${selectedText}${nextText}` : `${prevText}${selectedText} ${nextText}`;
+
                 event.target = inputRef.current;
                 props.onChange && props.onChange(event);
             }

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -220,7 +220,7 @@ export const Mention = React.memo(
                 const prevText = value.substring(0, triggerState.index);
                 const nextText = value.substring(spaceIndex > -1 ? selectionStart : triggerState.index + currentText.length);
 
-                inputRef.current.value = spaceIndex > -1 ? `${prevText}${selectedText}${nextText}` : `${prevText}${selectedText} ${nextText}`;
+                inputRef.current.value = nextText[0] === ' ' ? `${prevText}${selectedText}${nextText}` : `${prevText}${selectedText} ${nextText}`;
 
                 event.target = inputRef.current;
                 props.onChange && props.onChange(event);


### PR DESCRIPTION
Fixes: #7014 

The issue was that `event.target` is not the form element but actually a list item element, which doesn't have the selectionStart attribute.

I've also added a change where inserting the mention in front of a space does not result in a double space.

Note: this is my first time contributing to an open source project, let me know if there's anything I can do better!

