### PR TITLE
Fixing table errors and warnings

### DIFF
--- a/components/doc/datatable/rowexpansiondoc.js
+++ b/components/doc/datatable/rowexpansiondoc.js
@@ -107,7 +107,7 @@ export function RowExpansionDoc(props) {
     };
 
     const allowExpansion = (rowData) => {
-        return rowData.orders.length > 0;
+        return rowData.orders?.length > 0;
     };
 
     const rowExpansionTemplate = (data) => {

--- a/components/lib/datatable/TableFooter.js
+++ b/components/lib/datatable/TableFooter.js
@@ -66,7 +66,7 @@ export const TableFooter = React.memo((props) => {
             const rows = React.Children.toArray(ColumnGroupBase.getCProp(props.footerColumnGroup, 'children'));
 
             return rows.map((row, i) => {
-                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context)
+                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context);
 
                 const rootProps = mergeProps(
                     {

--- a/components/lib/datatable/TableFooter.js
+++ b/components/lib/datatable/TableFooter.js
@@ -66,11 +66,13 @@ export const TableFooter = React.memo((props) => {
             const rows = React.Children.toArray(ColumnGroupBase.getCProp(props.footerColumnGroup, 'children'));
 
             return rows.map((row, i) => {
+                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context)
+
                 const rootProps = mergeProps(
                     {
                         role: 'row'
                     },
-                    RowBase.getProps(row.props, context),
+                    unstyled ? { unstyled, ...rest } : rest,
                     getRowPTOptions(row, 'root')
                 );
 

--- a/components/lib/datatable/TableHeader.js
+++ b/components/lib/datatable/TableHeader.js
@@ -239,7 +239,7 @@ export const TableHeader = React.memo((props) => {
             const rows = React.Children.toArray(ColumnGroupBase.getCProp(props.headerColumnGroup, 'children'));
 
             return rows.map((row, i) => {
-                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context)
+                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context);
 
                 const headerRowProps = mergeProps(
                     {

--- a/components/lib/datatable/TableHeader.js
+++ b/components/lib/datatable/TableHeader.js
@@ -239,11 +239,13 @@ export const TableHeader = React.memo((props) => {
             const rows = React.Children.toArray(ColumnGroupBase.getCProp(props.headerColumnGroup, 'children'));
 
             return rows.map((row, i) => {
+                const { unstyled, __TYPE, ptOptions, ...rest } = RowBase.getProps(row.props, context)
+
                 const headerRowProps = mergeProps(
                     {
                         role: 'row'
                     },
-                    RowBase.getProps(row.props, context),
+                    unstyled ? { unstyled, ...rest } : rest,
                     getRowPTOptions(row, 'root')
                 );
 

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -1068,7 +1068,7 @@ export const MultiSelect = React.memo(
                 return value.map((val) => getLabelByValue(val)).join(', ');
             }
 
-            return value;
+            return value ? value : '';
         };
 
         const visibleOptions = getVisibleOptions();


### PR DESCRIPTION
Fix #7617 
Fix #7717

Console errors from table with column group. The props were being applied directly to an HTML component, which throws warnings if the props are not supported.

Also fixed error for multi select in table not supporting undefined for value and a crash when rowData.orders was not yet defined when testing the page locally.