### PR TITLE
Fix #7120: Breadcrumb shows a trailing separator when there…

### DIFF
--- a/components/lib/breadcrumb/BreadCrumb.js
+++ b/components/lib/breadcrumb/BreadCrumb.js
@@ -263,7 +263,7 @@ export const BreadCrumb = React.memo(
             <nav {...rootProps}>
                 <ol {...menuProps}>
                     {home}
-                    {home && separator}
+                    {home && !!items?.length && separator}
                     {items}
                 </ol>
             </nav>


### PR DESCRIPTION
Fix #7120: Breadcrumb shows a trailing separator when there is only one item