### PR TITLE
Fix #7545: Datatable fix alignFrozen="right"

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -507,7 +507,9 @@ export const BodyCell = React.memo((props) => {
         if (getColumnProp('frozen')) {
             updateStickyPosition();
         }
+    });
 
+    React.useEffect(() => {
         if (props.editMode === 'cell' || props.editMode === 'row') {
             focusOnElement();
         }


### PR DESCRIPTION
Fix #7545: Datatable fix alignFrozen="right"