### PR TITLE
fix: show current year when select year in month view

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3342,7 +3342,7 @@ export const Calendar = React.memo(
         const createTitleYearElement = (metaYear) => {
             const viewDate = getViewDate();
             const viewYear = viewDate.getFullYear();
-            const displayYear = props.numberOfMonths > 1 ? metaYear : viewYear;
+            const displayYear = props.yearNavigator ? metaYear : currentYear;
 
             if (props.yearNavigator) {
                 let yearOptions = [];

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3342,7 +3342,7 @@ export const Calendar = React.memo(
         const createTitleYearElement = (metaYear) => {
             const viewDate = getViewDate();
             const viewYear = viewDate.getFullYear();
-            const displayYear = props.yearNavigator ? metaYear : currentYear;
+            const displayYear = props.numberOfMonths > 1 || props.yearNavigator ? metaYear : currentYear;
 
             if (props.yearNavigator) {
                 let yearOptions = [];


### PR DESCRIPTION
### Defect Fixes
- fix: #7254

<br/><br/>

### Test
> I have verified four conditions in the Calendar year selection.

1. When changing the year in the normal mode and selecting a date, the changed year should be reflected.
```html
<Calendar value={date} onChange={(e) => setDate(e.value)}  />
```

https://github.com/user-attachments/assets/0c55e6fb-6e2f-4fdc-a42e-81340de526be

<br/><br/>

2.  When `numberOfMonths` is 2 or more, multiple years should be displayed. (_e.g., Dec 2023, Jan 2024_)

```html
<Calendar value={date} onChange={(e) => setDate(e.value)}  numberOfMonths={3} />
```

https://github.com/user-attachments/assets/058e42b6-c0f2-4af2-91ac-e4363d838f00

<br/><br/>

3. When `numberOfMonths > 1` and in `YearNavigator` mode: 
3-1. Multiple years should be displayed. 
3-2. When changing the year and selecting a date, the changed year should be reflected.

```html
<Calendar value={date} onChange={(e) => setDate(e.value)}  numberOfMonths={3} YearNavigator />
```

https://github.com/user-attachments/assets/41d1372f-e633-41bb-9258-c6a5ee7c5f73

<br/><br/>

4. In `YearNavigator` mode, when changing the year and selecting a date, the changed year should be reflected.


```html
<Calendar value={date} onChange={(e) => setDate(e.value)}  YearNavigator />
```


https://github.com/user-attachments/assets/e8cdd46e-85ef-445c-bb30-63fc179f64db

