### PR TITLE
fix: show viewDate year when yearNavigator mode

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3342,7 +3342,7 @@ export const Calendar = React.memo(
         const createTitleYearElement = (metaYear) => {
             const viewDate = getViewDate();
             const viewYear = viewDate.getFullYear();
-            const displayYear = props.numberOfMonths > 1 ? metaYear : currentYear;
+            const displayYear = props.numberOfMonths > 1 ? metaYear : viewYear;
 
             if (props.yearNavigator) {
                 let yearOptions = [];


### PR DESCRIPTION
## Defect Fixes
- fix: #7234

### how to resolve
- When using `yearNavigator` mode, changing the year in the select input doesn't update the displayed year. 
- This happens because the select input is showing the `currentYear` instead of the year selected by the user.
- Therefore, I changed it to display `viewYear` instead of `currentYear` to ensure that the select input reflects the year selected by the user.
```js
// before
const createTitleYearElement = (metaYear) => {
    const viewDate = getViewDate();
    const viewYear = viewDate.getFullYear();
    const displayYear = props.numberOfMonths > 1 ? metaYear : currentYear; // here!
    ...
```
```js
// after
const createTitleYearElement = (metaYear) => {
    const viewDate = getViewDate();
    const viewYear = viewDate.getFullYear();
    const displayYear = props.numberOfMonths > 1 ? metaYear : viewYear; // here!
    ...
```



### test

- First, I verified that the issue has been resolved.

https://github.com/user-attachments/assets/ed6514e9-8f49-4e27-b441-2fbaf5aac995


<br/>

> related issue: Incorrect year with numberOfMonths and yearNavigator
- Second, I have confirmed that related issue no longer occurs after the code modification. 
([related PR link](https://github.com/primefaces/primereact/pull/6294/files), [related issue link](https://github.com/primefaces/primereact/issues/6285))

https://github.com/user-attachments/assets/a2a2a3a8-997e-4d70-a089-35c3d158da12



