### PR TITLE
Fix #7494: ConfirmDialog do not call onHide if dialog is not visible

### DIFF
--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -92,10 +92,12 @@ export const ConfirmDialog = React.memo(
         };
 
         const hide = (result = 'cancel') => {
-            setVisibleState(false);
-            callbackFromProp('onHide', { result });
-            DomHandler.focus(focusElementOnHide.current);
-            focusElementOnHide.current = null;
+            if (visibleState) {
+                setVisibleState(false);
+                callbackFromProp('onHide', { result });
+                DomHandler.focus(focusElementOnHide.current);
+                focusElementOnHide.current = null;
+            }
         };
 
         const confirm = (updatedProps) => {


### PR DESCRIPTION
Fix #7494: ConfirmDialog do not call onHide if dialog is not visible