### PR TITLE
fix(Calendar): resolve invalid date error in validateDate function

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1020,20 +1020,27 @@ export const Calendar = React.memo(
 
         const validateDate = (value) => {
             if (props.yearNavigator) {
+                const [minRangeYear, maxRangeYear] = props.yearRange ? props.yearRange.split(':').map((year) => parseInt(year, 10)) : [null, null];
+
                 let viewYear = value.getFullYear();
+                let minYear = null;
+                let maxYear = null;
 
-                const minRangeYear = props.yearRange ? parseInt(props.yearRange.split(':')[0], 10) : null;
-                const maxRangeYear = props.yearRange ? parseInt(props.yearRange.split(':')[1], 10) : null;
-                const minYear = props.minDate && minRangeYear != null ? Math.max(props.minDate.getFullYear(), minRangeYear) : props.minDate || minRangeYear;
-                const maxYear = props.maxDate && maxRangeYear != null ? Math.min(props.maxDate.getFullYear(), maxRangeYear) : props.maxDate || maxRangeYear;
-
-                if (minYear && minYear > viewYear) {
-                    viewYear = minYear;
+                if (minRangeYear !== null) {
+                    minYear = props.minDate ? Math.max(props.minDate.getFullYear(), minRangeYear) : minRangeYear;
+                } else {
+                    minYear = props.minDate?.getFullYear() || minRangeYear;
                 }
 
-                if (maxYear && maxYear < viewYear) {
-                    viewYear = maxYear;
+                if (maxRangeYear !== null) {
+                    maxYear = props.maxDate ? Math.min(props.maxDate.getFullYear(), maxRangeYear) : maxRangeYear;
+                } else {
+                    maxYear = props.maxDate?.getFullYear() || maxRangeYear;
                 }
+
+                if (minYear && minYear > viewYear) viewYear = minYear;
+
+                if (maxYear && maxYear < viewYear) viewYear = maxYear;
 
                 value.setFullYear(viewYear);
             }


### PR DESCRIPTION
## Defect Fixes
- fix: #7422 

<br/><br/>

## How To Resolve

### Situation:
- When setting `minDate` data in `yearNavigator` mode, an error occurs that causes the selected date to be cleared (reset).

<br/>

### Problem Cause:

- `minYear` is originally intended to be used as a year (_number_), but under certain conditions, the `props.minDate` (_Date type_) is assigned directly.
- Specifically, the issue arises in the following code:

```js
function validateDate = (value) => {
  const minYear = props.minDate && minRangeYear != null 
      ? Math.max(props.minDate.getFullYear(), minRangeYear) 
      : props.minDate  /* (1) props.minDate (Date object) is assigned to minYear */
        || minRangeYear;

    ...

    if (minYear && minYear > viewYear) {    /* (2) this condition is true */
        viewYear = minYear;                 /* (3) viewYear is set to minYear (Date object). */
    }

    ...

   /* (4) setFullYear is called with a Date object, resulting in 'Invalid Date' error */
   value.setFullYear(viewYear);            
}

```


<br/>

### Proposed Solution
- By using `getFullYear()`, we extract only the numerical year from `props.minDate` and `props.maxDate`.
```js
function validateDate = (value) => {
  ...
  if (minRangeYear !== null) {
      minYear = props.minDate ? Math.max(props.minDate.getFullYear(), minRangeYear) : minRangeYear;
  } else {
      minYear = props.minDate?.getFullYear() || minRangeYear; /* use getFullYear() */
  }
}
```

<br/>

### Test
> **before:** After selecting a date and clicking the input, the selected date is cleared.


https://github.com/user-attachments/assets/74f4b416-847f-4b52-bd37-2c8672237ade

```js
<Calendar value={date} yearNavigator onChange={(e) => setDate(e.value)} minDate={minDate} />
```

<br/>


> **after:** After selecting a date and clicking the input, the selected date remains intact.


https://github.com/user-attachments/assets/5e942158-2096-401d-9194-97e5088a3cc8

```js
<Calendar value={date} yearNavigator onChange={(e) => setDate(e.value)} minDate={minDate} />
```
