### PR TITLE
Fix #7323: Clear timer in InputNumber component on unmount

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -1135,6 +1135,12 @@ export const InputNumber = React.memo(
             ObjectUtils.combinedRefs(inputRef, props.inputRef);
         }, [inputRef, props.inputRef]);
 
+        React.useEffect(() => {
+            return () => {
+                clearTimer();
+            };
+        }, []);
+
         useMountEffect(() => {
             constructParser();
 


### PR DESCRIPTION
### Fixed
 - #7323 

This pull request fixes issue #7323, where the `InputNumber` component would enter an infinite loop when unmounted due to a forgotten timer cleanup.

### Solution

The fix adds a cleanup function inside a `useEffect` hook to ensure that any active timers are cleared when the component unmounts.

**Before**:

https://github.com/user-attachments/assets/3080a952-03d8-4ccb-b4ab-a31fdfc9317d

**After**:
  
https://github.com/user-attachments/assets/85607e69-88aa-43ec-a481-54e0a6e4326c