### PR TITLE
Fix #7165: Badge/Tag typescript add secondary and contrast

### DIFF
--- a/components/lib/badge/badge.d.ts
+++ b/components/lib/badge/badge.d.ts
@@ -51,7 +51,7 @@ export interface BadgeProps extends Omit<React.DetailedHTMLProps<React.HTMLAttri
      * Severity type of the badge.
      * @defaultValue null
      */
-    severity?: 'success' | 'info' | 'warning' | 'danger' | null | undefined;
+    severity?: 'success' | 'info' | 'warning' | 'danger' | 'secondary' | 'contrast' | null | undefined;
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @defaultValue null

--- a/components/lib/tag/tag.d.ts
+++ b/components/lib/tag/tag.d.ts
@@ -58,7 +58,7 @@ export interface TagProps extends Omit<React.DetailedHTMLProps<React.HTMLAttribu
      * Severity type of the tag.
      * @defaultValue null
      */
-    severity?: 'success' | 'info' | 'warning' | 'danger' | null | undefined;
+    severity?: 'success' | 'info' | 'warning' | 'danger' | 'secondary' | 'contrast' | null | undefined;
     /**
      * Whether the corners of the tag are rounded.
      * @defaultValue false


### PR DESCRIPTION
Fix #7165: Badge/Tag typescript add secondary and contrast