### PR TITLE
Fix: Dropdowmitem: Passing key directly without using spread

### DIFF
--- a/components/lib/dropdown/DropdownItem.js
+++ b/components/lib/dropdown/DropdownItem.js
@@ -33,7 +33,6 @@ export const DropdownItem = React.memo((props) => {
         {
             id: `dropdownItem_${index}`,
             role: 'option',
-            key: props.label,
             className: classNames(option.className, cx('item', { selected, disabled, label, index, focusedOptionIndex, highlightOnSelect })),
             style: props.style,
             tabIndex: 0,
@@ -80,7 +79,7 @@ export const DropdownItem = React.memo((props) => {
     };
 
     return (
-        <li {...itemProps}>
+        <li key={props.label} {...itemProps}>
             {checkmark && iconRenderer()}
             <span {...itemGroupLabelProps}>{content}</span>
             <Ripple />


### PR DESCRIPTION
### Defect Fixes

Fix #7430 : "key" prop is being spread into JSX

Solution : 
Passing key directly without using spread