### PR TITLE
Fix: TabMenu - resolve rendering issue of stackblitz apps for Command and Template examples

### DIFF
--- a/components/doc/tabmenu/commanddoc.js
+++ b/components/doc/tabmenu/commanddoc.js
@@ -44,8 +44,9 @@ export function CommandDoc(props) {
 <TabMenu model={items} />
         `,
         javascript: `
-import React from 'react'; 
+import { useRef } from 'react';
 import { TabMenu } from 'primereact/tabmenu';
+import { Toast } from 'primereact/toast';
 
 export default function CommandDemo() {
     const toast = useRef(null);
@@ -89,9 +90,10 @@ export default function CommandDemo() {
 }
         `,
         typescript: `
-import React from 'react'; 
+import { useRef } from 'react';
 import { TabMenu } from 'primereact/tabmenu';
 import { MenuItem } from 'primereact/menuitem';
+import { Toast } from 'primereact/toast';
 
 export default function CommandDemo() {
     const toast = useRef<Toast>(null);

--- a/components/doc/tabmenu/templatedoc.js
+++ b/components/doc/tabmenu/templatedoc.js
@@ -35,7 +35,7 @@ export function TemplateDoc(props) {
 <TabMenu model={items} activeIndex={activeIndex} onTabChange={(e) => setActiveIndex(e.index)} />
         `,
         javascript: `
-import React from 'react'; 
+import { useState } from 'react';
 import { TabMenu } from 'primereact/tabmenu';
 
 export default function TemplateDemo() {
@@ -74,9 +74,8 @@ export default function TemplateDemo() {
 }
         `,
         typescript: `
-import React from 'react'; 
+import { useState } from 'react';
 import { TabMenu } from 'primereact/tabmenu';
-import { MenuItem } from 'primereact/menuitem';
 
 export default function TemplateDemo() {
     const [activeIndex, setActiveIndex] = useState<number>(0);


### PR DESCRIPTION
- In TabMenu documentation, update import to fix rendering issue of Command code examples hosted on stackblitz, both javascript and typescript. (Fix #7169) 
- In TabMenu documentation, update import to fix rendering issue of Template code examples hosted on stackblitz, both javascript and typescript. (Fix #7170) 