### PR TITLE
Reference correct translation key for the `aria-label` attribute within UIMessage's Close Icon

### DIFF
--- a/components/lib/messages/UIMessage.js
+++ b/components/lib/messages/UIMessage.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { localeOption } from '../api/Api';
+import { ariaLabel } from '../api/Api';
 import { useTimeout } from '../hooks/Hooks';
 import { CheckIcon } from '../icons/check';
 import { ExclamationTriangleIcon } from '../icons/exclamationtriangle';
@@ -53,8 +53,6 @@ export const UIMessage = React.memo(
 
         const createCloseIcon = () => {
             if (closable !== false) {
-                const ariaLabel = localeOption('close');
-
                 const buttonIconProps = mergeProps(
                     {
                         className: cx('uimessage.buttonicon')
@@ -70,7 +68,7 @@ export const UIMessage = React.memo(
                     {
                         type: 'button',
                         className: cx('uimessage.button'),
-                        'aria-label': ariaLabel,
+                        'aria-label': ariaLabel('close'),
                         onClick: onClose
                     },
                     getPTOptions('button', parentParams),


### PR DESCRIPTION
### Defect Fixes

Closes https://github.com/primefaces/primereact/issues/7364.

Uses the appropriate helper to retrieve the translated label.