### PR TITLE
fix(MultiSelect): refine condition for determining item groups in createItem function

### DIFF
--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -140,8 +140,9 @@ export const MultiSelectPanel = React.memo(
 
         const createItem = (option, index, scrollerOptions = {}) => {
             const style = { height: scrollerOptions.props ? scrollerOptions.props.itemSize : undefined };
+            const isItemGroup = option.group === true && props.optionGroupLabel && option.items?.length > 0;
 
-            if (option.group && props.optionGroupLabel) {
+            if (isItemGroup) {
                 const groupContent = props.optionGroupTemplate ? ObjectUtils.getJSXElement(props.optionGroupTemplate, option, index) : props.getOptionGroupLabel(option);
                 const key = index + '_' + props.getOptionGroupRenderKey(option);
                 const itemGroupProps = mergeProps(


### PR DESCRIPTION
## Defect Fixes
- fix: #7595 

<br/>

## How to resolve
### Issue Description
- When `visibleOptions` is flattened, the group option has `option.group: true`.
https://github.com/primefaces/primereact/blob/5e276d8b14df6261f885ed8525875ef4b96133c4/components/lib/multiselect/MultiSelect.js#L938-L940

<br/>

- However, during item rendering, the `option.group` condition evaluates as `true` if the item's group has a group key, regardless of its actual value.
```js
const createItem = (option, index, scrollerOptions = {}) => {
            ...
            if (option.group && props.optionGroupLabel) {   /* issue */
```

<br/>

### To Resolve the issue...

- To resolve this issue, I updated the group check condition to:
    - Verify that the group key is explicitly true. (`option.group === true `)
    - Check if the option contains valid item data. (`option.items?.length > 0`)
    - Ensure that props.optionGroupLabel is defined. (`props.optionGroupLabel`)

```js
        const createItem = (option, index, scrollerOptions = {}) => {
            ...            
            const isItemGroup = option.group === true   /* updated! */
                  && props.optionGroupLabel 
                  && option.items?.length > 0; 

            if (isItemGroup) {
```


<br/>

### Test

<details>
  <summary>Sample Code</summary>

  ```js
import { MultiSelect } from '@/components/lib/multiselect/MultiSelect';
import { useState } from 'react';

export function BasicDoc() {
    const [selectedCities, setSelectedCities] = useState(null);
    const groupedCities = [
        {
            label: 'Germany',
            code: 'DE',
            items: [
                { group: '1', label: 'Berlin', value: 'Berlin' },
                { group: '2', label: 'Frankfurt', value: 'Frankfurt' },
                { group: '3', label: 'Hamburg', value: 'Hamburg' },
                { group: '4', label: 'Munich', value: 'Munich' }
            ]
        },
        {
            label: 'USA',
            code: 'US',
            items: [
                { label: 'Chicago', value: 'Chicago' },
                { label: 'Los Angeles', value: 'Los Angeles' },
                { label: 'New York', value: 'New York' },
                { label: 'San Francisco', value: 'San Francisco' }
            ]
        },
        {
            label: 'Japan',
            code: 'JP',
            items: [
                { label: 'Kyoto', value: 'Kyoto' },
                { label: 'Osaka', value: 'Osaka' },
                { label: 'Tokyo', value: 'Tokyo' },
                { label: 'Yokohama', value: 'Yokohama' }
            ]
        }
    ];

    const groupedItemTemplate = (option) => {
        return (
            <div className="flex align-items-center">
                <img alt={option.label} src="https://primefaces.org/cdn/primereact/images/flag/flag_placeholder.png" className={`mr-2 flag`} style={{ width: '18px' }} />
                <div>{option.label}</div>
            </div>
        );
    };

    return (
        <div className="card flex justify-content-center">
            <MultiSelect
                value={selectedCities}
                options={groupedCities}
                onChange={(e) => setSelectedCities(e.value)}
                optionLabel="label"
                optionGroupLabel="label"
                optionGroupChildren="items"
                optionGroupTemplate={groupedItemTemplate}
                placeholder="Select Cities"
                display="chip"
                className="w-full md:w-20rem"
            />
        </div>
    );
}

  ```

</details>


|before|after|
|---|---|
|<img width="948" alt="스크린샷 2025-01-18 오전 11 25 37" src="https://github.com/user-attachments/assets/3e73fe01-2cfd-462d-93e5-6007fa9295e9" />|<img width="923" alt="스크린샷 2025-01-18 오전 11 29 11" src="https://github.com/user-attachments/assets/aee9b148-6c1e-412e-aedd-697502b62c6a" />|
