### PR TITLE
fix(multiSelect): group select items using the getOptionGroupChildren prop

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -937,11 +937,14 @@ export const MultiSelect = React.memo(
 
         const flatOptions = (options) => {
             return (options || []).reduce((result, option, index) => {
-                result.push({ ...option, group: true, index });
-
                 const optionGroupChildren = getOptionGroupChildren(option);
 
-                optionGroupChildren && optionGroupChildren.forEach((o) => result.push(o));
+                if (optionGroupChildren) {
+                    result.push({ ...option, group: true, index });
+                    optionGroupChildren.forEach((o) => result.push(o));
+                } else {
+                    result.push(option);
+                }
 
                 return result;
             }, []);

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -939,12 +939,9 @@ export const MultiSelect = React.memo(
             return (options || []).reduce((result, option, index) => {
                 const optionGroupChildren = getOptionGroupChildren(option);
 
-                if (optionGroupChildren) {
-                    result.push({ ...option, group: true, index });
-                    optionGroupChildren.forEach((o) => result.push(o));
-                } else {
-                    result.push(option);
-                }
+                result.push({ ...option, group: true, index });
+
+                optionGroupChildren && optionGroupChildren.forEach((o) => result.push(o));
 
                 return result;
             }, []);

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -937,9 +937,9 @@ export const MultiSelect = React.memo(
 
         const flatOptions = (options) => {
             return (options || []).reduce((result, option, index) => {
-                const optionGroupChildren = getOptionGroupChildren(option);
-
                 result.push({ ...option, group: true, index });
+
+                const optionGroupChildren = getOptionGroupChildren(option);
 
                 optionGroupChildren && optionGroupChildren.forEach((o) => result.push(o));
 

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -140,7 +140,8 @@ export const MultiSelectPanel = React.memo(
 
         const createItem = (option, index, scrollerOptions = {}) => {
             const style = { height: scrollerOptions.props ? scrollerOptions.props.itemSize : undefined };
-            const isItemGroup = option.group === true && props.optionGroupLabel && option.items?.length > 0;
+            const optionItems = props.getOptionGroupChildren(option);
+            const isItemGroup = option.group === true && props.optionGroupLabel && optionItems.length > 0;
 
             if (isItemGroup) {
                 const groupContent = props.optionGroupTemplate ? ObjectUtils.getJSXElement(props.optionGroupTemplate, option, index) : props.getOptionGroupLabel(option);

--- a/components/lib/multiselect/MultiSelectPanel.js
+++ b/components/lib/multiselect/MultiSelectPanel.js
@@ -140,8 +140,7 @@ export const MultiSelectPanel = React.memo(
 
         const createItem = (option, index, scrollerOptions = {}) => {
             const style = { height: scrollerOptions.props ? scrollerOptions.props.itemSize : undefined };
-            const optionItems = props.getOptionGroupChildren(option);
-            const isItemGroup = option.group === true && props.optionGroupLabel && optionItems.length > 0;
+            const isItemGroup = option.group === true && props.optionGroupLabel;
 
             if (isItemGroup) {
                 const groupContent = props.optionGroupTemplate ? ObjectUtils.getJSXElement(props.optionGroupTemplate, option, index) : props.getOptionGroupLabel(option);


### PR DESCRIPTION
## Defect Fixes
- fix: #7653

<br/>

## How To Resolve

### Cause
- When `props.optionGroupChildren` and `props.optionGroupLabel` are set, specific objects in the options can be designated as subgroups.
- However, in the current condition, an option is only considered a group if `option.items`
```
const isItemGroup = option.group === true && props.optionGroupLabel && option.items?.length > 0;
```

<br/>

- As a result, the following expected behavior does not occur (assuming v10.9.1 represents the correct behavior):
```
1. Options are grouped using `props.optionGroupChildren` (but `props.optionGroupLabel` is required).  
2. If an option has an unmatched object key, the item remains invisible.  
   - In v10.9.1, when there are no items under a group, only the group title is displayed.  
```

<br/>

### Solution
- The condition has been modified to ensure that `props.optionGroupChildren` is applied and that groups are still displayed even when they contain no items.

<br/>

### Test

<details>
  <summary>Sample test code</summary>

  ```js
import { MultiSelect } from '@/components/lib/multiselect/MultiSelect';
import { useState } from 'react';

export function BasicDoc(props) {
    const [selectedCities, setSelectedCities] = useState(null);

    const groupedCities = [
        {
            label: 'Germany',
            code: 'DE',
            itemsitems: [
                { label: 'Berlin', value: 'Berlin' },
                { label: 'Frankfurt', value: 'Frankfurt' },
                { label: 'Hamburg', value: 'Hamburg' },
                { label: 'Munich', value: 'Munich' }
            ]
        },
        {
            label: 'USA',
            code: 'US',
            itemsitems: [
                { label: 'Chicago', value: 'Chicago' },
                { label: 'Los Angeles', value: 'Los Angeles' },
                { label: 'New York', value: 'New York' },
                { label: 'San Francisco', value: 'San Francisco' }
            ]
        },
        {
            label: 'Japan',
            code: 'JP',
            items: [
                { label: 'Kyoto', value: 'Kyoto' },
                { label: 'Osaka', value: 'Osaka' },
                { label: 'Tokyo', value: 'Tokyo' },
                { label: 'Yokohama', value: 'Yokohama' }
            ]
        }
    ];

    const groupedItemTemplate = (option) => {
        return (
            <div className="flex align-items-center">
                <img alt={option.label} src="https://primefaces.org/cdn/primereact/images/flag/flag_placeholder.png" className={`mr-2 flag flag-${option.code.toLowerCase()}`} style={{ width: '18px' }} />
                <div>{option.label}</div>
            </div>
        );
    };

    return (
        <div className="card flex justify-content-center">
            <MultiSelect
                value={selectedCities}
                options={groupedCities}
                onChange={(e) => setSelectedCities(e.value)}
                optionLabel="label"
                optionGroupLabel="label"
                optionGroupChildren="itemsitems"
                optionGroupTemplate={groupedItemTemplate}
                placeholder="Select Cities"
                display="chip"
                className="w-full md:w-20rem"
            />
        </div>
    );
}

   ```

</details>


> Before:
- props.optionGroupChildren did not work.
- When props.optionGroupChildren was set to "itemsitems", but a specific group had no matching items, the group was not displayed.

<img width="878" alt="스크린샷 2025-01-30 오후 4 10 05" src="https://github.com/user-attachments/assets/d6321da8-4151-4856-ae93-c825b8726320" />

<br/><br/>

> After:
- props.optionGroupChildren now works as expected. (A)
- Even if a specific group has no matching items, the group title is still displayed. (B)


|A|B|
|---|---|
|<img width="890" alt="스크린샷 2025-01-30 오후 4 09 42" src="https://github.com/user-attachments/assets/cd44ced7-c2b7-4b63-966e-be974475ed51" />|<img width="888" alt="스크린샷 2025-01-30 오후 4 09 51" src="https://github.com/user-attachments/assets/712f9146-144c-43ad-96df-07a95231eeb2" />|




