### PR TITLE
refactor(panelmenu): replace submenuIcon with expandIcon and collapse…

### DIFF
--- a/components/lib/panelmenu/PanelMenu.js
+++ b/components/lib/panelmenu/PanelMenu.js
@@ -272,6 +272,7 @@ export const PanelMenu = React.memo(
 
             const key = item.id || idState + '_' + index;
             const active = isItemActive(item);
+
             const iconClassName = classNames('p-menuitem-icon', item.icon);
             const headerIconProps = mergeProps(
                 {
@@ -279,7 +280,9 @@ export const PanelMenu = React.memo(
                 },
                 getPTOptions(item, 'headerIcon', index)
             );
+
             const icon = IconUtils.getJSXIcon(item.icon, { ...headerIconProps }, { props });
+
             const submenuIconClassName = 'p-panelmenu-icon';
             const headerSubmenuIconProps = mergeProps(
                 {
@@ -287,7 +290,13 @@ export const PanelMenu = React.memo(
                 },
                 getPTOptions(item, 'headerSubmenuIcon', index)
             );
-            const submenuIcon = item.items && IconUtils.getJSXIcon(active ? props.submenuIcon || <ChevronDownIcon {...headerSubmenuIconProps} /> : props.submenuIcon || <ChevronRightIcon {...headerSubmenuIconProps} />);
+            
+            const submenuIcon = item.items && IconUtils.getJSXIcon(
+                active 
+                    ? (props.collapseIcon || <ChevronDownIcon {...headerSubmenuIconProps} />) 
+                    : (props.expandIcon || <ChevronRightIcon {...headerSubmenuIconProps} />)
+            );
+        
             const headerLabelProps = mergeProps(
                 {
                     className: cx('headerLabel')

--- a/components/lib/panelmenu/PanelMenuBase.js
+++ b/components/lib/panelmenu/PanelMenuBase.js
@@ -75,7 +75,6 @@ export const PanelMenuBase = ComponentBase.extend({
         id: null,
         model: null,
         style: null,
-        submenuIcon: null,
         expandedKeys: null,
         className: null,
         onExpandedKeysChange: null,
@@ -83,6 +82,8 @@ export const PanelMenuBase = ComponentBase.extend({
         onClose: null,
         multiple: false,
         transitionOptions: null,
+        expandIcon: null,
+        collapseIcon: null,
         children: undefined
     },
     css: {

--- a/components/lib/panelmenu/PanelMenuList.js
+++ b/components/lib/panelmenu/PanelMenuList.js
@@ -429,7 +429,8 @@ export const PanelMenuList = React.memo((props) => {
             onItemToggle={onItemToggle}
             level={0}
             className={cx('submenu')}
-            submenuIcon={props.submenuIcon}
+            expandIcon={props.expandIcon}
+            collapseIcon={props.collapseIcon}
             root
             ptm={ptm}
             cx={cx}

--- a/components/lib/panelmenu/PanelMenuSub.js
+++ b/components/lib/panelmenu/PanelMenuSub.js
@@ -137,7 +137,8 @@ export const PanelMenuSub = React.memo(
                                 onItemToggle={onItemToggle}
                                 menuProps={props.menuProps}
                                 model={processedItem.items}
-                                submenuIcon={props.submenuIcon}
+                                expandIcon={props.expandIcon}
+                                collapseIcon={props.collapseIcon}
                                 ptm={ptm}
                                 cx={cx}
                             />
@@ -183,7 +184,13 @@ export const PanelMenuSub = React.memo(
                 },
                 getPTOptions(processedItem, 'submenuicon', index)
             );
-            const submenuIcon = item.items && IconUtils.getJSXIcon(active ? props.submenuIcon || <ChevronDownIcon {...submenuIconProps} /> : props.submenuIcon || <ChevronRightIcon {...submenuIconProps} />);
+
+            const submenuIcon = item.items && IconUtils.getJSXIcon(
+                active 
+                    ? (props.collapseIcon || <ChevronDownIcon {...submenuIconProps} />) 
+                    : (props.expandIcon || <ChevronRightIcon {...submenuIconProps} />)
+            );
+            
             const submenu = createSubmenu(processedItem, active);
             const actionProps = mergeProps(
                 {

--- a/components/lib/panelmenu/panelmenu.d.ts
+++ b/components/lib/panelmenu/panelmenu.d.ts
@@ -53,9 +53,13 @@ export interface PanelMenuPassThroughOptions {
      */
     headerContent?: PanelMenuPassThroughType<React.HTMLAttributes<HTMLDivElement>>;
     /**
-     * Uses to pass attributes to the submenuIcon's DOM element.
+     * Uses to pass attributes to the expand icon's DOM element.
      */
-    submenuIcon?: PanelMenuPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    expandIcon?: PanelMenuPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    /**
+     * Uses to pass attributes to the collapse icon's DOM element.
+     */
+    collapseIcon?: PanelMenuPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
     /**
      * Uses to pass attributes to the header icon's DOM element.
      */
@@ -179,9 +183,13 @@ export interface PanelMenuProps extends Omit<React.DetailedHTMLProps<React.HTMLA
      */
     multiple?: boolean | undefined;
     /**
-     * Icon of the submenu.
+     * Icon used when a submenu is collapsed.
      */
-    submenuIcon?: IconType<PanelMenuProps> | undefined;
+    expandIcon?: IconType<PanelMenuProps> | undefined;
+    /**
+     * Icon used when a submenu is expanded.
+     */
+    collapseIcon?: IconType<PanelMenuProps> | undefined;
     /**
      * The properties of CSSTransition can be customized, except for "nodeRef" and "in" properties.
      */


### PR DESCRIPTION
## Description

This PR addresses the need to replace the deprecated `submenuIcon` prop with `expandIcon` and `collapseIcon` in the `PanelMenu` component, enhancing the flexibility and customization of icons used in expanded and collapsed states.

## Changes Made

- Replaced `submenuIcon` with `expandIcon` and `collapseIcon` in `PanelMenuList`, `PanelMenuSub`, and related components.
- Updated TypeScript definitions to reflect the new properties.
- Added passthrough options for `expandIcon` and `collapseIcon`.
- Updated styles and removed references to `submenuIcon`.

## Related Issue

This PR resolves [Issue #7026](https://github.com/primefaces/primereact/issues/7026).

## Tasks

- [x] Implemented `expandIcon` and `collapseIcon`.
- [x] Updated TypeScript definitions.
- [x] Modified styles and removed `submenuIcon`.
- [ ] Update documentation to reflect the changes.
- [ ] Add examples for using `expandIcon` and `collapseIcon`.
