### PR TITLE
fix(TreeTable): onValueChange to return latest sorted data

### DIFF
--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -405,11 +405,10 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         } else {
             // performance optimization to prevent resolving field data in each loop
             const lookupMap = new Map();
-            const sortField = getSortField();
             const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
 
             for (let node of data) {
-                lookupMap.set(node.data, ObjectUtils.resolveFieldData(node.data, sortField));
+                lookupMap.set(node.data, ObjectUtils.resolveFieldData(node.data, field));
             }
 
             value.sort((node1, node2) => {

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -397,19 +397,11 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         multiSortMeta = multiSortMeta.length > 0 ? multiSortMeta : null;
     };
 
-    const sortSingle = (data) => {
-        return sortNodes(data);
-    };
-
-    const sortNodes = (data) => {
+    const sortSingleNodes = ({ data, field, order }) => {
         let value = [...data];
 
         if (columnSortable.current && columnSortFunction.current) {
-            value = columnSortFunction.current({
-                data,
-                field: getSortField(),
-                order: getSortOrder()
-            });
+            value = columnSortFunction.current({ data, field, order });
         } else {
             // performance optimization to prevent resolving field data in each loop
             const lookupMap = new Map();
@@ -424,12 +416,12 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
                 const value1 = lookupMap.get(node1.data);
                 const value2 = lookupMap.get(node2.data);
 
-                return compareValuesOnSort(value1, value2, comparator, getSortOrder());
+                return compareValuesOnSort(value1, value2, comparator, order);
             });
 
             for (let i = 0; i < value.length; i++) {
                 if (value[i].children && value[i].children.length) {
-                    value[i].children = sortNodes(value[i].children);
+                    value[i].children = sortSingleNodes({ data: value[i].children, field, order });
                 }
             }
         }
@@ -437,17 +429,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         return value;
     };
 
-    const sortMultiple = (data) => {
-        let multiSortMeta = getMultiSortMeta();
-
-        if (multiSortMeta) {
-            return sortMultipleNodes(data, multiSortMeta);
-        }
-
-        return data;
-    };
-
-    const sortMultipleNodes = (data, multiSortMeta) => {
+    const sortMultipleNodes = ({ data, multiSortMeta = [] }) => {
         let value = [...data];
 
         const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
@@ -458,7 +440,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
         for (let i = 0; i < value.length; i++) {
             if (value[i].children && value[i].children.length) {
-                value[i].children = sortMultipleNodes(value[i].children, multiSortMeta);
+                value[i].children = sortMultipleNodes({ data: value[i].children, multiSortMeta });
             }
         }
 
@@ -1096,6 +1078,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
             if (data && data.length) {
                 const filters = (localState && localState.filters) || getFilters();
                 const sortField = (localState && localState.sortField) || getSortField();
+                const sortOrder = (localState && localState.sortOrder) || getSortOrder();
                 const multiSortMeta = (localState && localState.multiSortMeta) || getMultiSortMeta();
                 const columns = getColumns();
                 const sortColumn = columns.find((col) => getColumnProp(col, 'field') === sortField);
@@ -1111,9 +1094,9 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
                 if (sortField || ObjectUtils.isNotEmpty(multiSortMeta)) {
                     if (props.sortMode === 'single') {
-                        data = sortSingle(data);
+                        data = sortSingleNodes({ data, field: sortField, order: sortOrder });
                     } else if (props.sortMode === 'multiple') {
-                        data = sortMultiple(data);
+                        data = sortMultipleNodes({ data, multiSortMeta });
                     }
                 }
             }

--- a/components/lib/treetable/TreeTable.js
+++ b/components/lib/treetable/TreeTable.js
@@ -397,7 +397,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         multiSortMeta = multiSortMeta.length > 0 ? multiSortMeta : null;
     };
 
-    const sortSingleNodes = ({ data, field, order }) => {
+    const sortSingle = ({ data, field, order }) => {
         let value = [...data];
 
         if (columnSortable.current && columnSortFunction.current) {
@@ -421,7 +421,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
             for (let i = 0; i < value.length; i++) {
                 if (value[i].children && value[i].children.length) {
-                    value[i].children = sortSingleNodes({ data: value[i].children, field, order });
+                    value[i].children = sortSingle({ data: value[i].children, field, order });
                 }
             }
         }
@@ -429,7 +429,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
         return value;
     };
 
-    const sortMultipleNodes = ({ data, multiSortMeta = [] }) => {
+    const sortMultiple = ({ data, multiSortMeta = [] }) => {
         let value = [...data];
 
         const comparator = ObjectUtils.localeComparator((context && context.locale) || PrimeReact.locale);
@@ -440,7 +440,7 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
         for (let i = 0; i < value.length; i++) {
             if (value[i].children && value[i].children.length) {
-                value[i].children = sortMultipleNodes({ data: value[i].children, multiSortMeta });
+                value[i].children = sortMultiple({ data: value[i].children, multiSortMeta });
             }
         }
 
@@ -1094,9 +1094,9 @@ export const TreeTable = React.forwardRef((inProps, ref) => {
 
                 if (sortField || ObjectUtils.isNotEmpty(multiSortMeta)) {
                     if (props.sortMode === 'single') {
-                        data = sortSingleNodes({ data, field: sortField, order: sortOrder });
+                        data = sortSingle({ data, field: sortField, order: sortOrder });
                     } else if (props.sortMode === 'multiple') {
-                        data = sortMultipleNodes({ data, multiSortMeta });
+                        data = sortMultiple({ data, multiSortMeta });
                     }
                 }
             }


### PR DESCRIPTION
## Defect Fixes
- fix: #7474 

<br/><br/>

## How To Resolve 
### Issue
- When sorting a column, the `onValueChange` callback is triggered, 
- but it receives data from the previous sort instead of the currently sorted data.

<br/>

### Cause
- The issue occurs because the sorting function was directly referencing external state values. 
- As a result, it used values captured by closures from earlier render cycles, which—combined with the asynchronous nature of state updates—meant that the latest state was not reflected at the time of sorting. 
- Consequently, the comparator function was operating on stale sort criteria, causing the onValueChange callback to receive data from the previous sort rather than the current one.

<br/>

### Solution
- Updated the sorting functions (`sortSingle`, `sortMultiple`) to accept field and order as direct parameters. 

```js
// before

if (sortField || ObjectUtils.isNotEmpty(multiSortMeta)) {
      if (props.sortMode === 'single') {
          data = sortSingle(data);
      } else if (props.sortMode === 'multiple') {
          data = sortMultiple(data);
      }
  }
```
```js
// after

if (sortField || ObjectUtils.isNotEmpty(multiSortMeta)) {
      if (props.sortMode === 'single') {
          data = sortSingle({ data, field: sortField, order: sortOrder });
      } else if (props.sortMode === 'multiple') {
          data = sortMultiple({ data, multiSortMeta });
      }
  }
```

<br/>

### Test

<details>
  <summary>test sample code</summary>

  ```js
import { Column } from '@/components/lib/column/Column';
import { TreeTable } from '@/components/lib/treetable/TreeTable';
import { useEffect, useState } from 'react';
import { NodeService } from '../../../service/NodeService';

export function BasicDoc() {
    const [nodes, setNodes] = useState([]);

    useEffect(() => {
        NodeService.getTreeTableNodes().then((data) => {
            setNodes(data);
        });
    }, []);

    return (
        <div className="card">
            <TreeTable value={nodes} tableStyle={{ minWidth: '50rem' }} onValueChange={(v) => console.log('onValueChange:sorted first item', v[0]?.data?.name)}>
                <Column field="name" header="Name" expander sortable></Column>
                <Column field="size" header="Size" sortable></Column>
                <Column field="type" header="Type" sortable></Column>
            </TreeTable>
        </div>
    );
}

```
</details>




> before: onValueChange is return previous sorted data


https://github.com/user-attachments/assets/b1f3a814-e0d9-49ac-b2f2-7584366b5793

<br/>

> after: onValueChange is return latest sorted data


https://github.com/user-attachments/assets/7ef8fa90-8173-4a81-b357-6d29b12d43ec


