### PR TITLE
Fix #6996: keep the selected row in its position when it gets focused below…

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -710,7 +710,7 @@ export const TableBody = React.memo(
                         !isUnstyled() && DomHandler.addClass(rowElement, 'p-datatable-dragpoint-top');
                     }
 
-                    droppedRowIndex.current = index + 1;
+                    if (index + 1 !== draggedRowIndex.current) droppedRowIndex.current = index + 1;
                     rowElement.setAttribute('data-p-datatable-dragpoint-bottom', 'true');
                     !isUnstyled() && DomHandler.addClass(rowElement, 'p-datatable-dragpoint-bottom');
                 }


### PR DESCRIPTION
### Defect Fixes
- fix #6996

### How to resolve
- Previously, the `droppedRowIndex` was updated when the row was focused at the bottom.
In the modified code, the `droppedRowIndex` is not updated if the focus occurs at the bottom of the row directly above the selected row :)

### Result

https://github.com/user-attachments/assets/9026c7ed-f813-400e-9818-85a00987f0e7

