### PR TITLE
Fix #7023: Toast typescript def for content

### DIFF
--- a/components/lib/toast/toast.d.ts
+++ b/components/lib/toast/toast.d.ts
@@ -165,7 +165,7 @@ export interface ToastMessage {
     /**
      * Custom content of the message. If enabled, summary and details properties are ignored.
      */
-    content?: React.ReactNode | undefined;
+    content?: React.ReactNode | ((props: ContentProps) => React.ReactNode);
     /**
      * Whether the message can be closed manually using the close icon.
      * @defaultValue true


### PR DESCRIPTION
Fix #7023: Toast typescript def for content