### PR TITLE
fix: remove v-model example from iconfield documentation

### DIFF
--- a/components/doc/iconfield/basicdoc.js
+++ b/components/doc/iconfield/basicdoc.js
@@ -10,12 +10,12 @@ export function BasicDoc(props) {
         basic: `
 <IconField iconPosition="left">
     <InputIcon className="pi pi-search"> </InputIcon>
-    <InputText v-model="value1" placeholder="Search" />
+    <InputText placeholder="Search" />
 </IconField>
 
 <IconField>
     <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-    <InputText v-model="value2" />
+    <InputText />
 </IconField>
         `,
         javascript: `
@@ -29,12 +29,12 @@ export default function BasicDemo() {
         <div className="flex gap-3">
             <IconField iconPosition="left">
                 <InputIcon className="pi pi-search"> </InputIcon>
-                <InputText v-model="value1" placeholder="Search" />
+                <InputText placeholder="Search" />
             </IconField>
 
             <IconField>
                 <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-                <InputText v-model="value2" />
+                <InputText />
             </IconField>
         </div>
     )
@@ -51,12 +51,12 @@ export default function BasicDemo() {
         <div className="flex gap-3">
             <IconField iconPosition="left">
                 <InputIcon className="pi pi-search"> </InputIcon>
-                <InputText v-model="value1" placeholder="Search" />
+                <InputText placeholder="Search" />
             </IconField>
 
             <IconField>
                 <InputIcon className="pi pi-spin pi-spinner"> </InputIcon>
-                <InputText v-model="value2" />
+                <InputText />
             </IconField>
         </div>
     )
@@ -75,12 +75,12 @@ export default function BasicDemo() {
                 <div className="flex gap-3">
                     <IconField iconPosition="left">
                         <InputIcon className="pi pi-search" />
-                        <InputText v-model="value1" placeholder="Search" />
+                        <InputText placeholder="Search" />
                     </IconField>
 
                     <IconField>
                         <InputIcon className="pi pi-spin pi-spinner" />
-                        <InputText v-model="value2" />
+                        <InputText />
                     </IconField>
                 </div>
             </div>

--- a/components/doc/iconfield/templatedoc.js
+++ b/components/doc/iconfield/templatedoc.js
@@ -36,7 +36,7 @@ export function TemplateDoc(props) {
             <path d="..." fill="var(--primary-color)" />
         </svg>
     </InputIcon>
-    <InputText v-model="value1" placeholder="Search" />
+    <InputText placeholder="Search" />
 </IconField>
         `,
         javascript: `
@@ -75,7 +75,7 @@ export default function TemplateDemo() {
                     <path d="..." fill="var(--primary-color)" />
                 </svg>
             </InputIcon>
-            <InputText v-model="value1" placeholder="Search" />
+            <InputText placeholder="Search" />
         </IconField>
     )
 }
@@ -116,7 +116,7 @@ export default function TemplateDemo() {
                     <path d="..." fill="var(--primary-color)" />
                 </svg>
             </InputIcon>
-            <InputText v-model="value1" placeholder="Search" />
+            <InputText placeholder="Search" />
         </IconField>
     )
 }
@@ -159,7 +159,7 @@ export default function TemplateDemo() {
                             <path d="M12.1762 10.1789L8.4462 9.794L10.8145 7.09967H13.5378L12.1762 10.1789Z" fill="var(--primary-color)" />
                         </svg>
                     </InputIcon>
-                    <InputText v-model="value1" placeholder="Search" />
+                    <InputText placeholder="Search" />
                 </IconField>
             </div>
             <DocSectionCode code={code} />


### PR DESCRIPTION
Fixes #7028 