### PR TITLE
fix(iconField): number input style for missing padding-left and paddi…

### DIFF
--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -1374,10 +1374,16 @@
   .p-icon-field-left > .p-inputtext {
     padding-left: 2.5rem;
   }
+  .p-icon-field-left .p-inputnumber-input {
+    padding-left: 2.5rem;
+  }
   .p-icon-field-left.p-float-label > label {
     left: 2.5rem;
   }
   .p-icon-field-right > .p-inputtext {
+    padding-right: 2.5rem;
+  }
+  .p-icon-field-right .p-inputnumber-input {
     padding-right: 2.5rem;
   }
   ::-webkit-input-placeholder {


### PR DESCRIPTION
fixes #7310

Note: 
The last input is a IconField with InputNumber with my fixed style also I only updated one theme `lara-light-cyan` if it gets approved then I will add this style logic to every theme.

Example: 
![Capture-2024-10-06-213549](https://github.com/user-attachments/assets/a1f6043c-5c91-46e4-8eca-924d82b316e0)
