### PR TITLE
Fix #7343: Remove aria-hidden as not needed from focusable elements

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -985,8 +985,7 @@ export const Dropdown = React.memo(
                     required: props.required,
                     defaultValue: option.value,
                     name: props.name,
-                    tabIndex: -1,
-                    'aria-hidden': 'true'
+                    tabIndex: -1
                 },
                 ptm('select')
             );
@@ -1198,7 +1197,6 @@ export const Dropdown = React.memo(
             {
                 ref: firstHiddenFocusableElementOnOverlay,
                 role: 'presentation',
-                'aria-hidden': 'true',
                 className: 'p-hidden-accessible p-hidden-focusable',
                 tabIndex: '0',
                 onFocus: onFirstHiddenFocus,
@@ -1212,7 +1210,6 @@ export const Dropdown = React.memo(
             {
                 ref: lastHiddenFocusableElementOnOverlay,
                 role: 'presentation',
-                'aria-hidden': 'true',
                 className: 'p-hidden-accessible p-hidden-focusable',
                 tabIndex: '0',
                 onFocus: onLastHiddenFocus,

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -298,7 +298,6 @@ export const MultiSelectPanel = React.memo(
                 {
                     ref: props.firstHiddenFocusableElementOnOverlay,
                     role: 'presentation',
-                    'aria-hidden': 'true',
                     className: 'p-hidden-accessible p-hidden-focusable',
                     tabIndex: '0',
                     onFocus: props.onFirstHiddenFocus,
@@ -312,7 +311,6 @@ export const MultiSelectPanel = React.memo(
                 {
                     ref: props.lastHiddenFocusableElementOnOverlay,
                     role: 'presentation',
-                    'aria-hidden': 'true',
                     className: 'p-hidden-accessible p-hidden-focusable',
                     tabIndex: '0',
                     onFocus: props.onLastHiddenFocus,


### PR DESCRIPTION
Fix #7343: Remove aria-hidden as not needed from focusable elements