### PR TITLE
fix(breadcrumb): missing padding at the end due to unset display prop…

### DIFF
--- a/components/lib/breadcrumb/BreadCrumbBase.js
+++ b/components/lib/breadcrumb/BreadCrumbBase.js
@@ -17,6 +17,7 @@ const styles = `
 @layer primereact {
     .p-breadcrumb {
         overflow-x: auto;
+        display: flex;
     }
 
     .p-breadcrumb ol {


### PR DESCRIPTION
fixes #7280

### before

https://github.com/user-attachments/assets/e8416a71-ded5-4e66-abf1-968501106547

### after

https://github.com/user-attachments/assets/652fb90f-9385-4388-bc6b-06b326c5c388

I also checked other cases, and it doesn't break anything related to the `Breadcrumb` component. It's just a simple display issue; we just need to set `display: flex`
 