### PR TITLE
Fix: Icon aria-hidden value fix

### DIFF
--- a/components/lib/iconbase/IconBase.js
+++ b/components/lib/iconbase/IconBase.js
@@ -22,7 +22,7 @@ export const IconBase = {
             ),
             role: !isLabelEmpty ? 'img' : undefined,
             'aria-label': !isLabelEmpty ? props.label : undefined,
-            'aria-hidden': isLabelEmpty
+            'aria-hidden': props.label ? isLabelEmpty : undefined
         };
 
         return ObjectUtils.getMergedProps(otherProps, ptiProps);


### PR DESCRIPTION
Fix #7473
Password: Warning message related to aria-hidden displayed when clicking the toggleMask icon

In `aria-hidden`
[false](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden#false)
The element is exposed to the accessibility API as if it was rendered.

[true](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden#true)
The element is hidden from the accessibility API.

[undefined](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden#undefined) (default)
The element's hidden state is determined by the user agent based on whether it is rendered.

ToggleMask adds a `<EyeIcon>` which uses `<IconBase>`.

In `IconBase`, `aria-hidden` should be `undefined`.
