### PR TITLE
fix(TreeTable): define togglerTemplate props in TreeTableBase

### DIFF
--- a/components/lib/treetable/TreeTableBase.js
+++ b/components/lib/treetable/TreeTableBase.js
@@ -298,7 +298,8 @@ export const TreeTableBase = ComponentBase.extend({
         tableStyle: null,
         totalRecords: null,
         value: null,
-        children: undefined
+        children: undefined,
+        togglerTemplate: null
     },
     css: {
         classes,


### PR DESCRIPTION
### Defect Fixes
- fix: #7490 

### How to resolve
- when `togglerTemplate` option is applied, "React does not recognize the `togglerTemplate` prop" error occured.
<img width="1285" alt="스크린샷 2024-12-22 오후 12 33 45" src="https://github.com/user-attachments/assets/92010d8b-a7c1-4fd3-8591-a4756d480a42" />


- To recognize this option, I defined the `togglerTemplate` prop in the TreeTableBase component's props.