### PR TITLE
Add 'help' as severity in splitbutton.d.ts

### DIFF
--- a/components/lib/splitbutton/splitbutton.d.ts
+++ b/components/lib/splitbutton/splitbutton.d.ts
@@ -127,9 +127,9 @@ export interface SplitButtonProps extends Omit<React.DetailedHTMLProps<React.HTM
      */
     outlined?: boolean | undefined;
     /**
-     * Defines the style of the button, valid values are "secondary", "success", "info", "warning", "danger", "contrast".
+     * Defines the style of the button, valid values are "secondary", "success", "info", "warning", "danger", "contrast", "help".
      */
-    severity?: 'secondary' | 'success' | 'info' | 'warning' | 'danger' | 'contrast' | undefined;
+    severity?: 'secondary' | 'success' | 'info' | 'warning' | 'danger' | 'contrast' | 'help' | undefined;
     /**
      * Defines the size of the button, valid values are "small" and "large".
      */


### PR DESCRIPTION
`'help'` was missing in the Typescript definition of the `severity` field in the SplitButtonProps.
The severity is supported (see here: https://primereact.org/splitbutton/#severity), only the type annotation is wrong.