### PR TITLE
Fix #7269: TreeTable ignore size attribute

### DIFF
--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { getStorage } from '../../utils/utils';
 import PrimeReact, { FilterMatchMode, FilterService, PrimeReactContext } from '../api/Api';
 import { ColumnBase } from '../column/ColumnBase';
 import { useHandleStyle } from '../componentbase/ComponentBase';
-import { useEventListener, useUpdateEffect, useMergeProps, useMountEffect } from '../hooks/Hooks';
+import { useEventListener, useMergeProps, useMountEffect, useUpdateEffect } from '../hooks/Hooks';
 import { ArrowDownIcon } from '../icons/arrowdown';
 import { ArrowUpIcon } from '../icons/arrowup';
 import { SpinnerIcon } from '../icons/spinner';
@@ -13,7 +14,6 @@ import { TreeTableBody } from './TreeTableBody';
 import { TreeTableFooter } from './TreeTableFooter';
 import { TreeTableHeader } from './TreeTableHeader';
 import { TreeTableScrollableView } from './TreeTableScrollableView';
-import { getStorage } from '../../utils/utils';
 
 export const TreeTable = React.forwardRef((inProps, ref) => {
     const mergeProps = useMergeProps();
@@ -1439,7 +1439,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
             style: props.style,
             'data-scrollselectors': '.p-treetable-wrapper'
         },
-        ObjectUtils.findDiffKeys(props, TreeTable.defaultProps),
+        TreeTableBase.getOtherProps(props),
         ptCallbacks.ptm('root')
     );
 

--- a/components/lib/treetable/treetable.d.ts
+++ b/components/lib/treetable/treetable.d.ts
@@ -580,7 +580,7 @@ interface TreeTableColReorderEvent {
  * Defines valid properties in TreeTable component. In addition to these, all properties of HTMLDivElement can be used in this component.
  * @group Properties
  */
-export interface TreeTableProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'onContextMenu' | 'onSelect' | 'ref' | 'value'> {
+export interface TreeTableProps extends Omit<React.DetailedHTMLProps<React.InputHTMLAttributes<HTMLDivElement>, HTMLDivElement>, 'size' | 'onContextMenu' | 'onSelect' | 'ref' | 'value'> {
     /**
      * Whether to show it even there is only one page.
      * @defaultValue true


### PR DESCRIPTION
Fix #7269: TreeTable ignore size attribute
