### PR TITLE
fix #7518: Change icon from cog to palette on the Theming docs page

### DIFF
--- a/components/doc/theming/builtinthemesdoc.js
+++ b/components/doc/theming/builtinthemesdoc.js
@@ -53,7 +53,7 @@ primereact/resources/themes/arya-purple/theme.css
                 <p>
                     PrimeReact ships with various free themes to choose from. The list below states all the available themes in the npm distribution with import paths. For a live preview, use the configurator{' '}
                     <span className="border-round inline-flex border-1 w-2rem h-2rem p-0 align-items-center justify-content-center bg-primary">
-                        <span className="pi pi-cog" />
+                        <span className="pi pi-palette" />
                     </span>{' '}
                     at the topbar to switch themes.
                 </p>


### PR DESCRIPTION
Fixes #7518.

Changes the `cog` icon used in the text to `palette` in order to match the icon in the top toolbar.