### PR TITLE
Fix #6784 - Toast onRemove message

### DIFF
--- a/components/lib/messages/Messages.js
+++ b/components/lib/messages/Messages.js
@@ -77,7 +77,7 @@ export const Messages = React.memo(
 
             setMessagesState((prev) => prev.filter((msg) => msg._pId !== messageInfo._pId && !ObjectUtils.deepEquals(msg.message, removeMessage)));
 
-            props.onRemove && props.onRemove(removeMessage.message || removeMessage);
+            props.onRemove && props.onRemove(messageInfo.message || removeMessage);
         };
 
         const onClose = (messageInfo) => {

--- a/components/lib/toast/Toast.js
+++ b/components/lib/toast/Toast.js
@@ -80,7 +80,7 @@ export const Toast = React.memo(
 
             setMessagesState((prev) => prev.filter((msg) => msg._pId !== messageInfo._pId && !ObjectUtils.deepEquals(msg.message, removeMessage)));
 
-            props.onRemove && props.onRemove(removeMessage.message || removeMessage);
+            props.onRemove && props.onRemove(messageInfo.message || removeMessage);
         };
 
         const onClose = (messageInfo) => {


### PR DESCRIPTION
### Defect Fixes
This PR changes the return parameters on onRemove method to pass the original message instead of changing to return _pId when existing, if the original message is there, because removeMessage.message doesn't exist when the _pId is defined. This PR fix #6784 
