### PR TITLE
Adding collapsable prop for multiselect groups

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -3883,6 +3883,14 @@
                             "description": "Template of an option group item."
                         },
                         {
+                            "name": "optionGroupCollapsable",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "",
+                            "description": "Option to collapse group items."
+                        },
+                        {
                             "name": "panelClassName",
                             "optional": true,
                             "readonly": false,
@@ -23422,6 +23430,14 @@
                             "description": "Template of an option group item."
                         },
                         {
+                            "name": "optionGroupCollapsable",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "",
+                            "description": "Option to collapse group items."
+                        },
+                        {
                             "name": "optionLabel",
                             "optional": true,
                             "readonly": false,
@@ -32964,6 +32980,14 @@
                             "description": "Template of an option group item."
                         },
                         {
+                            "name": "optionGroupCollapsable",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "",
+                            "description": "Option to collapse group items."
+                        },
+                        {
                             "name": "optionLabel",
                             "optional": true,
                             "readonly": false,
@@ -36543,6 +36567,14 @@
                             "type": "ReactNode | Function",
                             "default": "",
                             "description": "Template of an option group item."
+                        },
+                        {
+                            "name": "optionGroupCollapsable",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "boolean",
+                            "default": "",
+                            "description": "Option to collapse group items."
                         },
                         {
                             "name": "optionLabel",

--- a/components/doc/multiselect/groupdoc.js
+++ b/components/doc/multiselect/groupdoc.js
@@ -50,7 +50,7 @@ export function GroupDoc(props) {
     const code = {
         basic: `
 <MultiSelect value={selectedCities} options={groupedCities} onChange={(e) => setSelectedCities(e.value)} optionLabel="label" 
-    optionGroupLabel="label" optionGroupChildren="items" optionGroupTemplate={groupedItemTemplate}
+    optionGroupLabel="label" optionGroupChildren="items" optionGroupTemplate={groupedItemTemplate} optionGroupCollapsable
     placeholder="Select Cities" display="chip" className="w-full md:w-20rem" />
         `,
         javascript: `
@@ -104,7 +104,7 @@ export default function GroupedDoc() {
     return (
         <div className="card flex justify-content-center">
             <MultiSelect value={selectedCities} options={groupedCities} onChange={(e) => setSelectedCities(e.value)} optionLabel="label" 
-                optionGroupLabel="label" optionGroupChildren="items" optionGroupTemplate={groupedItemTemplate}
+                optionGroupLabel="label" optionGroupChildren="items" optionGroupCollapsable optionGroupTemplate={groupedItemTemplate}
                 placeholder="Select Cities" display="chip" className="w-full md:w-20rem" />
         </div>
     );
@@ -172,7 +172,7 @@ export default function GroupedDoc() {
     return (
         <div className="card flex justify-content-center">
             <MultiSelect value={selectedCities} options={groupedCities} onChange={(e) => setSelectedCities(e.value)} optionLabel="label" 
-                optionGroupLabel="label" optionGroupChildren="items" optionGroupTemplate={groupedItemTemplate}
+                optionGroupLabel="label" optionGroupChildren="items" optionGroupCollapsable optionGroupTemplate={groupedItemTemplate}
                 placeholder="Select Cities" display="chip" className="w-full md:w-20rem" />
         </div>
     );
@@ -185,7 +185,7 @@ export default function GroupedDoc() {
             <DocSectionText {...props}>
                 <p>
                     Options can be grouped when a nested data structures is provided. To define the label of a group <i>optionGroupLabel</i> property is needed and also <i>optionGroupChildren</i> is required to define the property that refers to the
-                    children of a group.
+                    children of a group. Also you can provide a <i>optionGroupCollapsable</i> property to collapse the groups by default.
                 </p>
             </DocSectionText>
             <div className="card flex justify-content-center">
@@ -200,6 +200,7 @@ export default function GroupedDoc() {
                     placeholder="Select Cities"
                     display="chip"
                     className="w-full md:w-20rem"
+                    optionGroupCollapsable
                 />
             </div>
             <DocSectionCode code={code} />

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -872,7 +872,6 @@ export const MultiSelect = React.memo(
                     const labelKey = label + '_' + i;
                     const iconProps = mergeProps(
                         {
-                            'aria-label': localeOption('removeTokenIcon'),
                             className: cx('removeTokenIcon'),
                             onClick: (e) => removeChip(e, val),
                             onKeyDown: (e) => onRemoveTokenIconKeyDown(e, val),
@@ -1022,7 +1021,6 @@ export const MultiSelect = React.memo(
             const clearIconProps = mergeProps(
                 {
                     className: cx('clearIcon'),
-                    'aria-label': localeOption('clear'),
                     onClick: (e) => updateModel(e, [], []),
                     onKeyDown: (e) => onClearIconKeyDown(e),
                     tabIndex: props.tabIndex || '0'
@@ -1199,6 +1197,7 @@ export const MultiSelect = React.memo(
                         isUnstyled={isUnstyled}
                         metaData={metaData}
                         changeFocusedOptionIndex={changeFocusedOptionIndex}
+                        optionGroupCollapsable={props.optionGroupCollapsable}
                     />
                 </div>
                 {hasTooltip && <Tooltip target={elementRef} content={props.tooltip} pt={ptm('tooltip')} {...props.tooltipOptions} />}

--- a/components/lib/multiselect/MultiSelectBase.js
+++ b/components/lib/multiselect/MultiSelectBase.js
@@ -190,6 +190,18 @@ const styles = `
     .p-fluid .p-multiselect {
         display: flex;
     }
+    .p-multiselect-group-header{
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 1.25rem;
+        cursor: pointer;
+    }
+}
+    .p-multiselect-group-header:hover{
+        background-color: var(--primary-100);
+   
+    }
 }
 `;
 

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -580,6 +580,10 @@ export interface MultiSelectProps extends Omit<React.DetailedHTMLProps<React.Inp
      */
     optionLabel?: string | undefined;
     /**
+     * Collapsable option group item.
+     */
+    optionGroupCollapsable?: boolean;
+    /**
      * Property name or getter function to use as the value of an option, defaults to the option itself when not defined.
      */
     optionValue?: string | undefined;


### PR DESCRIPTION

Fix: #7426 

### **Feature: Collapsible Option Groups in MultiSelect**
**Why this change?**
In scenarios where a MultiSelect component contains numerous groups with a large number of options within each group, the list can become overwhelming to navigate. While filtering options is already available, I felt it was logical and user-friendly to introduce collapsible groups to enhance usability.

**What does this change bring?**

> _Collapsible Groups_: Users can now expand or collapse groups to manage the visibility of options within each group.

> _Improved User Experience_: This feature makes it easier to navigate through groups, especially when dealing with a long list of options.

>_Optional Behavior:_ This functionality is opt-in and can be controlled via a new optionGroupCollapsable prop.

**Implementation Details**
Added optionGroupCollapsable as a new prop to enable collapsible group headers.
Clicking on a group header toggles its visibility.
Collapsed and expanded states are visually indicated through icons (pi-chevron-right for collapsed and pi-chevron-down for expanded).
Backward compatibility is preserved, as this feature is disabled by default.
This addition aligns with the existing feature set of the MultiSelect component and provides an enhanced way to handle larger datasets efficiently.

![prime-react-collapsable-doc](https://github.com/user-attachments/assets/9153a837-946e-43f7-b63f-99eae40bf1e1)

![prime-react-collapsable-api-doc](https://github.com/user-attachments/assets/8af0149e-81bb-429f-9b19-47806dc45156)

https://github.com/user-attachments/assets/146d58a3-2ca6-484f-8ae3-236eba1ef1e8

