### PR TITLE
Fix #7513: TreeTable stripedRows fix

### DIFF
--- a/components/lib/treetable/TreeTableBase.js
+++ b/components/lib/treetable/TreeTableBase.js
@@ -190,7 +190,7 @@ const classes = {
     row: ({ isSelected, rowProps: props }) => ({
         'p-highlight': isSelected(),
         'p-highlight-contextmenu': props.contextMenuSelectionKey && props.contextMenuSelectionKey === props.node.key,
-        'p-row-odd': props.rowIndex % 2 !== 0
+        'p-row-odd': parseInt(String(props.rowIndex).split('_').pop(), 10) % 2 !== 0
     }),
     rowCheckbox: ({ partialChecked }) => classNames('p-treetable-checkbox', { 'p-indeterminate': partialChecked }),
     rowToggler: 'p-treetable-toggler p-link p-unselectable-text',

--- a/components/lib/treetable/TreeTableRow.js
+++ b/components/lib/treetable/TreeTableRow.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ariaLabel } from '../api/Api';
+import { Checkbox } from '../checkbox/Checkbox';
 import { ColumnBase } from '../column/ColumnBase';
 import { useMergeProps } from '../hooks/Hooks';
 import { CheckIcon } from '../icons/check';
@@ -9,7 +10,6 @@ import { MinusIcon } from '../icons/minus';
 import { Ripple } from '../ripple/Ripple';
 import { classNames, DomHandler, IconUtils, ObjectUtils } from '../utils/Utils';
 import { TreeTableBodyCell } from './TreeTableBodyCell';
-import { Checkbox } from '../checkbox/Checkbox';
 
 export const TreeTableRow = React.memo((props) => {
     const elementRef = React.useRef(null);


### PR DESCRIPTION
Fix #7513: TreeTable stripedRows fix

rowIndex can be any of the following:

`0` - first row
`1` - second row
`1_0` - Second Row expanded first Row
`3_1_2` - Fourth row expanded with its second row expanded showing 3rd row.

We only care about the last digit for determining even and odd for Striped Rows