### PR TITLE
fix: #7797, Dropdown: When using Dropdown filter to call data in API, the filter text bugs if the results is empty

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -948,10 +948,6 @@ export const Dropdown = React.memo(
         }, [filterState]);
 
         useUpdateEffect(() => {
-            if (filterState && (!props.options || props.options.length === 0)) {
-                setFilterState('');
-            }
-
             updateInputField();
 
             if (inputRef.current) {


### PR DESCRIPTION
fix: #7797, Dropdown: When using Dropdown filter to call data in API, the filter text bugs if the results is empty