### PR TITLE
fix: #7239: Incorrect behaviour of dragging over DataTable rows

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -678,7 +678,11 @@ export const TableBody = React.memo(
         const onRowDragOver = (e) => {
             const { originalEvent: event, index } = e;
 
-            if (rowDragging.current && draggedRowIndex.current !== index) {
+            if (!rowDragging.current) {
+                return;
+            }
+
+            if (draggedRowIndex.current !== index) {
                 const rowElement = event.currentTarget;
                 const rowY = DomHandler.getOffset(rowElement).top + DomHandler.getWindowScrollTop();
                 const pageY = event.pageY + window.scrollY;


### PR DESCRIPTION
### Defect Fixes
https://github.com/primefaces/primereact/issues/7239

### Changes
Fixed onRowDragOver listener to prevent default action only when row dragging is active. Added an early return if rowDragging is inactive, avoiding unnecessary preventDefault() calls.


https://github.com/user-attachments/assets/27c8984d-83eb-4728-a192-e9e300b4da91


https://github.com/user-attachments/assets/24224481-76bb-47e6-8e50-9cf78fac4268

