### PR TITLE
fix: #7377, MultiSelect: Cannot access the close Icon and clear the input using keyboard in Filled mode

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -981,11 +981,28 @@ export const MultiSelect = React.memo(
             ZIndexUtils.clear(overlayRef.current);
         });
 
+        const onClearIconKeyDown = (event) => {
+            switch (event.code) {
+                case 'Space':
+                case 'NumpadEnter':
+                case 'Enter':
+                    if (props.inline) {
+                        break;
+                    }
+
+                    updateModel(event, [], []);
+                    break;
+            }
+        };
+
         const createClearIcon = () => {
             const clearIconProps = mergeProps(
                 {
                     className: cx('clearIcon'),
-                    onClick: (e) => updateModel(e, [], [])
+                    onClick: (e) => updateModel(e, [], []),
+                    tabIndex: props.tabIndex || '0',
+                    'aria-label': localeOption('clear'),
+                    onKeyDown: (e) => onClearIconKeyDown(e)
                 },
                 ptm('clearIcon')
             );

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -982,6 +982,9 @@ export const MultiSelect = React.memo(
         });
 
         const onClearIconKeyDown = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+
             switch (event.code) {
                 case 'Space':
                 case 'NumpadEnter':


### PR DESCRIPTION
fix: #7377, MultiSelect: Cannot access the close Icon and clear the input using keyboard in Filled mode