### PR TITLE
Fix missing commas in PrimeReact message examples

### DIFF
--- a/components/doc/messages/severitydoc.js
+++ b/components/doc/messages/severitydoc.js
@@ -27,8 +27,8 @@ msgs.current.show([
     {sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false},
     {sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false},
     {sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false},
-    {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false}
-    {sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content', closable: false}
+    {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false},
+    {sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content', closable: false},
     {sticky: true, severity: 'contrast', summary: 'Contrast', detail: 'Message Content', closable: false}
 ]);
         `,
@@ -47,8 +47,8 @@ export default function SeverityDemo() {
                 { sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content', closable: false },
                 { sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content', closable: false },
                 { sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content', closable: false },
-                { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false }
-                { sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content', closable: false }
+                { sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content', closable: false },
+                { sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content', closable: false },
                 { sticky: true, severity: 'contrast', summary: 'Contrast', detail: 'Message Content', closable: false }
             ]);
         }
@@ -73,8 +73,8 @@ export default function SeverityDemo() {
             {sticky: true, severity: 'info', summary: 'Info', detail: 'Message Content'},
             {sticky: true, severity: 'success', summary: 'Success', detail: 'Message Content'},
             {sticky: true, severity: 'warn', summary: 'Warning', detail: 'Message Content'},
-            {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content'}
-            {sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content'}
+            {sticky: true, severity: 'error', summary: 'Error', detail: 'Message Content'},
+            {sticky: true, severity: 'secondary', summary: 'Secondary', detail: 'Message Content'},
             {sticky: true, severity: 'contrast', summary: 'Contrast', detail: 'Message Content'}
         ]);
     });


### PR DESCRIPTION
This pull request fixes the missing commas in the code examples within the PrimeReact message documentation. These changes ensure that users can copy and paste the examples without encountering syntax errors.

**Changes:**

- Added missing commas in the code examples in `primereact/components/doc/messages`.

**Testing:**

- Verified that all updated code examples run without errors.
- Ensured that the documentation examples are clear and easy to follow.

**Additional Notes:**

- This update improves the user experience by providing accurate examples for developers.

