### PR TITLE
fix: remove a div attribute type from TreeTable's prop type

### DIFF
--- a/components/lib/treetable/treetable.d.ts
+++ b/components/lib/treetable/treetable.d.ts
@@ -577,10 +577,10 @@ interface TreeTableColReorderEvent {
 }
 
 /**
- * Defines valid properties in TreeTable component. In addition to these, all properties of HTMLDivElement can be used in this component.
+ * Defines valid properties in TreeTable component.
  * @group Properties
  */
-export interface TreeTableProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onContextMenu' | 'onSelect' | 'ref' | 'value'> {
+export interface TreeTableProps {
     /**
      * Whether to show it even there is only one page.
      * @defaultValue true


### PR DESCRIPTION
### Defect Fixes
fix #7269 and reflects the div attributes not being applied

### Why fix?

In the type declaration, it was stated that div attrs were allow, but these were not actually applied in the TreeTable component.

```typescript
/**
 * Defines valid properties in TreeTable component. In addition to these, all properties of HTMLDivElement can be used in this component.
 * @group Properties
 */
export interface TreeTableProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onContextMenu' | 'onSelect' | 'ref' | 'value'> { ... }
```

in the rootProps, div attrs are excluded.
For example, attrs like 'hidden', 'size', etc.

```typescript
const rootProps = mergeProps(
  {
    role: 'table',
    id: props.id,
    className: classNames(props.className, ptCallbacks.cx('root', { isRowSelectionMode })),
    style: props.style,
    'data-scrollselectors': '.p-treetable-wrapper'
  },
  ObjectUtils.findDiffKeys(props, TreeTable.defaultProps),
  ptCallbacks.ptm('root')
);
```

i have fix the type declaration for TreeTable's Props to only expose the props allowed in the official documentation, similar to the Props type declaration for Tree.
