### PR TITLE
Unexpected Behavior in Password Component Width and Icon Customization #7633

### DIFF
--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import PrimeReact, { PrimeReactContext, ariaLabel, localeOption } from '../api/Api';
+import PrimeReact, { ariaLabel, localeOption, PrimeReactContext } from '../api/Api';
 import { useHandleStyle } from '../componentbase/ComponentBase';
 import { CSSTransition } from '../csstransition/CSSTransition';
 import { ESC_KEY_HANDLING_PRIORITIES, useDisplayOrder, useGlobalOnEscapeKey, useMergeProps, useMountEffect, useOverlayListener, useUnmountEffect, useUpdateEffect } from '../hooks/Hooks';
@@ -10,7 +10,7 @@ import { InputIcon } from '../inputicon/InputIcon';
 import { InputText } from '../inputtext/InputText';
 import { OverlayService } from '../overlayservice/OverlayService';
 import { Portal } from '../portal/Portal';
-import { DomHandler, IconUtils, ObjectUtils, ZIndexUtils, classNames } from '../utils/Utils';
+import { classNames, DomHandler, IconUtils, ObjectUtils, ZIndexUtils } from '../utils/Utils';
 import { PasswordBase } from './PasswordBase';
 
 export const Password = React.memo(
@@ -155,6 +155,7 @@ export const Password = React.memo(
 
         const toggleMask = () => {
             setUnmaskedState((prevUnmasked) => !prevUnmasked);
+            props.onToggleMaskClick?.(unmaskedState);
         };
 
         const show = () => {
@@ -309,7 +310,7 @@ export const Password = React.memo(
                 {
                     role: 'switch',
                     tabIndex: props.tabIndex || '0',
-                    className: cx('hideIcon'),
+                    className: classNames(props.iconClassNames?.className, props.iconClassNames?.hideIconClassName, cx('hideIcon')),
                     onClick: toggleMask,
                     onKeyDown: onToggleMaskKeyDown,
                     'aria-label': ariaLabel('passwordHide') || 'Hide Password',
@@ -322,7 +323,7 @@ export const Password = React.memo(
                 {
                     role: 'switch',
                     tabIndex: props.tabIndex || '0',
-                    className: cx('showIcon'),
+                    className: classNames(props.iconClassNames?.className, props.iconClassNames?.showIconClassName, cx('showIcon')),
                     onClick: toggleMask,
                     onKeyDown: onToggleMaskKeyDown,
                     'aria-label': ariaLabel('passwordShow') || 'Show Password',

--- a/components/lib/password/PasswordBase.js
+++ b/components/lib/password/PasswordBase.js
@@ -29,31 +29,31 @@ const styles = `
         position: relative;
         display: inline-flex;
     }
-    
+
     .p-password-panel {
         position: absolute;
         top: 0;
         left: 0;
     }
-    
+
     .p-password .p-password-panel {
         min-width: 100%;
     }
-    
+
     .p-password-meter {
         height: 10px;
     }
-    
+
     .p-password-strength {
         height: 100%;
         width: 0%;
         transition: width 1s ease-in-out;
     }
-    
+
     .p-fluid .p-password {
         display: flex;
     }
-    
+
     .p-password-input::-ms-reveal,
     .p-password-input::-ms-clear {
         display: none;
@@ -81,6 +81,7 @@ export const PasswordBase = ComponentBase.extend({
         strongRegex: '^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.{8,})',
         feedback: true,
         toggleMask: false,
+        onToggleMaskClick: null,
         appendTo: null,
         header: null,
         content: null,
@@ -92,6 +93,7 @@ export const PasswordBase = ComponentBase.extend({
         tooltipOptions: null,
         style: null,
         className: null,
+        iconClassNames: null,
         inputStyle: null,
         inputClassName: null,
         invalid: false,

--- a/components/lib/password/password.d.ts
+++ b/components/lib/password/password.d.ts
@@ -226,6 +226,28 @@ export interface PasswordProps extends Omit<React.DetailedHTMLProps<React.InputH
      */
     toggleMask?: boolean | undefined;
     /**
+     * Callback to invoke when the mask toggle button is clicked.
+     * @param {boolean} state - Current state of the mask (true if unmasked, false if masked).
+     */
+    onToggleMaskClick?: (state: boolean) => void | undefined;
+    /**
+     * Object containing class names for icon elements in the Password component.
+     */
+    iconClassNames?: {
+        /**
+         * General style class applied to all icons.
+         */
+        className?: string | undefined;
+        /**
+         * Style class applied to the show icon (used to display the password).
+         */
+        showIconClassName?: string | undefined;
+        /**
+         * Style class applied to the hide icon (used to mask the password).
+         */
+        hideIconClassName?: string | undefined;
+    };
+    /**
      * DOM element instance where the overlay panel should be mounted. Valid values are any DOM Element and 'self'. The self value is used to render a component where it is located.
      * @defaultValue document.body
      */

--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -4,7 +4,7 @@ import { useHandleStyle } from '../componentbase/ComponentBase';
 import { useMergeProps, useMountEffect } from '../hooks/Hooks';
 import { Ripple } from '../ripple/Ripple';
 import { Tooltip } from '../tooltip/Tooltip';
-import { DomHandler, IconUtils, ObjectUtils, classNames } from '../utils/Utils';
+import { classNames, DomHandler, IconUtils, ObjectUtils } from '../utils/Utils';
 import { ToggleButtonBase } from './ToggleButtonBase';
 
 export const ToggleButton = React.memo(
@@ -101,7 +101,7 @@ export const ToggleButton = React.memo(
             {
                 ref: elementRef,
                 id: props.id,
-                className: classNames(props.className, cx('root', { hasIcon, hasLabel })),
+                className: cx('root', { hasIcon, hasLabel }),
                 'data-p-highlight': props.checked,
                 'data-p-disabled': props.disabled
             },
@@ -133,7 +133,7 @@ export const ToggleButton = React.memo(
 
         const boxProps = mergeProps(
             {
-                className: cx('box', { hasIcon, hasLabel })
+                className: classNames(props.className, cx('box', { hasIcon, hasLabel }))
             },
             ptm('box')
         );

--- a/public/themes/arya-blue/theme.css
+++ b/public/themes/arya-blue/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/arya-orange/theme.css
+++ b/public/themes/arya-orange/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/arya-purple/theme.css
+++ b/public/themes/arya-purple/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/bootstrap4-dark-blue/theme.css
+++ b/public/themes/bootstrap4-dark-blue/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/bootstrap4-dark-purple/theme.css
+++ b/public/themes/bootstrap4-dark-purple/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/bootstrap4-light-blue/theme.css
+++ b/public/themes/bootstrap4-light-blue/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/bootstrap4-light-purple/theme.css
+++ b/public/themes/bootstrap4-light-purple/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/fluent-light/theme.css
+++ b/public/themes/fluent-light/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-amber/theme.css
+++ b/public/themes/lara-dark-amber/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-blue/theme.css
+++ b/public/themes/lara-dark-blue/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-cyan/theme.css
+++ b/public/themes/lara-dark-cyan/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-green/theme.css
+++ b/public/themes/lara-dark-green/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-indigo/theme.css
+++ b/public/themes/lara-dark-indigo/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-pink/theme.css
+++ b/public/themes/lara-dark-pink/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-purple/theme.css
+++ b/public/themes/lara-dark-purple/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-dark-teal/theme.css
+++ b/public/themes/lara-dark-teal/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-amber/theme.css
+++ b/public/themes/lara-light-amber/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-blue/theme.css
+++ b/public/themes/lara-light-blue/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-cyan/theme.css
+++ b/public/themes/lara-light-cyan/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-green/theme.css
+++ b/public/themes/lara-light-green/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-indigo/theme.css
+++ b/public/themes/lara-light-indigo/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-pink/theme.css
+++ b/public/themes/lara-light-pink/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-purple/theme.css
+++ b/public/themes/lara-light-purple/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/lara-light-teal/theme.css
+++ b/public/themes/lara-light-teal/theme.css
@@ -1409,6 +1409,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/luna-amber/theme.css
+++ b/public/themes/luna-amber/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/luna-blue/theme.css
+++ b/public/themes/luna-blue/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/luna-green/theme.css
+++ b/public/themes/luna-green/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/luna-pink/theme.css
+++ b/public/themes/luna-pink/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/md-dark-deeppurple/theme.css
+++ b/public/themes/md-dark-deeppurple/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/md-dark-indigo/theme.css
+++ b/public/themes/md-dark-indigo/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/md-light-deeppurple/theme.css
+++ b/public/themes/md-light-deeppurple/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/md-light-indigo/theme.css
+++ b/public/themes/md-light-indigo/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 1.25rem 1.25rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/mdc-dark-deeppurple/theme.css
+++ b/public/themes/mdc-dark-deeppurple/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/mdc-dark-indigo/theme.css
+++ b/public/themes/mdc-dark-indigo/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/mdc-light-deeppurple/theme.css
+++ b/public/themes/mdc-light-deeppurple/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/mdc-light-indigo/theme.css
+++ b/public/themes/mdc-light-indigo/theme.css
@@ -1412,6 +1412,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/mira/theme.css
+++ b/public/themes/mira/theme.css
@@ -1414,6 +1414,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/nano/theme.css
+++ b/public/themes/nano/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.3125rem 0.3125rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/nova-accent/theme.css
+++ b/public/themes/nova-accent/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/nova-alt/theme.css
+++ b/public/themes/nova-alt/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/nova/theme.css
+++ b/public/themes/nova/theme.css
@@ -1395,6 +1395,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/rhea/theme.css
+++ b/public/themes/rhea/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.53625rem 0.53625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/saga-blue/theme.css
+++ b/public/themes/saga-blue/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/saga-green/theme.css
+++ b/public/themes/saga-green/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/saga-orange/theme.css
+++ b/public/themes/saga-orange/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/saga-purple/theme.css
+++ b/public/themes/saga-purple/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/soho-dark/theme.css
+++ b/public/themes/soho-dark/theme.css
@@ -1411,6 +1411,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/soho-light/theme.css
+++ b/public/themes/soho-light/theme.css
@@ -1411,6 +1411,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/tailwind-light/theme.css
+++ b/public/themes/tailwind-light/theme.css
@@ -1420,6 +1420,12 @@
     font-size: 1.25rem;
     padding: 0.9375rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/vela-blue/theme.css
+++ b/public/themes/vela-blue/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/vela-green/theme.css
+++ b/public/themes/vela-green/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/vela-orange/theme.css
+++ b/public/themes/vela-orange/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/vela-purple/theme.css
+++ b/public/themes/vela-purple/theme.css
@@ -1392,6 +1392,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.625rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/viva-dark/theme.css
+++ b/public/themes/viva-dark/theme.css
@@ -1418,6 +1418,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }

--- a/public/themes/viva-light/theme.css
+++ b/public/themes/viva-light/theme.css
@@ -1418,6 +1418,12 @@
     font-size: 1.25rem;
     padding: 0.625rem 0.9375rem;
   }
+  .p-password > .p-icon-field {
+    width: 100%;
+  }
+  .p-password-input {
+    width: 100%;
+  }
   .p-icon-field {
     position: relative;
   }


### PR DESCRIPTION
This fixes #7633

Changes Made:
	1.	Fixed Full-Width Issue:
	•	Applied styles to container elements in the Password component for all themes, ensuring proper handling of className like w-full.
	2.	Added New Props:
	•	iconClassNames: Enables assigning custom classes to toggle mask icons (showIconClassName and hideIconClassName).
	•	onToggleMaskClick: Provides a callback function triggered on icon clicks to allow custom logic.

Example Usage:

```javascript
<div className="card flex justify-content-center">
    <Password
        value={value}
        onChange={(e) => setValue(e.target.value)}
        toggleMask
        onToggleMaskClick={(state) => console.log(state)}
        className={'w-full'}
        iconClassNames={{
            className: 'mr-8',
            showIconClassName: 'text-red-500',
            hideIconClassName: 'text-yellow-700'
        }}
    />
</div>
```

Visual Output:

<img width="851" alt="Screenshot 2025-01-22 at 02 23 44" src="https://github.com/user-attachments/assets/0848e4a0-8f56-453e-bee2-7424533c0fd9" />
<img width="854" alt="Screenshot 2025-01-22 at 02 24 08" src="https://github.com/user-attachments/assets/41f34dc2-1686-4afa-bb34-d576e90261d0" />


Let me know if additional changes or adjustments are required!