### PR TITLE
fix(tree): toggle node when filtering mode

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -117,7 +117,6 @@ export const Dropdown = React.memo(
                 return;
             }
 
-            event.stopPropagation();
             props.onClick && props.onClick(event);
 
             // do not continue if the user defined click wants to prevent it

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -117,6 +117,7 @@ export const Dropdown = React.memo(
                 return;
             }
 
+            event.stopPropagation();
             props.onClick && props.onClick(event);
 
             // do not continue if the user defined click wants to prevent it

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -92,6 +92,7 @@ export const Tree = React.memo(
 
         React.useEffect(() => {
             if (props.filter) _filter();
+            // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [filteredValue, props.value, props.filter]);
 
         const onDragStart = (event) => {

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -16,7 +16,7 @@ export const Tree = React.memo(
 
         const [filterValue, filterValueState, setFilterValueState] = useDebounce('', props.filterDelay || 0);
         const [expandedKeysState, setExpandedKeysState] = React.useState(props.expandedKeys);
-        const [filterExpandedKeys, setFilterExpandedKeys] = React.useState(null);
+        const [filterExpandedKeys, setFilterExpandedKeys] = React.useState({});
 
         const elementRef = React.useRef(null);
         const filteredNodes = React.useRef([]);
@@ -319,7 +319,6 @@ export const Tree = React.memo(
 
         const _filter = () => {
             if (!filterChanged.current) return;
-            currentFilterExpandedKeys = {};
 
             if (ObjectUtils.isEmpty(filteredValue)) {
                 filteredNodes.current = props.value;

--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -368,7 +368,6 @@ export const Tree = React.memo(
 
                 if (matched) {
                     currentFilterExpandedKeys[node.key] = true;
-                    node.expanded = true;
 
                     return true;
                 }

--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -15,7 +15,7 @@ export const UITreeNode = React.memo((props) => {
     const mergeProps = useMergeProps();
     const isLeaf = props.isNodeLeaf(props.node);
     const label = props.node.label;
-    const expanded = (props.expandedKeys ? props.expandedKeys[props.node.key] !== undefined : false) || props.node.expanded;
+    const expanded = props.expandedKeys ? props.expandedKeys[props.node.key] !== undefined : false;
     const { ptm, cx } = props;
 
     const getPTOptions = (key) => {


### PR DESCRIPTION
## Defect Fixes
- fix #7232
- Fix #7392

## How To Resolve
### Issue
- When filtering in the tree, the toggle function doesn't work.
- Upon investigation, it was found that previously, when filtering, we used `node.expanded = true` to expand nodes.
- In this case, the child component would recognize the `node.expanded` value based on specific conditions and expand the node.
- However, in this approach, when filtering, the toggle event argument is an empty object 
- Therefore, the toggle function does not work while filtering.

### Solution
- I added `filterExpandedKeys` to be used when filtering and ensured that this value is used during filtering.
- When a toggle is requested, I update `filterExpandedKeys` while filtering, and in other cases, I update `expandedKeysState`.

```js
if (isFiltering) {
    setFilterExpandedKeys(value);
} else {
    setExpandedKeysState(value);
}
```

### Result
> Test Cases:
1. When filtering, the corresponding node should be expanded.
2. It should be possible to toggle nodes while in a filtering state.
3. If a node was toggled before filtering, it should remain expanded after filtering is finished.

https://github.com/user-attachments/assets/94c4f472-5181-4b8f-9f22-f680e54ac84b


