### PR TITLE
Fix #7259: SplitButton menu passthrough

### DIFF
--- a/components/lib/splitbutton/SplitButton.js
+++ b/components/lib/splitbutton/SplitButton.js
@@ -202,11 +202,14 @@ export const SplitButton = React.memo(
                         style={props.menuStyle}
                         autoZIndex={props.autoZIndex}
                         baseZIndex={props.baseZIndex}
-                        className={props.menuClassName}
+                        className={classNames(props.menuClassName, cx('menu'))}
                         onClick={onPanelClick}
                         onShow={onMenuShow}
                         onHide={onMenuHide}
                         pt={ptm('menu')}
+                        __parentMetadata={{
+                            parent: metaData
+                        }}
                     />
                 </div>
                 {hasTooltip && <Tooltip target={elementRef} content={props.tooltip} pt={ptm('tooltip')} {...props.tooltipOptions} />}

--- a/components/lib/splitbutton/SplitButtonBase.js
+++ b/components/lib/splitbutton/SplitButtonBase.js
@@ -16,7 +16,7 @@ const classes = {
         }),
     button: 'p-splitbutton-defaultbutton',
     menuButton: 'p-splitbutton-menubutton',
-    menu: ({ subProps: props }) => classNames('p-menu p-menu-overlay p-component', props.menuClassName),
+    menu: ({ props }) => classNames('p-menu p-menu-overlay p-component', props.menuClassName),
     menuList: 'p-menu-list p-reset',
     separator: 'p-menu-separator',
     menuIcon: 'p-menuitem-icon',

--- a/components/lib/tieredmenu/TieredMenu.js
+++ b/components/lib/tieredmenu/TieredMenu.js
@@ -26,14 +26,16 @@ export const TieredMenu = React.memo(
         const [visibleItems, setVisibleItems] = React.useState([]);
         const [focusTrigger, setFocusTrigger] = React.useState(false);
         const [attributeSelectorState, setAttributeSelectorState] = React.useState(null);
-        const { ptm, cx, sx, isUnstyled } = TieredMenuBase.setMetaData({
+        const metaData = {
             props,
+            ...props.__parentMetadata,
             state: {
                 id: idState,
                 visible: visibleState,
                 attributeSelector: attributeSelectorState
             }
-        });
+        };
+        const { ptm, cx, sx, isUnstyled } = TieredMenuBase.setMetaData(metaData);
 
         useHandleStyle(TieredMenuBase.css.styles, isUnstyled, { name: 'tieredmenu' });
 

--- a/components/lib/tieredmenu/TieredMenuBase.js
+++ b/components/lib/tieredmenu/TieredMenuBase.js
@@ -82,6 +82,7 @@ const styles = `
 export const TieredMenuBase = ComponentBase.extend({
     defaultProps: {
         __TYPE: 'TieredMenu',
+        __parentMetadata: null,
         id: null,
         model: null,
         popup: false,


### PR DESCRIPTION
Fix #7259: SplitButton menu passthrough

Will work with

```js
pt={{ menu: { root: { className: 'where-am-i' } } }}
```
