### PR TITLE
fix(Tree): ensure correct DragNode/DropNode on filtered tree

### DIFF
--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -133,7 +133,7 @@ export const Tree = React.memo(
 
         const onDrop = (event) => {
             if (validateDropNode(dragState.current?.path, event.path)) {
-                const value = cloneValue(props.value);
+                const value = cloneValue(getRootNode());
                 let dragPaths = dragState.current.path.split('-');
 
                 dragPaths.pop();
@@ -168,7 +168,7 @@ export const Tree = React.memo(
 
         const onDropPoint = (event) => {
             if (validateDropPoint(event)) {
-                const value = cloneValue(props.value);
+                const value = cloneValue(getRootNode());
                 let dragPaths = dragState.current.path.split('-');
 
                 dragPaths.pop();


### PR DESCRIPTION
Fixes #7698

Replaces `props.value` with return value of  `getRootNode` function to ensure correct values are used for both filtered and non filtered tree.