### PR TITLE
style: add highlight for rows selected with checkbox

### DIFF
--- a/components/lib/treetable/TreeTableRow.js
+++ b/components/lib/treetable/TreeTableRow.js
@@ -13,8 +13,6 @@ import { Checkbox } from '../checkbox/Checkbox';
 
 export const TreeTableRow = React.memo((props) => {
     const elementRef = React.useRef(null);
-    const checkboxRef = React.useRef(null);
-    const checkboxBoxRef = React.useRef(null);
     const nodeTouched = React.useRef(false);
     const mergeProps = useMergeProps();
     const expanded = props.expandedKeys ? props.expandedKeys[props.node.key] !== undefined : false;
@@ -455,11 +453,13 @@ export const TreeTableRow = React.memo((props) => {
     };
 
     const isSelected = () => {
-        if (props.selectionMode === 'single' || (props.selectionMode === 'multiple' && props.selectionKeys)) {
-            return props.selectionMode === 'single' ? props.selectionKeys === props.node.key : props.selectionKeys[props.node.key] !== undefined;
+        if (props.selectionMode === 'single') {
+            return props.selectionKeys === props.node.key;
+        } else if ((props.selectionMode === 'multiple' || props.selectionMode === 'checkbox') && props.selectionKeys) {
+            return props.selectionKeys[props.node.key] !== undefined;
+        } else {
+            return false;
         }
-
-        return false;
     };
 
     const isChecked = () => {

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -776,7 +776,7 @@
     background: #111827;
     width: 22px;
     height: 22px;
-    color: rgba(255, 255, 255, 0.87);
+    color: #212529;
     border-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
     outline-color: transparent;
@@ -789,16 +789,6 @@
   .p-checkbox .p-checkbox-box .p-checkbox-icon.p-icon {
     width: 14px;
     height: 14px;
-  }
-  .p-checkbox .p-checkbox-box {
-    border: 2px solid #424b57;
-    background: #111827;
-    width: 22px;
-    height: 22px;
-    color: rgba(255, 255, 255, 0.87);
-    border-radius: 6px;
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    outline-color: transparent;
   }
   .p-checkbox .p-checkbox-box .p-checkbox-icon {
     transition-duration: 0.2s;

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -776,7 +776,7 @@
     background: #ffffff;
     width: 22px;
     height: 22px;
-    color: #4b5563;
+    color: rgba(255, 255, 255, 0.87);
     border-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
     outline-color: transparent;
@@ -789,16 +789,6 @@
   .p-checkbox .p-checkbox-box .p-checkbox-icon.p-icon {
     width: 14px;
     height: 14px;
-  }
-  .p-checkbox .p-checkbox-box {
-    border: 2px solid #d1d5db;
-    background: #ffffff;
-    width: 22px;
-    height: 22px;
-    color: #4b5563;
-    border-radius: 6px;
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    outline-color: transparent;
   }
   .p-checkbox .p-checkbox-box .p-checkbox-icon {
     transition-duration: 0.2s;


### PR DESCRIPTION
### Defect Fixes
- fix: #7387 

<br/>

### Changes

> Before: When selecting a row with a checkbox, the row is not highlighted.

<img width="1101" alt="스크린샷 2024-11-11 오후 8 59 46" src="https://github.com/user-attachments/assets/f1946275-d06d-42db-b03b-8ea37a4fd0cf">



> After: When selecting a row with a checkbox, the row is highlighted.
<img width="889" alt="스크린샷 2024-11-11 오후 8 49 52" src="https://github.com/user-attachments/assets/42047ed4-ee72-427e-8598-77a01d880472">


