### PR TITLE
Fix #7182: FloatLabel proper SPAN attributes

### DIFF
--- a/components/lib/floatlabel/floatlabel.d.ts
+++ b/components/lib/floatlabel/floatlabel.d.ts
@@ -83,4 +83,4 @@ export interface FloatLabelProps {
  * @group Component
  *
  */
-export declare const FloatLabel: React.ForwardRefExoticComponent<FloatLabelProps & React.RefAttributes<HTMLSpanElement>>;
+export declare const FloatLabel: React.ForwardRefExoticComponent<FloatLabelProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLSpanElement>, HTMLSpanElement>>;


### PR DESCRIPTION
Fix #7182: FloatLabel proper SPAN attributes