### PR TITLE
Fix #6998: add closest check condition to detect handle icon drag.

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -592,25 +592,12 @@ export const TableBody = React.memo(
         const onRowMouseDown = (e) => {
             const { originalEvent: event } = e;
 
-            if (isUnstyled()) {
-                const isDraggableHandle = DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon' || event.target.closest('[data-pc-section="rowreordericon"]');
+            const isDraggableHandle = isUnstyled()
+                ? DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon' || event.target.closest('[data-pc-section="rowreordericon"]')
+                : DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
 
-                if (isDraggableHandle) {
-                    event.currentTarget.draggable = true;
-                    event.target.draggable = false;
-                } else {
-                    event.currentTarget.draggable = false;
-                }
-            } else {
-                const isDraggableHandle = DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
-
-                if (isDraggableHandle) {
-                    event.currentTarget.draggable = true;
-                    event.target.draggable = false;
-                } else {
-                    event.currentTarget.draggable = false;
-                }
-            }
+            event.currentTarget.draggable = isDraggableHandle;
+            event.target.draggable = !isDraggableHandle;
 
             if (allowRowDrag(e)) {
                 enableDragSelection(event, 'row');

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -593,18 +593,18 @@ export const TableBody = React.memo(
             const { originalEvent: event } = e;
 
             if (isUnstyled()) {
-                const isDragHandle = DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon' || event.target.closest('[data-pc-section="rowreordericon"]');
+                const isDraggableHandle = DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon' || event.target.closest('[data-pc-section="rowreordericon"]');
 
-                if (isDragHandle) {
+                if (isDraggableHandle) {
                     event.currentTarget.draggable = true;
                     event.target.draggable = false;
                 } else {
                     event.currentTarget.draggable = false;
                 }
             } else {
-                const isDragHandle = DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
+                const isDraggableHandle = DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
 
-                if (isDragHandle) {
+                if (isDraggableHandle) {
                     event.currentTarget.draggable = true;
                     event.target.draggable = false;
                 } else {

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -592,14 +592,24 @@ export const TableBody = React.memo(
         const onRowMouseDown = (e) => {
             const { originalEvent: event } = e;
 
-            if (!isUnstyled() && DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle')) {
-                event.currentTarget.draggable = true;
-                event.target.draggable = false;
-            } else if (isUnstyled() && DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon') {
-                event.currentTarget.draggable = true;
-                event.target.draggable = false;
+            if (isUnstyled()) {
+                const isDragHandle = DomHandler.getAttribute(event.target, 'data-pc-section') === 'rowreordericon' || event.target.closest('[data-pc-section="rowreordericon"]');
+
+                if (isDragHandle) {
+                    event.currentTarget.draggable = true;
+                    event.target.draggable = false;
+                } else {
+                    event.currentTarget.draggable = false;
+                }
             } else {
-                event.currentTarget.draggable = false;
+                const isDragHandle = DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
+
+                if (isDragHandle) {
+                    event.currentTarget.draggable = true;
+                    event.target.draggable = false;
+                } else {
+                    event.currentTarget.draggable = false;
+                }
             }
 
             if (allowRowDrag(e)) {


### PR DESCRIPTION
## Defect Fixes
- fix #6998 
### Cause
- In the dataTable, handle drag sometimes does not trigger.
- This issue occurs when the mousedown event is fired on the handle, and the event.target is a child element (e.g., `<path>`) of the icon.

_In the video, you can see in the console that sorting fails to work when `event.target` is a `<path>` element._

https://github.com/user-attachments/assets/351a5b1f-dcc5-4c3c-a435-e814a6df48f2


<br/>


### Solution
- To determine if the handle is being used, the `closest`([mdn docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest)) function is employed to check if the parent element of `event.target` is the handle element.
- This allows sorting to occur even if a child element (e.g., `<path>`) within the icon is selected, as long as the parent element is the handle.

_fixed example_

https://github.com/user-attachments/assets/a7188988-d0aa-437a-91df-3c18546a8191


