### PR TITLE
Fix: #7831 InputUtp: Using the normal enter key allows submitting the form, not with the numpad enter key.

### DIFF
--- a/components/lib/inputotp/InputOtp.js
+++ b/components/lib/inputotp/InputOtp.js
@@ -177,6 +177,8 @@ export const InputOtp = React.memo(
 
                 case 'Tab':
 
+                case 'NumpadEnter':
+
                 case 'Enter': {
                     break;
                 }


### PR DESCRIPTION
Fixes #7831

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/primefaces/primereact/pull/7832?shareId=a137d3fe-a783-456d-a1f0-c7752d88e941).