### PR TITLE
fix: #7437, TabView: Unable to select closable icon of tabs through keyboard

### DIFF
--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -362,8 +362,8 @@ export const TabView = React.forwardRef((inProps, ref) => {
             {
                 className: cx('tab.closeIcon'),
                 onClick: (e) => onTabHeaderClose(e, index),
-                tabIndex: 0,
-                onKeyDown: (e) => onCloseIconKeyDown(e, index)
+                onKeyDown: (e) => onCloseIconKeyDown(e, index),
+                tabIndex: 0
             },
             getTabPT(tab, 'closeIcon', index)
         );

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -330,6 +330,19 @@ export const TabView = React.forwardRef((inProps, ref) => {
         getElement: () => elementRef.current
     }));
 
+    const onCloseIconKeyDown = (event, index) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        switch (event.code) {
+            case 'Space':
+            case 'NumpadEnter':
+            case 'Enter':
+                onTabHeaderClose(event, index);
+                break;
+        }
+    };
+
     const createTabHeader = (tab, index) => {
         const selected = isSelected(index);
         const { headerStyle, headerClassName, style: _style, className: _className, disabled, leftIcon, rightIcon, header, headerTemplate, closable, closeIcon } = TabPanelBase.getCProps(tab);
@@ -348,7 +361,9 @@ export const TabView = React.forwardRef((inProps, ref) => {
         const closeIconProps = mergeProps(
             {
                 className: cx('tab.closeIcon'),
-                onClick: (e) => onTabHeaderClose(e, index)
+                onClick: (e) => onTabHeaderClose(e, index),
+                tabIndex: 0,
+                onKeyDown: (e) => onCloseIconKeyDown(e, index)
             },
             getTabPT(tab, 'closeIcon', index)
         );

--- a/components/lib/tabview/TabView.js
+++ b/components/lib/tabview/TabView.js
@@ -363,7 +363,8 @@ export const TabView = React.forwardRef((inProps, ref) => {
                 className: cx('tab.closeIcon'),
                 onClick: (e) => onTabHeaderClose(e, index),
                 onKeyDown: (e) => onCloseIconKeyDown(e, index),
-                tabIndex: 0
+                tabIndex: 0,
+                'aria-label': ariaLabel('close') || 'Close'
             },
             getTabPT(tab, 'closeIcon', index)
         );


### PR DESCRIPTION
fix: #7437, TabView: Unable to select closable icon of tabs through keyboard