### PR TITLE
fix(Calendar): not trigger onViewDateSelect when input typing

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -162,7 +162,6 @@ export const Calendar = React.memo(
                     const date = value.length ? value[0] : value;
 
                     updateViewDate(event, date);
-                    onViewDateSelect({ event, date });
                 }
             } catch (err) {
                 //invalid date


### PR DESCRIPTION
## Defect Fixes
- fix: #7553

<br/>

## How to resolve
### Cause of the Issue


_issue occurred flow (current version)_
```mermaid
graph TD
    A[User types in input field] --> B[onUserInput function is triggered]
    B --> C[updateValueOnInput function is triggered]
    C --> D[onViewDateSelect function is triggered]
    D --> E[onSelect function is triggered]
    E --> F["Issue occurred!!"] 
```

- Due to the above flow, when typing in the input field, the onSelect event is triggered, causing a bug.

<br/>

### Proposed Solution
- To address the issue, the behavior of the onSelect function has been modified so that it is triggered only when the user interacts with the date picker button.
- **However, if the onSelect function is also intended to work while typing in the input field, please leave a comment, and I will update it accordingly.**


<br/>

### Test
```js
<Calendar value={date} onChange={(e) => setDate(e.value)} onSelect={(e) => console.log(e.value)} />
```


https://github.com/user-attachments/assets/cbca041c-a44b-4d82-b130-f5af6c8e3085



