### PR TITLE
Fixing cssTransitionfalse does not disable animations globally

### DIFF
--- a/components/lib/api/PrimeReactContext.js
+++ b/components/lib/api/PrimeReactContext.js
@@ -12,7 +12,7 @@ export const PrimeReactProvider = (props) => {
     const [locale, setLocale] = useState(propsValue.locale || 'en');
     const [appendTo, setAppendTo] = useState(propsValue.appendTo || null);
     const [styleContainer, setStyleContainer] = useState(propsValue.styleContainer || null);
-    const [cssTransition, setCssTransition] = useState(propsValue.cssTransition || true);
+    const [cssTransition, setCssTransition] = useState(propsValue.cssTransition ?? true);
     const [autoZIndex, setAutoZIndex] = useState(propsValue.autoZIndex || true);
     const [hideOverlaysOnDocumentScrolling, setHideOverlaysOnDocumentScrolling] = useState(propsValue.hideOverlaysOnDocumentScrolling || false);
     const [nonce, setNonce] = useState(propsValue.nonce || null);

--- a/components/lib/api/PrimeReactContext.js
+++ b/components/lib/api/PrimeReactContext.js
@@ -5,20 +5,20 @@ import PrimeReact from './PrimeReact';
 export const PrimeReactContext = React.createContext();
 
 export const PrimeReactProvider = (props) => {
-    const propsValue = props.value || {};
+    const propsValue = props.value ?? {};
 
-    const [ripple, setRipple] = useState(propsValue.ripple || false);
-    const [inputStyle, setInputStyle] = useState(propsValue.inputStyle || 'outlined');
-    const [locale, setLocale] = useState(propsValue.locale || 'en');
-    const [appendTo, setAppendTo] = useState(propsValue.appendTo || null);
-    const [styleContainer, setStyleContainer] = useState(propsValue.styleContainer || null);
+    const [ripple, setRipple] = useState(propsValue.ripple ?? false);
+    const [inputStyle, setInputStyle] = useState(propsValue.inputStyle ?? 'outlined');
+    const [locale, setLocale] = useState(propsValue.locale ?? 'en');
+    const [appendTo, setAppendTo] = useState(propsValue.appendTo ?? null);
+    const [styleContainer, setStyleContainer] = useState(propsValue.styleContainer ?? null);
     const [cssTransition, setCssTransition] = useState(propsValue.cssTransition ?? true);
-    const [autoZIndex, setAutoZIndex] = useState(propsValue.autoZIndex || true);
-    const [hideOverlaysOnDocumentScrolling, setHideOverlaysOnDocumentScrolling] = useState(propsValue.hideOverlaysOnDocumentScrolling || false);
-    const [nonce, setNonce] = useState(propsValue.nonce || null);
-    const [nullSortOrder, setNullSortOrder] = useState(propsValue.nullSortOrder || 1);
+    const [autoZIndex, setAutoZIndex] = useState(propsValue.autoZIndex ?? true);
+    const [hideOverlaysOnDocumentScrolling, setHideOverlaysOnDocumentScrolling] = useState(propsValue.hideOverlaysOnDocumentScrolling ?? false);
+    const [nonce, setNonce] = useState(propsValue.nonce ?? null);
+    const [nullSortOrder, setNullSortOrder] = useState(propsValue.nullSortOrder ?? 1);
     const [zIndex, setZIndex] = useState(
-        propsValue.zIndex || {
+        propsValue.zIndex ?? {
             modal: 1100,
             overlay: 1000,
             menu: 1000,
@@ -27,15 +27,15 @@ export const PrimeReactProvider = (props) => {
         }
     );
     const [ptOptions, setPtOptions] = useState(
-        propsValue.ptOptions || {
+        propsValue.ptOptions ?? {
             mergeSections: true,
             mergeProps: true
         }
     );
-    const [pt, setPt] = useState(propsValue.pt || undefined);
-    const [unstyled, setUnstyled] = useState(propsValue.unstyled || false);
+    const [pt, setPt] = useState(propsValue.pt ?? undefined);
+    const [unstyled, setUnstyled] = useState(propsValue.unstyled ?? false);
     const [filterMatchModeOptions, setFilterMatchModeOptions] = useState(
-        propsValue.filterMatchModeOptions || {
+        propsValue.filterMatchModeOptions ?? {
             text: [FilterMatchMode.STARTS_WITH, FilterMatchMode.CONTAINS, FilterMatchMode.NOT_CONTAINS, FilterMatchMode.ENDS_WITH, FilterMatchMode.EQUALS, FilterMatchMode.NOT_EQUALS],
             numeric: [FilterMatchMode.EQUALS, FilterMatchMode.NOT_EQUALS, FilterMatchMode.LESS_THAN, FilterMatchMode.LESS_THAN_OR_EQUAL_TO, FilterMatchMode.GREATER_THAN, FilterMatchMode.GREATER_THAN_OR_EQUAL_TO],
             date: [FilterMatchMode.DATE_IS, FilterMatchMode.DATE_IS_NOT, FilterMatchMode.DATE_BEFORE, FilterMatchMode.DATE_AFTER]

--- a/components/templates/TemplateLicense.js
+++ b/components/templates/TemplateLicense.js
@@ -1,4 +1,3 @@
-
 const TemplateLicense = ({ license }) => {
     return (
         <div className="template-license-wrapper">


### PR DESCRIPTION
### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

Fix #7395

Description - 
Problem is in file `PrimeReactContext.js`, line 15

` const [cssTransition, setCssTransition] = useState(propsValue.cssTransition || true);`

|| is OR, which basically means that even when cssTransition from props is `false`, `false || true` return `true`. 

Instead of OR what we really want is 'Nullish coalescing operator (??)', which returns its right-hand side operand when its left-hand side operand is [null](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/null) or [undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined), and otherwise returns its left-hand side.

Updating the same for other props as well. 