### PR TITLE
Fix #7489: ScrollPanel defend against NULL ref

### DIFF
--- a/components/lib/scrollpanel/ScrollPanel.js
+++ b/components/lib/scrollpanel/ScrollPanel.js
@@ -51,6 +51,7 @@ export const ScrollPanel = React.forwardRef((inProps, ref) => {
     };
 
     const moveBar = () => {
+        if (!contentRef.current) return;
         // horizontal scroll
         const totalWidth = contentRef.current.scrollWidth;
         const ownWidth = contentRef.current.clientWidth;


### PR DESCRIPTION
Fix #7489: ScrollPanel defend against NULL ref