### PR TITLE
Fix #7502: autoResize not working when value is updated

### DIFF
--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -130,7 +130,7 @@ export const InputTextarea = React.memo(
                 resize(true);
             }
             // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [props.autoResize]);
+        }, [props.autoResize, props.value]);
 
         const isFilled = React.useMemo(() => ObjectUtils.isNotEmpty(props.value) || ObjectUtils.isNotEmpty(props.defaultValue), [props.value, props.defaultValue]);
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip);


### PR DESCRIPTION
### Fixed

Fix #7502

This pull request resolves issue #7502, where the `InputTextarea` component did not automatically resize when the value prop changed.

### Solution

- Added `props.value` to the dependency array of the `useEffect` responsible for auto-resizing.
- This ensures the resize function is triggered whenever the value prop changes, allowing the component to dynamically adjust its height.

#### Before

https://github.com/user-attachments/assets/6657885c-beac-443d-b1c5-c245f2ad9bde

#### After

https://github.com/user-attachments/assets/9c9fcafb-ed7a-450c-806a-e9a8b69af1ef
