### PR TITLE
fix: flatOptions on Dropdown causing option group label blank

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -846,7 +846,7 @@ export const Dropdown = React.memo(
         };
 
         const isOptionGroup = (option) => {
-            return props.optionGroupLabel && option.optionGroup && option.group;
+            return props.optionGroupLabel && option.group;
         };
 
         const isOptionDisabled = (option) => {

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -59,7 +59,7 @@ export const Dropdown = React.memo(
 
         const flatOptions = (options) => {
             return (options || []).reduce((result, option, index) => {
-                result.push({ optionGroup: option, group: true, index, code: option.code, label: option.label });
+                result.push({ ...option, group: true, index });
 
                 const optionGroupChildren = getOptionGroupChildren(option);
 

--- a/components/lib/dropdown/DropdownPanel.js
+++ b/components/lib/dropdown/DropdownPanel.js
@@ -93,7 +93,7 @@ export const DropdownPanel = React.memo(
 
             style = { ...style, ...option.style };
 
-            if (option.group && option.optionGroup && props.optionGroupLabel) {
+            if (option.group && props.optionGroupLabel) {
                 const { optionGroupLabel } = props;
                 const groupContent = props.optionGroupTemplate ? ObjectUtils.getJSXElement(props.optionGroupTemplate, option, index) : props.getOptionGroupLabel(option);
                 const key = index + '_' + props.getOptionGroupRenderKey(option);


### PR DESCRIPTION
### Defect Fixes

- fix [Dropdown: OptionGroup using optionGroupLabel is blank #7285 ](https://github.com/primefaces/primereact/issues/7285)

### Changes

- Merged optionGroup object to its parent (option)
- To determine if an option is a group, it is sufficient to use the `group` and `optionGroupLabel` properties

#### Before
![image](https://github.com/user-attachments/assets/1dc948e9-af05-4b7e-963c-1a9c0b26f751)

#### After
![image](https://github.com/user-attachments/assets/49a29b6f-7a60-4fac-8c2e-5da2454de404)
