### PR TITLE
fix(Mention): pass autoResize props to inner component

### DIFF
--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -537,6 +537,7 @@ export const Mention = React.memo(
                 style: props.inputStyle,
                 ...inputProps,
                 unstyled: props.unstyled,
+                autoResize: props.autoResize,
                 onFocus: onFocus,
                 onBlur: onBlur,
                 onKeyDown: onKeyDown,
@@ -560,6 +561,8 @@ export const Mention = React.memo(
             MentionBase.getOtherProps(props),
             ptm('root')
         );
+
+        console.log('MentionBase.js', rootProps);
 
         return (
             <div {...rootProps}>

--- a/components/lib/mention/Mention.js
+++ b/components/lib/mention/Mention.js
@@ -562,8 +562,6 @@ export const Mention = React.memo(
             ptm('root')
         );
 
-        console.log('MentionBase.js', rootProps);
-
         return (
             <div {...rootProps}>
                 <InputTextarea {...inputMentionProps} />


### PR DESCRIPTION
### Defect Fixes
- fix #7367
- fix https://github.com/primefaces/primereact/issues/6296
- The `Mention` component uses the `InputTextarea` component, and the `InputTextarea` component supports the `autoResize` option.
- However, the `Mention` component does not pass the `autoResize` option to the `InputTextarea` component.
- To fix this bug, I added the `autoResize` option to the props variable.


<br/>

### Test

_before: Setting autoResize still causes a scroll when content overflows._


https://github.com/user-attachments/assets/f134dd40-0d6c-4097-a9f1-0008f6c517e2



<br/><br/>

_after: The height increases when content overflows._


https://github.com/user-attachments/assets/a0ce5597-69db-41fb-9b93-1fd9c62f19dd

