### PR TITLE
Fix: : Type not Working with Sample Template on InputOtp

### DIFF
--- a/components/doc/inputotp/sampledoc.js
+++ b/components/doc/inputotp/sampledoc.js
@@ -104,12 +104,12 @@ export default function SampleDemo() {
         `,
         typescript: `
 import React, { useState } from 'react';
-import { InputOtp } from 'primereact/inputotp';
+import { InputOtp, InputOtpProps } from 'primereact/inputotp';
 import { Button } from 'primereact/button';
 
-interface CustomInputProps extends InputHTMLAttributes<HTMLInputElement> {
-    events: any;
-    props: any;
+interface CustomInputProps extends InputOtpProps {
+    events?: any;
+    props?: any;
 }
 
 export default function SampleDemo() {


### PR DESCRIPTION
This fixes https://github.com/primefaces/primereact/issues/6765

**Defect Fixes**

**Changes made**

Resolved Type Conflicts
 - Replaced InputHTMLAttributes<HTMLInputElement> with InputOtpProps in CustomInputProps, preventing conflicts with properties like onChange and value.
- Making them optional (events?: any; props?: any;) ensures flexibility, as InputOtpProps already includes certain required properties. This approach prevents conflicts while allowing additional customization when needed.