### PR TITLE
Fix #7166 - Datatable : fix ColumnFilter aria-controls

### DIFF
--- a/components/lib/datatable/ColumnFilter.js
+++ b/components/lib/datatable/ColumnFilter.js
@@ -559,7 +559,7 @@ export const ColumnFilter = React.memo((props) => {
                 'aria-haspopup': true,
                 'aria-expanded': overlayVisibleState,
                 'aria-label': label,
-                'aria-controls': overlayId.current,
+                'aria-controls': overlayVisibleState ? overlayId.current : undefined,
                 onClick: (e) => toggleMenu(e),
                 onKeyDown: (e) => onToggleButtonKeyDown(e)
             },


### PR DESCRIPTION
Set `aria-controls` for ColumnFilter only when the menu filter is visible in DOM.

fix #7166