### PR TITLE
fix(InputOtp): align Delete key behavior with Backspace

### DIFF
--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -91,7 +91,7 @@ export const InputOtp = React.memo(
 
             if (event.nativeEvent.inputType === 'deleteContentBackward') {
                 moveToPrevInput(event);
-            } else if (event.nativeEvent.inputType === 'insertText' || event.nativeEvent.inputType === 'deleteContentForward') {
+            } else if (event.nativeEvent.inputType === 'insertText') {
                 moveToNextInput(event);
             }
         };
@@ -144,6 +144,21 @@ export const InputOtp = React.memo(
                 case 'ArrowRight': {
                     moveToNextInput(event);
                     event.preventDefault();
+                    break;
+                }
+
+                case 'Delete': {
+                    event.preventDefault();
+                    const idx = Number(event.target.id);
+                    const newTokens = [...tokens];
+
+                    if (!Number.isNaN(idx)) {
+                        newTokens.splice(idx, 1);
+                        setTokens(newTokens);
+                        onChange(event, newTokens);
+                        moveToPrevInput(event);
+                    }
+
                     break;
                 }
 

--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -151,7 +151,7 @@ export const InputOtp = React.memo(
                     event.preventDefault();
                     const idx = Number(event.target.id);
 
-                    if (!Number.isNaN(idx)) {
+                    if (!Number.isNaN(idx) && !isAllEmpty(tokens, props.length)) {
                         updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
                         moveToPrevInput(event);
                     }
@@ -190,6 +190,10 @@ export const InputOtp = React.memo(
                     break;
                 }
             }
+        };
+
+        const isAllEmpty = (arr, n) => {
+            return arr.length === n && arr.every((item) => item === '' || item == null);
         };
 
         useUpdateEffect(() => {

--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -150,12 +150,9 @@ export const InputOtp = React.memo(
                 case 'Delete': {
                     event.preventDefault();
                     const idx = Number(event.target.id);
-                    const newTokens = [...tokens];
 
                     if (!Number.isNaN(idx)) {
-                        newTokens.splice(idx, 1);
-                        setTokens(newTokens);
-                        onChange(event, newTokens);
+                        updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
                         moveToPrevInput(event);
                     }
 


### PR DESCRIPTION
## Defect Fixes
- fix: #7807 

<br/><br/>

## How To Resolve 
### Issue
- Pressing the Delete key in an OTP input cell does not clear the value or move focus backwards, unlike Backspace.

<br/>

### Cause
- The existing Delete‑handling logic lived in the `onInput` handler under the `deleteContentForward` branch
- but `onInput` does not fire when Delete is pressed on an empty input, 
- so the deletion logic never ran for the last (or already‑empty) cell.

<br/>

### Solution
- Move Delete key handling into `onKeyDown` (which always fires), preventing default browser behavior.
- Reuse existing `updateTokens` logic to clear the current cell’s value and invoke `onChange`.
```js
const onKeyDown = (event) => {
  case 'Delete': {
      event.preventDefault();
      const idx = Number(event.target.id);
      if (!Number.isNaN(idx)) {
          updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
          moveToPrevInput(event);
      }
      break;
  }
}
```

<br/>

- The Delete key does not fire an `onInput` event when deleting the last (or an already empty) cell, yet it does fire for non‑final cells—resulting in inconsistent behavior. 
- To simplify and unify the input flow, the `deleteContentForward` branch was removed.

```js
const onInput = (event, index) => {
    ...
    if (event.nativeEvent.inputType === 'deleteContentBackward') {
        moveToPrevInput(event);
    } else if (event.nativeEvent.inputType === 'insertText') { // Remove: deleteContentForward condition
        moveToNextInput(event);
    }
};
```

<br/>

### Test
> before: Pressing the Delete key on an OTP input field (especially the last or empty one) had no effect


https://github.com/user-attachments/assets/ac8fd6da-7d25-4e66-bc10-5c2a9cb6c0ed


<br/>

> after: 
- **Delete key behavior**
  - Non‑empty cell → clears value + moves focus to previous cell
  - Empty cell → moves focus to previous cell
  - First cell → no action

- **onChange**
  - After Delete, the callback’s value should be the updated OTP string with the deleted character removed

https://github.com/user-attachments/assets/5937ee30-7821-42c6-8918-dde29ec3db51


