### PR TITLE
Fix #7118 : Updating Chart accessibility documentation

### DIFF
--- a/components/doc/chart/accessibilitydoc.js
+++ b/components/doc/chart/accessibilitydoc.js
@@ -4,7 +4,7 @@ import { DocSectionText } from '@/components/doc/common/docsectiontext';
 export function AccessibilityDoc() {
     const code = {
         basic: `
-<Chart type="line" data={data} canvasProps={{'role': 'img', 'aria-label': 'Data'}} />
+<Chart type="line" data={data} pt={canvas: {'role': 'img', 'aria-label': 'Data'}}} />
 
 <Chart type="line" data={data}>
     <DataTable />
@@ -20,8 +20,8 @@ export function AccessibilityDoc() {
                 <a className="text-primary hover:underline font-medium" href="https://www.chartjs.org/docs/latest/general/accessibility.html">
                     Chart.js accessibility
                 </a>{' '}
-                guide for more information. The canvas element can be customized with <i>canvasProps</i> property to define aria roles and properties, in addition any content inside the component is directly passed as a child of the canvas to be able
-                to provide fallback content like a table.
+                guide for more information. The canvas element can be customized with <i>pt</i> property to define aria roles and properties, in addition any content inside the component is directly passed as a child of the canvas to be able to
+                provide fallback content like a table.
             </p>
             <DocSectionCode code={code} hideToggleCode import hideStackBlitz />
         </DocSectionText>


### PR DESCRIPTION
Fix #7118 : Updating Chart accessibility documentation

The documentation mentions a 'canvasProps' property which is not available in PrimeReact.  To define aria roles and properties, the 'pt' property must be used insteed.
