### PR TITLE
Fixed typo in onPaste callback in InputNumber

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -580,7 +580,7 @@ export const InputNumber = React.memo(
                 let filteredData = parseValue(data);
 
                 if (filteredData != null) {
-                    if (isFloat(data)) {
+                    if (isFloat(filteredData)) {
                         const formattedValue = formatValue(filteredData);
 
                         inputRef.current.value = formattedValue;


### PR DESCRIPTION
### Defect Fixes

Fix #7780
Fixed typo in onPaste callback function in InputNumber.
it was calling `isFloat(data)` instead of `isFloat(filteredData)`
