### PR TITLE
Fix #7109: SplitterPanel pass onClick through

### DIFF
--- a/components/lib/splitter/Splitter.js
+++ b/components/lib/splitter/Splitter.js
@@ -449,7 +449,8 @@ export const Splitter = React.memo(
                     className: panelClassName,
                     style: { ...getPanelProp(panel, 'style'), flexBasis },
                     role: 'presentation',
-                    'data-p-splitter-panel-nested': false
+                    'data-p-splitter-panel-nested': false,
+                    onClick: getPanelProp(panel, 'onClick')
                 },
                 getPanelPT('splitterpanel.root')
             );


### PR DESCRIPTION
Fix #7109: SplitterPanel pass onClick through