### PR TITLE
fix(AutoComplete): update selectedItem when props.value changed

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -480,7 +480,7 @@ export const AutoComplete = React.memo(
         }, [inputRef, props.inputRef]);
 
         React.useEffect(() => {
-            if (props.value) {
+            if (ObjectUtils.isNotEmpty(props.value)) {
                 selectedItem.current = props.value;
             }
         }, [props.value]);

--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -479,6 +479,12 @@ export const AutoComplete = React.memo(
             ObjectUtils.combinedRefs(inputRef, props.inputRef);
         }, [inputRef, props.inputRef]);
 
+        React.useEffect(() => {
+            if (props.value) {
+                selectedItem.current = props.value;
+            }
+        }, [props.value]);
+
         useMountEffect(() => {
             if (!idState) {
                 setIdState(UniqueComponentId());


### PR DESCRIPTION
### Defect Fixes
- fix: #7737

<br/>

### How To Resolve
- When passing a default `props.value`, the target item was not receiving the selected style.
- This issue occurred because the AutoComplete component did not detect changes in `props.value`.
- To fix this, I updated `selectedItem` whenever `props.value` changes.

```js
/* added */
React.useEffect(() => {
    if (ObjectUtils.isNotEmpty(props.value)) {
        selectedItem.current = props.value;
    }
}, [props.value]);
```

<br/>

### Test

<details>
  <summary>Sample Code</summary>
  
  ```js
import { AutoComplete } from '@/components/lib/autocomplete/AutoComplete';
import { useState } from 'react';

export function MultipleDoc() {
    const [value, setValue] = useState(['value1']);
    const [items, setItems] = useState(['value1', 'value2', 'value3']);

    const search = (event) => {
        // Timeout to emulate a network connection
        setTimeout(() => {
            let _filtered;

            if (!event.query.trim().length) {
                _filtered = [...items];
            } else {
                _filtered = items.filter((i) => {
                    return i.toLowerCase().startsWith(event.query.toLowerCase());
                });
            }

            setItems(_filtered);
        }, 250);
    };

    return (
        <div className="App">
            <AutoComplete multiple value={value} completeMethod={search} suggestions={items} onChange={(e) => setValue(e.value)} />
        </div>
    );
}

  ```
</details>


> Before: When passing a default `props.value`, the target item did not receive the selected style.


https://github.com/user-attachments/assets/c29e4c2f-81ff-4b84-94e0-b73a7cab4b20

<br/>


> After: When passing a default `props.value`, the target item correctly receives the selected style.


https://github.com/user-attachments/assets/8cb0a000-059b-4a02-a0a4-ee771df4e6a7


