### PR TITLE
fix(Dropdown): prevent event bubbling when dropdown click

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -117,6 +117,7 @@ export const Dropdown = React.memo(
                 return;
             }
 
+            event.stopPropagation();
             props.onClick && props.onClick(event);
 
             // do not continue if the user defined click wants to prevent it


### PR DESCRIPTION
### Defect Fixes
- fix (#7309)

### How to resolve
- When there is a Dropdown inside the DataTable, clicking the Dropdown triggers the DataTable's click event. 
- To resolve this issue, I prevent event bubbling in the Dropdown's onClick event handler.

_result_

https://github.com/user-attachments/assets/87ed60e3-0bc7-4b98-92db-6482edfcc19b

