### PR TITLE
fix(InputOtp): allow Delete key in interOnly option

### DIFF
--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -91,7 +91,7 @@ export const InputOtp = React.memo(
 
             if (event.nativeEvent.inputType === 'deleteContentBackward') {
                 moveToPrevInput(event);
-            } else if (event.nativeEvent.inputType === 'insertText' || event.nativeEvent.inputType === 'deleteContentForward') {
+            } else if (event.nativeEvent.inputType === 'insertText') {
                 moveToNextInput(event);
             }
         };
@@ -144,6 +144,21 @@ export const InputOtp = React.memo(
                 case 'ArrowRight': {
                     moveToNextInput(event);
                     event.preventDefault();
+                    break;
+                }
+
+                case 'Delete': {
+                    event.preventDefault();
+                    const idx = Number(event.target.id);
+                    const newTokens = [...tokens];
+
+                    if (!Number.isNaN(idx)) {
+                        newTokens.splice(idx, 1);
+                        setTokens(newTokens);
+                        onChange(event, newTokens);
+                        moveToPrevInput(event);
+                    }
+
                     break;
                 }
 

--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -151,7 +151,7 @@ export const InputOtp = React.memo(
                     event.preventDefault();
                     const idx = Number(event.target.id);
 
-                    if (!Number.isNaN(idx)) {
+                    if (!Number.isNaN(idx) && !isAllEmpty(tokens, props.length)) {
                         updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
                         moveToPrevInput(event);
                     }
@@ -190,6 +190,10 @@ export const InputOtp = React.memo(
                     break;
                 }
             }
+        };
+
+        const isAllEmpty = (arr, n) => {
+            return arr.length === n && arr.every((item) => item === '' || item == null);
         };
 
         useUpdateEffect(() => {

--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -150,12 +150,9 @@ export const InputOtp = React.memo(
                 case 'Delete': {
                     event.preventDefault();
                     const idx = Number(event.target.id);
-                    const newTokens = [...tokens];
 
                     if (!Number.isNaN(idx)) {
-                        newTokens.splice(idx, 1);
-                        setTokens(newTokens);
-                        onChange(event, newTokens);
+                        updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
                         moveToPrevInput(event);
                     }
 

--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -153,7 +153,7 @@ export const InputOtp = React.memo(
 
                     if (!Number.isNaN(idx) && !isAllEmpty(tokens, props.length)) {
                         updateTokens({ ...event, target: { ...event.target, value: '' } }, idx);
-                        moveToPrevInput(event);
+                        moveToNextInput(event);
                     }
 
                     break;


### PR DESCRIPTION
### Defect Fixes

- fix: #7810 
- I submitted a [PR](https://github.com/primefaces/primereact/pull/7810) to fix a bug in InputOtp, 
- but I accidentally made the Delete key move focus backward instead of forward. 😢 😢 
- I’ve now corrected it so that when the integerOnly option is enabled, pressing Delete moves focus forward.


### Test
> When the Delete key is pressed, the target value is cleared and the focus moves to the next input.


https://github.com/user-attachments/assets/762dacac-6712-4b67-a768-99dfe9ba6b25


