### PR TITLE
fix: #6868 Refactor location of tailwind styles

### DIFF
--- a/components/doc/tabview/theming/tailwinddoc.js
+++ b/components/doc/tabview/theming/tailwinddoc.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 export function TailwindDoc(props) {
     const code = {
         basic: `
-const Tailwind = {          
+const Tailwind = {
     tabview: {
         navContainer: ({ props }) => ({
             className: classNames(
@@ -23,30 +23,30 @@ const Tailwind = {
         nav: {
             className: classNames('flex flex-1 list-none m-0 p-0', 'bg-transparent border border-gray-300 border-0 border-b-2', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 ') // Flex, list, margin, padding, and border styles.
         },
-        tabpanel: {
-            header: ({ props }) => ({
-                className: classNames('mr-0', { 'cursor-default pointer-events-none select-none user-select-none opacity-60': props?.disabled }) // Margin and condition-based styles.
-            }),
-            headerAction: ({ parent, context }) => ({
-                className: classNames(
-                    'items-center cursor-pointer flex overflow-hidden relative select-none text-decoration-none user-select-none', // Flex and overflow styles.
-                    'border-b-2 p-5 font-bold rounded-t-md transition-shadow duration-200 m-0', // Border, padding, font, and transition styles.
-                    'transition-colors duration-200', // Transition duration style.
-                    'focus:outline-none focus:outline-offset-0 focus:shadow-[inset_0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]', // Focus styles.
-                    {
-                        'border-gray-300 bg-white text-gray-700 hover:bg-white hover:border-gray-400 hover:text-gray-600 dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 dark:hover:bg-gray-800/80':
-                            parent.state.activeIndex !== context.index, // Condition-based hover styles.
-                        'bg-white border-blue-500 text-blue-500 dark:bg-gray-900 dark:border-blue-300 dark:text-blue-300': parent.state.activeIndex === context.index // Condition-based active styles.
-                    }
-                ),
-                style: { marginBottom: '-2px' } // Negative margin style.
-            }),
-            headerTitle: {
-                className: classNames('leading-none whitespace-nowrap') // Leading and whitespace styles.
-            },
-            content: {
-                className: classNames('bg-white p-5 border-0 text-gray-700 rounded-bl-md rounded-br-md', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80') // Background, padding, border, and text styles.
-            }
+    },
+    tabpanel: {
+        header: ({ props }) => ({
+            className: classNames('mr-0', { 'cursor-default pointer-events-none select-none user-select-none opacity-60': props?.disabled }) // Margin and condition-based styles.
+        }),
+        headerAction: ({ parent, context }) => ({
+            className: classNames(
+                'items-center cursor-pointer flex overflow-hidden relative select-none text-decoration-none user-select-none', // Flex and overflow styles.
+                'border-b-2 p-5 font-bold rounded-t-md transition-shadow duration-200 m-0', // Border, padding, font, and transition styles.
+                'transition-colors duration-200', // Transition duration style.
+                'focus:outline-none focus:outline-offset-0 focus:shadow-[inset_0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]', // Focus styles.
+                {
+                    'border-gray-300 bg-white text-gray-700 hover:bg-white hover:border-gray-400 hover:text-gray-600 dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 dark:hover:bg-gray-800/80':
+                        parent.state.activeIndex !== context.index, // Condition-based hover styles.
+                    'bg-white border-blue-500 text-blue-500 dark:bg-gray-900 dark:border-blue-300 dark:text-blue-300': parent.state.activeIndex === context.index // Condition-based active styles.
+                }
+            ),
+            style: { marginBottom: '-2px' } // Negative margin style.
+        }),
+        headerTitle: {
+            className: classNames('leading-none whitespace-nowrap') // Leading and whitespace styles.
+        },
+        content: {
+            className: classNames('bg-white p-5 border-0 text-gray-700 rounded-bl-md rounded-br-md', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80') // Background, padding, border, and text styles.
         }
     }
 }
@@ -55,7 +55,7 @@ const Tailwind = {
 
     const code2 = {
         javascript: `
-import React from 'react'; 
+import React from 'react';
 import { TabView, TabPanel } from 'primereact/tabview';
 
 export default function UnstyledDemo() {
@@ -64,25 +64,25 @@ export default function UnstyledDemo() {
             <TabView>
                 <TabPanel header="Header I">
                     <p className="m-0">
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 
+                        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                         Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </p>
                 </TabPanel>
                 <TabPanel header="Header II">
                     <p className="m-0">
-                        Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, 
+                        Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam,
                         eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
-                        enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui 
+                        enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui
                         ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
                     </p>
                 </TabPanel>
                 <TabPanel header="Header III">
                     <p className="m-0">
-                        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti 
+                        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti
                         quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in
-                        culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. 
+                        culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
                         Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
                     </p>
                 </TabPanel>

--- a/components/lib/passthrough/tailwind/index.js
+++ b/components/lib/passthrough/tailwind/index.js
@@ -250,31 +250,30 @@ const Tailwind = {
         },
         nav: {
             className: classNames('flex flex-1 list-none m-0 p-0', 'bg-transparent border border-gray-300 border-0 border-b-2', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 ') // Flex, list, margin, padding, and border styles.
+        }
+    },
+    tabpanel: {
+        header: ({ props }) => ({
+            className: classNames('mr-0', { 'cursor-default pointer-events-none select-none user-select-none opacity-60': props?.disabled }) // Margin and condition-based styles.
+        }),
+        headerAction: ({ parent, context }) => ({
+            className: classNames(
+                'items-center cursor-pointer flex overflow-hidden relative select-none text-decoration-none user-select-none', // Flex and overflow styles.
+                'border-b-2 p-5 font-bold rounded-t-md transition-shadow duration-200 m-0', // Border, padding, font, and transition styles.
+                'transition-colors duration-200', // Transition duration style.
+                'focus:outline-none focus:outline-offset-0 focus:shadow-[inset_0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]', // Focus styles.
+                {
+                    'border-gray-300 bg-white text-gray-700 hover:bg-white hover:border-gray-400 hover:text-gray-600 dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 dark:hover:bg-gray-800/80': parent.state.activeIndex !== context.index, // Condition-based hover styles.
+                    'bg-white border-blue-500 text-blue-500 dark:bg-gray-900 dark:border-blue-300 dark:text-blue-300': parent.state.activeIndex === context.index // Condition-based active styles.
+                }
+            ),
+            style: { marginBottom: '-2px' } // Negative margin style.
+        }),
+        headerTitle: {
+            className: classNames('leading-none whitespace-nowrap') // Leading and whitespace styles.
         },
-        tabpanel: {
-            header: ({ props }) => ({
-                className: classNames('mr-0', { 'cursor-default pointer-events-none select-none user-select-none opacity-60': props?.disabled }) // Margin and condition-based styles.
-            }),
-            headerAction: ({ parent, context }) => ({
-                className: classNames(
-                    'items-center cursor-pointer flex overflow-hidden relative select-none text-decoration-none user-select-none', // Flex and overflow styles.
-                    'border-b-2 p-5 font-bold rounded-t-md transition-shadow duration-200 m-0', // Border, padding, font, and transition styles.
-                    'transition-colors duration-200', // Transition duration style.
-                    'focus:outline-none focus:outline-offset-0 focus:shadow-[inset_0_0_0_0.2rem_rgba(191,219,254,1)] dark:focus:shadow-[inset_0_0_0_0.2rem_rgba(147,197,253,0.5)]', // Focus styles.
-                    {
-                        'border-gray-300 bg-white text-gray-700 hover:bg-white hover:border-gray-400 hover:text-gray-600 dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80 dark:hover:bg-gray-800/80':
-                            parent.state.activeIndex !== context.index, // Condition-based hover styles.
-                        'bg-white border-blue-500 text-blue-500 dark:bg-gray-900 dark:border-blue-300 dark:text-blue-300': parent.state.activeIndex === context.index // Condition-based active styles.
-                    }
-                ),
-                style: { marginBottom: '-2px' } // Negative margin style.
-            }),
-            headerTitle: {
-                className: classNames('leading-none whitespace-nowrap') // Leading and whitespace styles.
-            },
-            content: {
-                className: classNames('bg-white p-5 border-0 text-gray-700 rounded-bl-md rounded-br-md', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80') // Background, padding, border, and text styles.
-            }
+        content: {
+            className: classNames('bg-white p-5 border-0 text-gray-700 rounded-bl-md rounded-br-md', 'dark:bg-gray-900 dark:border-blue-900/40 dark:text-white/80') // Background, padding, border, and text styles.
         }
     },
     splitter: {

--- a/pages/tabview/index.js
+++ b/pages/tabview/index.js
@@ -101,7 +101,18 @@ const TabViewDemo = () => {
         }
     ];
 
-    return <DocComponent title="React Tabs Component" header="TabView" description="TabView is a container component to group content with tabs." componentDocs={docs} apiDocs={['TabView', 'TabPanel']} ptDocs={ptDocs} ptDescription="" />;
+    return (
+        <DocComponent
+            title="React Tabs Component"
+            header="TabView"
+            description="TabView is a container component to group content with tabs."
+            componentDocs={docs}
+            apiDocs={['TabView', 'TabPanel']}
+            ptDocs={ptDocs}
+            ptDescription=""
+            themingDocs={themingDocs}
+        />
+    );
 };
 
 export default TabViewDemo;


### PR DESCRIPTION
### Defect Fixes
- Fixes  #6868
- Refactor location of tailwind styles
- Enable theme docs for tabview

@melloware For whatever reason the theme documentation was not hooked up for Tabview even though it was all written and in place. I went ahead and fixed that as well.

<img width="1079" alt="Screenshot 2024-08-16 at 10 29 06" src="https://github.com/user-attachments/assets/9085f192-9710-4286-8cc8-a5d261d80dd1">


Another thing @melloware -> I have the styling working but there are a few things that should be fixed to make the default tailwind styling a bit better (fix the missing bottom border, for instance)