### PR TITLE
fix:#7546#Datatable: Sort with multiselect - wrong selection

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1642,7 +1642,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         );
     };
 
-    const createTableBody = (options, selectionModeInColumn, empty, isVirtualScrollerDisabled) => {
+    const createTableBody = (options, selectionModeInColumn, empty, isVirtualScrollerDisabled, processedData) => {
         const first = getFirst();
         const { rows, columns, contentRef, style, className, spacerStyle, itemSize } = options;
 
@@ -1700,6 +1700,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 onRowUnselect={props.onRowUnselect}
                 onSelectionChange={props.onSelectionChange}
                 paginator={props.paginator}
+                // pass processedData #7546
+                processedData={processedData}
                 reorderableRows={props.reorderableRows}
                 responsiveLayout={props.responsiveLayout}
                 rowClassName={props.rowClassName}
@@ -1784,6 +1786,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 onRowUnselect={props.onRowUnselect}
                 onSelectionChange={props.onSelectionChange}
                 paginator={props.paginator}
+                // pass processedData #7546
+                processedData={processedData}
                 reorderableRows={props.reorderableRows}
                 responsiveLayout={props.responsiveLayout}
                 rowClassName={props.rowClassName}
@@ -1873,7 +1877,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                         };
 
                         const tableHeader = createTableHeader(options, empty, _isVirtualScrollerDisabled);
-                        const tableBody = createTableBody(options, selectionModeInColumn, empty, _isVirtualScrollerDisabled);
+                        const tableBody = createTableBody(options, selectionModeInColumn, empty, _isVirtualScrollerDisabled, processedData);
                         const tableFooter = createTableFooter(options);
                         const tableProps = mergeProps(
                             {
@@ -2020,6 +2024,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const footer = createFooter();
     const resizeHelper = createResizeHelper();
     const reorderIndicators = createReorderIndicators();
+
     const rootProps = mergeProps(
         {
             id: props.id,

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -2024,7 +2024,6 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const footer = createFooter();
     const resizeHelper = createResizeHelper();
     const reorderIndicators = createReorderIndicators();
-
     const rootProps = mergeProps(
         {
             id: props.id,

--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -354,7 +354,7 @@ export const TableBody = React.memo(
             let selection = [];
 
             for (let i = rowRangeStart; i <= rowRangeEnd; i++) {
-                let rangeRowData = props.value[i] ?? props.tableProps.value[i];
+                let rangeRowData = props.processedData[i];
 
                 if (!isSelectable({ data: rangeRowData, index: i })) {
                     continue;


### PR DESCRIPTION
Fix #7546 
Fix #7093
passing processed data should be the convenient solution

- `props.value`  only contains the current data (the virtual list only contains data in the visible area)
- `props.tableProps.value`  only contains raw data
- maybe `onRowDrop` have the same problem

https://github.com/user-attachments/assets/c1b527fa-ae63-48f9-808a-c92bcc5a9ca8


@sja-cslab 