### PR TITLE
Dropdown issue 7423: preventDefault on click

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -132,6 +132,7 @@ export const Dropdown = React.memo(
                 overlayVisibleState ? hide() : show();
             }
 
+            event.preventDefault();
             clickedRef.current = true;
         };
 


### PR DESCRIPTION
Fix #7423 

In `Dropdown.onClick` calls `event.preventDefault()` in addition to the `event.stopPropagation()` added in PR #7317 for Issue #7309