### PR TITLE
Fix #7321: DataTable 10.8.4: Drag Selection is still broken

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -597,7 +597,7 @@ export const TableBody = React.memo(
                 : DomHandler.hasClass(event.target, 'p-datatable-reorderablerow-handle') || event.target.closest('.p-datatable-reorderablerow-handle');
 
             event.currentTarget.draggable = isDraggableHandle;
-            event.target.draggable = !isDraggableHandle;
+            event.target.draggable = isDraggableHandle;
 
             if (allowRowDrag(e)) {
                 enableDragSelection(event, 'row');


### PR DESCRIPTION
Fix #7321 
This pull request includes a small but important change to the `TableBody` component in `components/lib/datatable/TableBody.js`. The change ensures that the `draggable` attribute of the event target is correctly set based on whether the element is a draggable handle.

* [`components/lib/datatable/TableBody.js`](diffhunk://#diff-760d13999e77f41593a865b0c92c5fc0942d1708ed40657985cd69f5446b9cc4L600-R600): Corrected the setting of the `draggable` attribute on the event target to ensure it matches the draggable handle state.
 