### PR TITLE
Fix #7684: ConfirmDialog close/escape report 'cancel' event

### DIFF
--- a/components/lib/confirmdialog/ConfirmDialog.js
+++ b/components/lib/confirmdialog/ConfirmDialog.js
@@ -93,6 +93,10 @@ export const ConfirmDialog = React.memo(
 
         const hide = (result = 'cancel') => {
             if (visibleState) {
+                if (typeof result !== 'string') {
+                    result = 'cancel';
+                }
+
                 setVisibleState(false);
                 callbackFromProp('onHide', result);
                 DomHandler.focus(focusElementOnHide.current);


### PR DESCRIPTION
Fix #7684: ConfirmDialog close/escape report 'cancel' event