### PR TITLE
fix: align OverlayPanel arrow directly above trigger for top position #7204

### DIFF
--- a/components/lib/overlaypanel/OverlayPanelBase.js
+++ b/components/lib/overlaypanel/OverlayPanelBase.js
@@ -25,7 +25,7 @@ const styles = `
     }
     
     .p-overlaypanel-flipped {
-        margin-top: 0;
+        margin-top: -10px;
         margin-bottom: 10px;
     }
     


### PR DESCRIPTION
Fix #7204 

Before:
![Screen Shot 2024-09-18 at 00 02 10 AM](https://github.com/user-attachments/assets/90be1084-2b5c-47db-a54b-bfdfd70747e0)

After: 
![Screen Shot 2024-09-18 at 00 02 24 AM](https://github.com/user-attachments/assets/c2e8244b-cc8f-4cc9-90bb-d48071a62271)
