### PR TITLE
docs: remove v-model example from iconfield documentation

### DIFF
--- a/components/doc/iconfield/basicdoc.js
+++ b/components/doc/iconfield/basicdoc.js
@@ -10,12 +10,12 @@ export function BasicDoc(props) {
         basic: `
 <IconField iconPosition="left">
     <InputIcon className="pi pi-search"> </InputIcon>
-    <InputText v-model="value1" placeholder="Search" />
+    <InputText placeholder="Search" />
 </IconField>
 
 <IconField>
     <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-    <InputText v-model="value2" />
+    <InputText />
 </IconField>
         `,
         javascript: `
@@ -29,12 +29,12 @@ export default function BasicDemo() {
         <div className="flex gap-3">
             <IconField iconPosition="left">
                 <InputIcon className="pi pi-search"> </InputIcon>
-                <InputText v-model="value1" placeholder="Search" />
+                <InputText placeholder="Search" />
             </IconField>
 
             <IconField>
                 <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-                <InputText v-model="value2" />
+                <InputText />
             </IconField>
         </div>
     )
@@ -51,12 +51,12 @@ export default function BasicDemo() {
         <div className="flex gap-3">
             <IconField iconPosition="left">
                 <InputIcon className="pi pi-search"> </InputIcon>
-                <InputText v-model="value1" placeholder="Search" />
+                <InputText placeholder="Search" />
             </IconField>
 
             <IconField>
                 <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-                <InputText v-model="value2" />
+                <InputText />
             </IconField>
         </div>
     )
@@ -75,12 +75,12 @@ export default function BasicDemo() {
                 <div className="flex gap-3">
                     <IconField iconPosition="left">
                         <InputIcon className="pi pi-search" />
-                        <InputText v-model="value1" placeholder="Search" />
+                        <InputText placeholder="Search" />
                     </IconField>
 
                     <IconField>
                         <InputIcon className="pi pi-spin pi-spinner" />
-                        <InputText v-model="value2" />
+                        <InputText />
                     </IconField>
                 </div>
             </div>


### PR DESCRIPTION
This PR updates the documentation for the IconField component in `primereact/components/doc/iconfield.` The example using `<InputText v-model="value2" />` has been removed as `v-model` is not applicable; the component is implemented in React, not Vue.

**Changes Made**
Removed the example of `<InputText v-model="value2" />` from the documentation.

**Reason**
The v-model example was outdated and not relevant to the IconField component, which is a React component. This update ensures the documentation accurately reflects the current usage.

https://github.com/primefaces/primereact/issues/7028