### PR TITLE
fix(Multiselect): optimize handling of grouped options by flattening structure

### DIFF
--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -104,39 +104,6 @@ export const MultiSelectPanel = React.memo(
             }
         };
 
-        const createGroupChildren = (optionGroup, style) => {
-            const groupChildren = props.getOptionGroupChildren(optionGroup);
-
-            return groupChildren.map((option, j) => {
-                const optionLabel = props.getOptionLabel(option);
-                const optionKey = j + '_' + props.getOptionRenderKey(option);
-                const disabled = props.isOptionDisabled(option);
-                const selected = props.isSelected(option);
-
-                return (
-                    <MultiSelectItem
-                        hostName={props.hostName}
-                        index={j}
-                        key={optionKey}
-                        focusedOptionIndex={props.focusedOptionIndex}
-                        label={optionLabel}
-                        option={option}
-                        style={style}
-                        template={props.itemTemplate}
-                        selected={selected}
-                        onClick={props.onOptionSelect}
-                        onMouseMove={changeFocusedItemOnHover}
-                        disabled={disabled}
-                        className={props.itemClassName}
-                        checkboxIcon={props.checkboxIcon}
-                        isUnstyled={isUnstyled}
-                        ptm={ptm}
-                        cx={cx}
-                    />
-                );
-            });
-        };
-
         const createEmptyFilter = () => {
             const emptyFilterMessage = ObjectUtils.getJSXElement(props.emptyFilterMessage, props) || localeOption('emptyFilterMessage');
 
@@ -174,9 +141,8 @@ export const MultiSelectPanel = React.memo(
         const createItem = (option, index, scrollerOptions = {}) => {
             const style = { height: scrollerOptions.props ? scrollerOptions.props.itemSize : undefined };
 
-            if (props.optionGroupLabel) {
+            if (option.group && props.optionGroupLabel) {
                 const groupContent = props.optionGroupTemplate ? ObjectUtils.getJSXElement(props.optionGroupTemplate, option, index) : props.getOptionGroupLabel(option);
-                const groupChildrenContent = createGroupChildren(option, style);
                 const key = index + '_' + props.getOptionGroupRenderKey(option);
                 const itemGroupProps = mergeProps(
                     {
@@ -187,12 +153,9 @@ export const MultiSelectPanel = React.memo(
                 );
 
                 return (
-                    <React.Fragment key={key}>
-                        <li {...itemGroupProps} key={key}>
-                            {groupContent}
-                        </li>
-                        {groupChildrenContent}
-                    </React.Fragment>
+                    <li key={key} {...itemGroupProps}>
+                        {groupContent}
+                    </li>
                 );
             }
 


### PR DESCRIPTION
## Defect Fixes
- fix #6678
- reference code: https://github.com/primefaces/primereact/pull/6430/files

<br/>

## How to Resolve
- Based on the [reference code](https://github.com/primefaces/primereact/pull/6430/files), the structure of the group options was modified to a flattened structure.

### Issue Description
- A. When focusing on an item in the first group, the focus class is also applied to items in the another group.
- B. When move using down arrow key and press Enter, I can not select items within the group.

### Test

#### A. Focus check
- Before
<img width="1638" alt="스크린샷 2024-10-19 오후 2 55 25" src="https://github.com/user-attachments/assets/0fd72f60-06b0-4463-ab39-4e20adae39b1">

- After
<img width="1628" alt="스크린샷 2024-10-19 오후 2 54 44" src="https://github.com/user-attachments/assets/057e554b-6f8c-4731-b109-ed5a7cd46027">


<br/><br/>

#### B. Arrow keys + Enter to select group items
- Before

https://github.com/user-attachments/assets/ab611150-cf61-429e-9431-b1eb193f3236



<br/>

- After

https://github.com/user-attachments/assets/4ce0ee34-6066-4b76-8f44-1331447039eb



