### PR TITLE
Update MultiSelect.js: do not return option as object if optionValue is present

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -620,9 +620,7 @@ export const MultiSelect = React.memo(
             }
 
             if (props.optionValue) {
-                const data = ObjectUtils.resolveFieldData(option, props.optionValue);
-
-                return data !== null ? data : option;
+                return ObjectUtils.resolveFieldData(option, props.optionValue);
             }
 
             return option && option.value !== undefined ? option.value : option;


### PR DESCRIPTION
Fix #7724
If optionValue is present it is assumed that option is object and has the attribute.
So options with null values are supported