### PR TITLE
fix(Dropdown): pass option object value to selectItem when optionValue is set

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -171,11 +171,9 @@ export const Dropdown = React.memo(
         };
 
         const onOptionSelect = (event, option, isHide = true) => {
-            const value = getOptionValue(option);
-
             selectItem({
                 originalEvent: event,
-                option: value
+                option
             });
 
             isHide && hide(true);


### PR DESCRIPTION
### Defect Fixes
- fix #7318 

<br/><br/>

### How to Resolve
- When `optionValue` is set, selecting an option using `[arrow keys + Enter]` does not work.(<a href="https://github.com/primefaces/primereact/issues/7064">related PR</a>)
- The issue is caused by the **`value` being undefined**.
- To resolve this, I pass the option object to the selectItem function, similar to `onOptionClick` function.
```js
const onOptionClick = (event) => {
      const option = event.option;

      if (!option.disabled) {
          selectItem(event);  // like this!
          DomHandler.focus(focusInputRef.current);
      }

      hide();
  };
```


<br/>

_Test 1: The optionValue is undefined(Basic example)._


https://github.com/user-attachments/assets/6e99e50f-2bd4-4437-a2f7-7da61fd6bddd




<br/><br/>

_Test 2: The optionValue is set to 'code.'_
- you can select option using `[arrow keys + Enter]` :)

https://github.com/user-attachments/assets/4ce5d2e6-81df-43f3-a63c-a0c18006f91e



