### PR TITLE
fix #7210: align ConfirmPopup arrow directly above trigger for top position

### DIFF
--- a/components/lib/confirmpopup/ConfirmPopup.js
+++ b/components/lib/confirmpopup/ConfirmPopup.js
@@ -142,7 +142,7 @@ export const ConfirmPopup = React.memo(
 
         const onEnter = () => {
             ZIndexUtils.set('overlay', overlayRef.current, (context && context.autoZIndex) || PrimeReact.autoZIndex, (context && context.zIndex.overlay) || PrimeReact.zIndex.overlay);
-            DomHandler.addStyles(overlayRef.current, { position: 'absolute', top: '50%', left: '50%', marginTop: '10px' });
+            DomHandler.addStyles(overlayRef.current, { position: 'absolute', top: '0', left: '0' });
             align();
         };
 

--- a/components/lib/confirmpopup/ConfirmPopupBase.js
+++ b/components/lib/confirmpopup/ConfirmPopupBase.js
@@ -4,9 +4,12 @@ import { classNames } from '../utils/Utils';
 
 const styles = `
 @layer primereact {
+   .p-confirm-popup {
+        margin-top: 10px;       
+    }
+
     .p-confirm-popup-flipped {
-        margin-top: 0;
-        margin-bottom: 10px;
+        margin-top: -10px;
     }
     
     .p-confirm-popup:after, .p-confirm-popup:before {


### PR DESCRIPTION
Fix #7210 

Before:
![Screen Shot 2024-09-18 at 11 52 09 AM](https://github.com/user-attachments/assets/5ce48c2e-f63f-4534-a5e5-b4dda0d613a5)

After:
![Screen Shot 2024-09-18 at 11 52 46 AM](https://github.com/user-attachments/assets/f6b5932b-95ac-4449-a256-4bed662ecf0b)

