### PR TITLE
Fix: allow zero value using nullish coalescing operator(Slider)

### DIFF
--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -20,7 +20,7 @@ export const Slider = React.memo(
         const barWidth = React.useRef(0);
         const barHeight = React.useRef(0);
         const touchId = React.useRef();
-        const value = props.range ? props.value || [props.min, props.max] : props.value || props.min || 0;
+        const value = props.range ? props.value ?? [props.min, props.max] : props.value ?? props.min ?? 0;
         const horizontal = props.orientation === 'horizontal';
         const vertical = props.orientation === 'vertical';
 


### PR DESCRIPTION
### Defect Fixes
- fix #7072 
- The issue where the value is being reset to the minimum, when the value is 0 occurs 
- Because the logical OR (`||`) operator treats 0 as a falsy value. 
- To address this, I modified the operator to use the nullish coalescing operator (`??`)(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing">mdn docs</a>), which only checks for null or undefined, ensuring that a value of 0 is preserved and not replaced by the default.

<br/>

### Test
> When the min value is set to -180 and the max value is set to 180.

_Before_
- When the value is 0, the handle moves to the wrong position.

https://github.com/user-attachments/assets/f75e99f1-1319-42a3-87e6-91f49a071a4e

<br/>

_After_

https://github.com/user-attachments/assets/1bb0915d-bce7-4e42-a8ab-57f13ccf3515

