### PR TITLE
fix(Menu): popup mode with template hover issue

### DIFF
--- a/components/doc/menu/popupdoc.js
+++ b/components/doc/menu/popupdoc.js
@@ -22,6 +22,18 @@ export function PopupDoc(props) {
                 {
                     label: 'Export',
                     icon: 'pi pi-upload'
+                },
+                {
+                    label: 'Custom template',
+                    template: (item, options) => {
+                        return (
+                            <div className="p-menuitem-content" data-pc-section="content" onMouseMove={(e) => options.onMouseMove(e)}>
+                                <a href="#" className="p-menuitem-link">
+                                    Lorem ipsum
+                                </a>
+                            </div>
+                        );
+                    }
                 }
             ]
         }
@@ -56,6 +68,18 @@ export default function PopupDoc() {
                 {
                     label: 'Export',
                     icon: 'pi pi-upload'
+                },
+                {
+                    label: 'Custom template',
+                    template: (item, options) => {
+                        return (
+                            <div className="p-menuitem-content" data-pc-section="content" onMouseMove={(e) => options.onMouseMove(e)}>
+                                <a href="#" className="p-menuitem-link">
+                                    Lorem ipsum
+                                </a>
+                            </div>
+                        );
+                    }
                 }
             ]
         }
@@ -94,6 +118,18 @@ export default function PopupDoc() {
                 {
                     label: 'Export',
                     icon: 'pi pi-upload'
+                },
+                {
+                    label: 'Custom template',
+                    template: (item, options) => {
+                        return (
+                            <div className="p-menuitem-content" data-pc-section="content" onMouseMove={(e) => options.onMouseMove(e)}>
+                                <a href="#" className="p-menuitem-link">
+                                    Lorem ipsum
+                                </a>
+                            </div>
+                        );
+                    }
                 }
             ]
         }

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -397,6 +397,7 @@ export const Menu = React.memo(
             if (item.template) {
                 const defaultContentOptions = {
                     onClick: (event) => onItemClick(event, item, key),
+                    onMouseMove: (event) => onItemMouseMove(event, key),
                     className: linkClassName,
                     tabIndex: '-1',
                     labelClassName: 'p-menuitem-text',


### PR DESCRIPTION
Fixes #7826

Expose `onMouseMove` event listener to popup menu template options

```

{
    label: 'Custom template',
    template: (item, options) => {
        return (
            <div className="p-menuitem-content" data-pc-section="content" onMouseMove={options.onMouseMove}>
                <a className="p-menuitem-link">
                    Lorem ipsum
                </a>
            </div>
        );
    }
}
```

The issue can also be fixed without exposing the `onMouseMove` event listener to the template options. We can replace the [line](https://github.com/primefaces/primereact/blob/master/components/lib/menu/Menu.js#L408) with the following:

```
 const templateContent = ObjectUtils.getJSXElement(item.template, item, defaultContentOptions);  
                
 content = React.cloneElement(templateContent, {
     onMouseMove: (event) => onItemMouseMove(event, key),
})
```
@melloware Please let me know your opinion on the second approach. If it looks good, I'll update the PR.
