### PR TITLE
fix: #7239: Incorrect behaviour of dragging over DataTable rows

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -678,7 +678,11 @@ export const TableBody = React.memo(
         const onRowDragOver = (e) => {
             const { originalEvent: event, index } = e;
 
-            if (rowDragging.current && draggedRowIndex.current !== index) {
+            if (!rowDragging.current) {
+                return;
+            }
+
+            if (draggedRowIndex.current !== index) {
                 const rowElement = event.currentTarget;
                 const rowY = DomHandler.getOffset(rowElement).top + DomHandler.getWindowScrollTop();
                 const pageY = event.pageY + window.scrollY;


### PR DESCRIPTION
Defect Fixes
Fix #7239

Changes
Fixed onRowDragOver listener to prevent default action only when row dragging is active. Added an early return if rowDragging is inactive, avoiding unnecessary preventDefault() call.

https://github.com/user-attachments/assets/4a0f625f-1877-4aaa-b9aa-55ef315ac209


https://github.com/user-attachments/assets/159898e0-7a96-4691-b0aa-9b7ff5df9974

