### PR TITLE
fix: #7349, MultiSelect: Unable to select remove icon of chips through keyboard

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -858,6 +858,23 @@ export const MultiSelect = React.memo(
                 return ObjectUtils.getJSXElement(props.selectedItemTemplate);
             }
 
+            const onremoveTokenIconKeyDown = (event, val) => {
+                event.preventDefault();
+                event.stopPropagation();
+
+                switch (event.code) {
+                    case 'Space':
+                    case 'NumpadEnter':
+                    case 'Enter':
+                        if (props.inline) {
+                            break;
+                        }
+
+                        removeChip(event, val);
+                        break;
+                }
+            };
+
             if (props.display === 'chip' && !empty) {
                 const value = props.value.slice(0, props.maxSelectedLabels || props.value.length);
 
@@ -873,7 +890,10 @@ export const MultiSelect = React.memo(
                     const iconProps = mergeProps(
                         {
                             className: cx('removeTokenIcon'),
-                            onClick: (e) => removeChip(e, val)
+                            onClick: (e) => removeChip(e, val),
+                            tabIndex: props.tabIndex || '0',
+                            'aria-label': localeOption('removeTokenIcon'),
+                            onKeyDown: (e) => onremoveTokenIconKeyDown(e, val)
                         },
                         ptm('removeTokenIcon', context)
                     );

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -891,9 +891,9 @@ export const MultiSelect = React.memo(
                         {
                             className: cx('removeTokenIcon'),
                             onClick: (e) => removeChip(e, val),
+                            onKeyDown: (e) => onremoveTokenIconKeyDown(e, val),
                             tabIndex: props.tabIndex || '0',
-                            'aria-label': localeOption('removeTokenIcon'),
-                            onKeyDown: (e) => onremoveTokenIconKeyDown(e, val)
+                            'aria-label': localeOption('removeTokenIcon')
                         },
                         ptm('removeTokenIcon', context)
                     );


### PR DESCRIPTION
fix: #7349, MultiSelect: Unable to select remove icon of chips through keyboard