### PR TITLE
Datatable: Allow ignore of data-tag in CellEdit outside click

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -65,6 +65,7 @@ export const BodyCell = React.memo((props) => {
 
     const isIgnoredElement = (element) => {
         const isCellEditor = (el) => el.getAttribute && el.getAttribute('data-pr-is-overlay');
+        
         return isCellEditor(element) || DomHandler.getParents(element).find((el) => isCellEditor(el));
     };
 
@@ -74,6 +75,7 @@ export const BodyCell = React.memo((props) => {
             if (isIgnoredElement(e.target)) {
                 return;
             }
+            
             setTimeout(() => {
                 if (!selfClick.current && isOutsideClicked(e.target)) {
                     // #2666 for overlay components and outside is clicked

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -63,9 +63,17 @@ export const BodyCell = React.memo((props) => {
         return getColumnProp('cellEditValidateOnClose');
     };
 
+    const isIgnoredElement = (element) => {
+        const isCellEditor = (el) => el.getAttribute && el.getAttribute('data-pr-is-overlay');
+        return isCellEditor(element) || DomHandler.getParents(element).find((el) => isCellEditor(el));
+    };
+
     const [bindDocumentClickListener, unbindDocumentClickListener] = useEventListener({
         type: 'click',
         listener: (e) => {
+            if (isIgnoredElement(e.target)) {
+                return
+            }
             setTimeout(() => {
                 if (!selfClick.current && isOutsideClicked(e.target)) {
                     // #2666 for overlay components and outside is clicked

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -65,7 +65,7 @@ export const BodyCell = React.memo((props) => {
 
     const isIgnoredElement = (element) => {
         const isCellEditor = (el) => el.getAttribute && el.getAttribute('data-pr-is-overlay');
-        
+
         return isCellEditor(element) || DomHandler.getParents(element).find((el) => isCellEditor(el));
     };
 
@@ -75,7 +75,7 @@ export const BodyCell = React.memo((props) => {
             if (isIgnoredElement(e.target)) {
                 return;
             }
-            
+
             setTimeout(() => {
                 if (!selfClick.current && isOutsideClicked(e.target)) {
                     // #2666 for overlay components and outside is clicked

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -72,7 +72,7 @@ export const BodyCell = React.memo((props) => {
         type: 'click',
         listener: (e) => {
             if (isIgnoredElement(e.target)) {
-                return
+                return;
             }
             setTimeout(() => {
                 if (!selfClick.current && isOutsideClicked(e.target)) {


### PR DESCRIPTION
### Defect Fixes
Overlay Editors behave different when in CellEdit mode. This PR adds a workaround - adding the attribute
`data-pr-is-overlay:true` to the overlay excludes it from the onClickOutside handler.
This *could* be extended by adding it to the overlay editors by default. 
We could then even remove the setTimeout.
It also works für third party editors. 
#7405 #2097
