### PR TITLE
fix: #7835, Knob: Hand Icon missing while hovering over knob range

### DIFF
--- a/components/lib/knob/KnobBase.js
+++ b/components/lib/knob/KnobBase.js
@@ -45,6 +45,7 @@ export const KnobBase = ComponentBase.extend({
             .p-knob-range {
                 fill: none;
                 transition: stroke .1s ease-in;
+                cursor: pointer;
             }
             .p-knob-value {
                 animation-name: dash-frame;


### PR DESCRIPTION
fix: #7835, Knob: Hand Icon missing while hovering over knob range