### PR TITLE
fix: #7622 update checkboxElement type from HTMLElement to JSX.Element

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -37358,7 +37358,7 @@
                             "name": "checkboxElement",
                             "optional": false,
                             "readonly": false,
-                            "type": "HTMLElement",
+                            "type": "Element",
                             "description": "The checkbox element for selecting items."
                         },
                         {

--- a/components/lib/multiselect/multiselect.d.ts
+++ b/components/lib/multiselect/multiselect.d.ts
@@ -225,7 +225,7 @@ interface MultiSelectPanelHeaderTemplateEvent {
     /**
      * The checkbox element for selecting items.
      */
-    checkboxElement: HTMLElement;
+    checkboxElement: JSX.Element;
     /**
      * Whether the checkbox is checked.
      */


### PR DESCRIPTION
Fix #7622
This pull request includes a minor change to the `components/doc/common/apidoc/index.json` file. 
The type of `checkboxElement` is changed from `HTMLElement` to `Element`.

* [`components/doc/common/apidoc/index.json`](diffhunk://#diff-8ca461f8b4551fad9b54277453d927babb16c9e50d8357c82398c7d2df989a87L37361-R37361): Changed the type of `checkboxElement` from `HTMLElement` to `Element`.