### PR TITLE
Fix #6782: Datatable fix rowExpansion PT prop

### DIFF
--- a/components/lib/datatable/TableBody.js
+++ b/components/lib/datatable/TableBody.js
@@ -1096,7 +1096,7 @@ export const TableBody = React.memo(
                         className: cx('rowExpansion'),
                         role: 'row'
                     },
-                    getColumnPTOptions('rowExpansion')
+                    ptm('rowExpansion')
                 );
 
                 return <tr {...rowExpansionProps}>{content}</tr>;


### PR DESCRIPTION
Fix #6782: Datatable fix rowExpansion PT prop