### PR TITLE
fix: display today button for currentDate even when code executes wit…

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -4213,20 +4213,14 @@ export const Calendar = React.memo(
         };
 
         const truncateToMinutes = (date) => {
-            return new Date(
-                date.getFullYear(),
-                date.getMonth(),
-                date.getDate(),
-                date.getHours(),
-                date.getMinutes(),
-            );
+            return new Date(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes());
         };
 
         const createButtonBar = () => {
             if (props.showButtonBar) {
                 const { today, clear, now } = localeOptions(props.locale);
                 const nowDate = new Date();
-                const isHidden = (props.minDate && truncateToMinutes(props.minDate) > truncateToMinutes(nowDate) || (props.maxDate && truncateToMinutes(props.maxDate) < truncateToMinutes(nowDate)));
+                const isHidden = (props.minDate && truncateToMinutes(props.minDate) > truncateToMinutes(nowDate)) || (props.maxDate && truncateToMinutes(props.maxDate) < truncateToMinutes(nowDate));
                 const buttonbarProps = mergeProps(
                     {
                         className: cx('buttonbar')

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -4212,11 +4212,21 @@ export const Calendar = React.memo(
             );
         };
 
+        const truncateToMinutes = (date) => {
+            return new Date(
+                date.getFullYear(),
+                date.getMonth(),
+                date.getDate(),
+                date.getHours(),
+                date.getMinutes(),
+            );
+        };
+
         const createButtonBar = () => {
             if (props.showButtonBar) {
                 const { today, clear, now } = localeOptions(props.locale);
                 const nowDate = new Date();
-                const isHidden = (props.minDate && props.minDate > nowDate) || (props.maxDate && props.maxDate < nowDate);
+                const isHidden = (props.minDate && truncateToMinutes(props.minDate) > truncateToMinutes(nowDate) || (props.maxDate && truncateToMinutes(props.maxDate) < truncateToMinutes(nowDate)));
                 const buttonbarProps = mergeProps(
                     {
                         className: cx('buttonbar')


### PR DESCRIPTION
Fix #7598

Issue without this fix: 
Today button is hidden when maxDate is passed as new Date(). 

Fix with the PR: Fixes the issue when maxDate is passed as new Date(). 
Since the code could executes at slightly different time intervals so currentDate in prime react component is always greater than new Date() passed from parent component hence condition executed for Today Button is true therefore Today Button is hidden 

With this fix we will compare timeStamp upto minutes only (truncating seconds and milliseconds)
 
### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
