### PR TITLE
fix: correct case for setLazyState method

### DIFF
--- a/components/doc/datatable/lazyloaddoc.js
+++ b/components/doc/datatable/lazyloaddoc.js
@@ -11,7 +11,7 @@ export function LazyLoadDoc(props) {
     const [customers, setCustomers] = useState(null);
     const [selectAll, setSelectAll] = useState(false);
     const [selectedCustomers, setSelectedCustomers] = useState(null);
-    const [lazyState, setlazyState] = useState({
+    const [lazyState, setLazyState] = useState({
         first: 0,
         rows: 10,
         page: 1,
@@ -52,16 +52,16 @@ export function LazyLoadDoc(props) {
     };
 
     const onPage = (event) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSort = (event) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onFilter = (event) => {
         event.first = 0;
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSelectionChange = (event) => {
@@ -129,7 +129,7 @@ export default function LazyLoadDemo() {
     const [customers, setCustomers] = useState(null);
     const [selectAll, setSelectAll] = useState(false);
     const [selectedCustomers, setSelectedCustomers] = useState(null);
-    const [lazyState, setlazyState] = useState({
+    const [lazyState, setLazyState] = useState({
         first: 0,
         rows: 10,
         page: 1,
@@ -167,16 +167,16 @@ export default function LazyLoadDemo() {
     };
 
     const onPage = (event) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSort = (event) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onFilter = (event) => {
         event['first'] = 0;
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSelectionChange = (event) => {
@@ -280,7 +280,7 @@ export default function LazyLoadDemo() {
     const [customers, setCustomers] = useState<Customer[] | null>(null);
     const [selectAll, setSelectAll] = useState<boolean>(false);
     const [selectedCustomers, setSelectedCustomers] = useState<Customer[] | null>(null);
-    const [lazyState, setlazyState] = useState<LazyTableState>({
+    const [lazyState, setLazyState] = useState<LazyTableState>({
         first: 0,
         rows: 10,
         page: 1,
@@ -318,16 +318,16 @@ export default function LazyLoadDemo() {
     };
 
     const onPage = (event: DataTablePageEvent) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSort = (event: DataTableSortEvent) => {
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onFilter = (event: DataTableFilterEvent) => {
         event['first'] = 0;
-        setlazyState(event);
+        setLazyState(event);
     };
 
     const onSelectionChange = (event: DataTableSelectionChangeEvent) => {


### PR DESCRIPTION
- from `setlazyState` to `setLazyState`

![image](https://github.com/user-attachments/assets/cdd2c511-731f-433a-90b9-7b15d9e326a4)

I noticed this typo while reading the documentation, although there was no existing issue for it. This PR fixes the incorrect casing of the method name.