### PR TITLE
fix: #7200 Fix Drag Selection for Datatable

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -151,7 +151,7 @@ export const TableBody = React.memo(
         };
 
         const allowRowDrag = (event) => {
-            return (!allowCellSelection() && allowDrag(event)) || props.reorderableRows;
+            return (!allowCellSelection() && allowDrag({ originalEvent: event })) || props.reorderableRows;
         };
 
         const allowCellDrag = (event) => {

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -151,7 +151,7 @@ export const TableBody = React.memo(
         };
 
         const allowRowDrag = (event) => {
-            return (!allowCellSelection() && allowDrag({ originalEvent: event })) || props.reorderableRows;
+            return (!allowCellSelection() && allowDrag(event)) || props.reorderableRows;
         };
 
         const allowCellDrag = (event) => {
@@ -668,7 +668,7 @@ export const TableBody = React.memo(
         const onRowDragStart = (e) => {
             const { originalEvent: event, index } = e;
 
-            if (allowRowDrag(event)) {
+            if (allowRowDrag(e)) {
                 rowDragging.current = true;
                 draggedRowIndex.current = index;
                 event.dataTransfer.setData('text', 'b'); // For firefox


### PR DESCRIPTION
### Defect Fixes
fix: #7200 Fix Drag Selection for Datatable

The existing implementation of `allowRowDrag` takes an "event" and passes it through to `allowDrag`, however `allowDrag` expects the `event` parameter to have `originalEvent` as a property. This PR fixes that issue.