### PR TITLE
Fixed incorrect defaultValues for emptyMessage

### DIFF
--- a/components/lib/dropdown/dropdown.d.ts
+++ b/components/lib/dropdown/dropdown.d.ts
@@ -302,12 +302,12 @@ export interface DropdownProps extends Omit<React.DetailedHTMLProps<React.InputH
     checkmark?: boolean;
     /**
      * Template to display when filtering does not return any results.
-     * @defaultValue No available options
+     * @defaultValue No results found
      */
     emptyFilterMessage?: React.ReactNode | ((props: DropdownProps) => React.ReactNode) | undefined;
     /**
      * Text to display when there are no options available.
-     * @defaultValue No results found
+     * @defaultValue No available options
      */
     emptyMessage?: React.ReactNode | ((props: DropdownProps) => React.ReactNode) | undefined;
     /**


### PR DESCRIPTION
Simple documentation fix. The default values for `emptyFilterMessage` and `emptyMessage` were reversed. 