### PR TITLE
fix(Checkbox): bind value prop to input value attribute

### DIFF
--- a/components/lib/checkbox/Checkbox.js
+++ b/components/lib/checkbox/Checkbox.js
@@ -136,6 +136,7 @@ export const Checkbox = React.memo(
                     required: props.required,
                     'aria-invalid': props.invalid,
                     checked: checked,
+                    value: props.value,
                     ...ariaProps
                 },
                 ptm('input')


### PR DESCRIPTION
### Defect Fixes

- fix: #7762

<br/>

### How To Resolve
- The checkbox input was missing the value attribute. (ex. `value="Mushroom"`)
<img width="1719" alt="스크린샷 2025-03-16 오후 4 26 24" src="https://github.com/user-attachments/assets/250205b7-c12f-4feb-8bbf-e91a995e4e4b" />

_< primeReact checkbox example >_


<br/>

- Referring to a similar implementation in the PrimeVue library, 
- the PrimeReact checkbox was updated to bind the value prop to the input's value attribute.

<img width="1728" alt="스크린샷 2025-03-16 오후 4 27 39" src="https://github.com/user-attachments/assets/130bba8c-08c4-4535-9f7c-4994851f2fb8" />


_< primeVue checkbox example >_


<br/>

### Test
> Before Fix: The input element did not have a value attribute.

<img width="1719" alt="스크린샷 2025-03-16 오후 4 26 24" src="https://github.com/user-attachments/assets/250205b7-c12f-4feb-8bbf-e91a995e4e4b" />

<br/><br/>

> After Fix: The input element's value attribute is correctly assigned from `props.value`(_Mushroom_)


<img width="1719" alt="스크린샷 2025-03-16 오후 4 30 44" src="https://github.com/user-attachments/assets/e80ab2be-ffa7-4ca4-a3dc-80a5c21156eb" />
