### PR TITLE
fix(Calendar): replace invalid date with a valid one in event

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -157,6 +157,7 @@ export const Calendar = React.memo(
                 const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);
 
                 if (isValidSelection(value)) {
+                    validateDate(value);
                     updateModel(event, value);
 
                     const date = value.length ? value[0] : value;


### PR DESCRIPTION
### Defect Fixes
- fix: #7691 

<br/>

### How To Resolve
- When typing a date that exceeds the allowed `yearRange`, the input field adjusts it to a valid date. 
- However, the `onChange` event still passes the unadjusted invalid date.
- The `validateDate` function ensures the date is valid.
- Therefore, I called the `validateDate` function in the `updateValueOnInput` callback.

```js
 const updateValueOnInput = (event, rawValue, invalidCallback) => {
      try {
          const value = parseValueFromString(props.timeOnly ? rawValue.replace('_', '') : rawValue);

          if (isValidSelection(value)) {
              validateDate(value);  // this!
              updateModel(event, value);
              const date = value.length ? value[0] : value;
              updateViewDate(event, date);
              ...
}

```
<br/>


### Test

<details>
  <summary>sample code</summary>

  ```js
import { Calendar } from '@/components/lib/calendar/Calendar';
import { useState } from 'react';

export function BasicDoc() {
    const [date, setDate] = useState(null);

    return (
        <div className="card">
            <Calendar showButtonBar monthNavigator yearNavigator value={date} onChange={(e) => setDate(e.value)} yearRange="2020:2030" showIcon showOnFocus={false} />
            <p>CUR DATE: {date?.toLocaleDateString()}</p>
        </div>
    );
}

  ```
</details>


> before: When typing an invalid date(01/01/2000), the onChange event passes the unadjusted date value.


https://github.com/user-attachments/assets/229d74e8-d69c-481c-878f-dd83cbdd6a84



<br/>

> after: When typing an invalid date(01/01/2000), the onChange event now passes the adjusted valid date value(01/01/2020).


https://github.com/user-attachments/assets/dc23563f-aef1-49ce-91fc-d259c48f19c4


