### PR TITLE
feat: make AdditionalProps argument in IconOptions type optional

### DIFF
--- a/components/lib/utils/utils.d.ts
+++ b/components/lib/utils/utils.d.ts
@@ -181,7 +181,7 @@ export declare namespace ZIndexUtils {
  * @template ComponentProps Props from the owning component.
  * @template AdditionalProps Any custom properties of an icon like SortIcon of the Datatable for example.
  */
-export type IconOptions<ComponentProps, AdditionalProps> = AdditionalProps & {
+export type IconOptions<ComponentProps, AdditionalProps = NonNullable<unknown>> = AdditionalProps & {
     /**
      * Icon specific properties. Size property allows FontAwesome to work properly.
      * @type {(React.HTMLProps<unknown> & { size?: string }) | (React.SVGProps<unknown> & { size?: string })}


### PR DESCRIPTION
### Feature Requests

### Description
When switching from PrimeReact `v9.6.3` to `v10.8.2`, i had to do some migrations due to the feature introduced by https://github.com/primefaces/primereact/pull/4642.

Also, i noticed the inconsistency among the code in `utils.d.ts`, i.e. `AdditionalProps` argument is defined to be optional in some places. Yet, I believe, `IconOptions` was missed out.

This PR makes the `AdditionalProps` argument for the type `IconOptions` optional, so that you don't get the following TypeScript error:
![screenshot](https://github.com/user-attachments/assets/37021ec4-64f0-47ff-a319-cfa3734a4cac)

P.S. This relates to a closed issue https://github.com/primefaces/primereact/issues/4639 and I'm not sure whether to create new one.