### PR TITLE
Remove null check from Dropdown getSelectedOptionIndex()

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -716,7 +716,7 @@ export const Dropdown = React.memo(
         const getSelectedOptionIndex = (options) => {
             options = options || visibleOptions;
 
-            if (props.value != null && options) {
+            if (options) {
                 if (props.optionGroupLabel) {
                     for (let i = 0; i < options.length; i++) {
                         let selectedOptionIndex = findOptionIndexInList(props.value, getOptionGroupChildren(options[i]));


### PR DESCRIPTION
Fix #7370 

Currently setting `props.value` to null clears the dropdown even if an option with a null value is present.

This allows for null option values in Dropdowns again.

Functionally it's fully compatible - if the options don't contain a null value option, the function's return value will be -1 and the dropdown will be cleared as before.

There might be a small performance hit if `value=null` is used to clear the selection of a dropdown with lots of entries.
