### PR TITLE
fix(DataTable): Don't mix controlled and uncontrolled filter

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1503,7 +1503,12 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             filter(props.globalFilter, 'global', props.globalFilterMatchMode);
         } else {
             // #3819 was filtering but now reset filter state
-            setFiltersState(props.filters);
+            if (d_filtersState["global"]) {
+                let filters = { ...d_filtersState };
+                delete filters["global"];
+                setD_filtersState(filters);
+                onFilterApply(filters);
+            }
         }
     }, [props.globalFilter, props.globalFilterMatchMode]);
 


### PR DESCRIPTION
In a components where `props.filters` is not set because user rely on generated filter object: if a column filter is applied, a global filter is applied and then the global filter set to "" the `props.filter` is used (null) instead of the generated filter (object with only one column defined).

The generated filter object before global filtering enter in action has no `global` key: so we revert this modifications.

Fix #7103
