### PR TITLE
fix(Calendar): apply viewDate Year when yearNavigator and view month mode

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -507,10 +507,6 @@ export const Calendar = React.memo(
             return _currentYear;
         };
 
-        const getViewYear = () => {
-            return props.yearNavigator ? getViewDate().getFullYear() : currentYear;
-        };
-
         const onMonthDropdownChange = (event, value) => {
             const currentViewDate = getViewDate();
             let newViewDate = cloneDate(currentViewDate);
@@ -1813,6 +1809,10 @@ export const Calendar = React.memo(
                 updateViewDate(event, currentDate);
                 onViewDateSelect({ event, date: currentDate });
             }
+        };
+
+        const getViewYear = () => {
+            return props.yearNavigator ? getViewDate().getFullYear() : currentYear;
         };
 
         const onYearSelect = (event, year) => {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -481,7 +481,7 @@ export const Calendar = React.memo(
         const decrementYear = () => {
             const year = getViewYear();
             const _currentYear = year - 1;
-            
+
             setCurrentYear(_currentYear);
 
             if (props.yearNavigator && _currentYear < yearOptions[0]) {
@@ -1792,7 +1792,7 @@ export const Calendar = React.memo(
         const onMonthSelect = (event, month) => {
             if (props.view === 'month') {
                 const year = getViewYear();
-                
+
                 onDateSelect(event, { year, month: month, day: 1, selectable: true });
                 event.preventDefault();
             } else {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1789,7 +1789,8 @@ export const Calendar = React.memo(
 
         const onMonthSelect = (event, month) => {
             if (props.view === 'month') {
-                onDateSelect(event, { year: currentYear, month: month, day: 1, selectable: true });
+                const year = props.yearNavigator ? getViewDate().getFullYear() : currentYear;
+                onDateSelect(event, { year, month: month, day: 1, selectable: true });
                 event.preventDefault();
             } else {
                 setCurrentMonth(month);
@@ -1897,8 +1898,8 @@ export const Calendar = React.memo(
                       transform: 'translate(-50%, -50%)'
                   }
                 : !props.inline
-                  ? { position: 'absolute', top: '0', left: '0' }
-                  : undefined;
+                ? { position: 'absolute', top: '0', left: '0' }
+                : undefined;
 
             DomHandler.addStyles(overlayRef.current, styles);
 

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -479,8 +479,8 @@ export const Calendar = React.memo(
         };
 
         const decrementYear = () => {
-            const _currentYear = currentYear - 1;
-
+            const year = getViewYear();
+            const _currentYear = year - 1;
             setCurrentYear(_currentYear);
 
             if (props.yearNavigator && _currentYear < yearOptions[0]) {
@@ -493,7 +493,8 @@ export const Calendar = React.memo(
         };
 
         const incrementYear = () => {
-            const _currentYear = currentYear + 1;
+            const year = getViewYear();
+            const _currentYear = year + 1;
 
             setCurrentYear(_currentYear);
 
@@ -504,6 +505,10 @@ export const Calendar = React.memo(
             }
 
             return _currentYear;
+        };
+
+        const getViewYear = () => {
+            return props.yearNavigator ? getViewDate().getFullYear() : currentYear;
         };
 
         const onMonthDropdownChange = (event, value) => {
@@ -1789,7 +1794,7 @@ export const Calendar = React.memo(
 
         const onMonthSelect = (event, month) => {
             if (props.view === 'month') {
-                const year = props.yearNavigator ? getViewDate().getFullYear() : currentYear;
+                const year = getViewYear();
                 onDateSelect(event, { year, month: month, day: 1, selectable: true });
                 event.preventDefault();
             } else {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -481,6 +481,7 @@ export const Calendar = React.memo(
         const decrementYear = () => {
             const year = getViewYear();
             const _currentYear = year - 1;
+            
             setCurrentYear(_currentYear);
 
             if (props.yearNavigator && _currentYear < yearOptions[0]) {
@@ -1791,6 +1792,7 @@ export const Calendar = React.memo(
         const onMonthSelect = (event, month) => {
             if (props.view === 'month') {
                 const year = getViewYear();
+                
                 onDateSelect(event, { year, month: month, day: 1, selectable: true });
                 event.preventDefault();
             } else {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1903,8 +1903,8 @@ export const Calendar = React.memo(
                       transform: 'translate(-50%, -50%)'
                   }
                 : !props.inline
-                ? { position: 'absolute', top: '0', left: '0' }
-                : undefined;
+                  ? { position: 'absolute', top: '0', left: '0' }
+                  : undefined;
 
             DomHandler.addStyles(overlayRef.current, styles);
 


### PR DESCRIPTION
### Defect Fixes
- fix: #7496


### How to resolve?
- When a year is selected in yearNavigator mode, the `onYearDropdownChange function` is triggered.
- The `onYearDropdownChange function` updates the viewDate state.
- However, the `onMonthSelect function` uses currentYear, causing the updated viewDate to not be applied correctly.
- To resolve this issue, I updated the `onMonthSelect function` as shown below:
```javascript
const onMonthSelect = (event, month) => {
    if (props.view === 'month') {
        const year = props.yearNavigator ? getViewDate().getFullYear() : currentYear; // updated!
        onDateSelect(event, { year, month: month, day: 1, selectable: true });
    }
};
```

<br/>

### Test
_When both YearNavigator and view="month" props are used together_
> Before
When both YearNavigator and view="month" props were used together, the selected year was being replaced with the current year when the calendar closed. 
Additionally, clicking the previous and next buttons did not correctly reflect the viewYear.



https://github.com/user-attachments/assets/bdb353b4-87f3-43f2-a61a-3336203f53f8

<br/>

> After
the selected year is correctly applied when the calendar closes. 
Furthermore, clicking the previous and next buttons accurately reflects the viewYear.


https://github.com/user-attachments/assets/ed104eb4-77b1-49a1-af23-6d735dce1744

