### PR TITLE
fix(Dropdown): prevent item selection on Escape key press

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -285,13 +285,15 @@ export const Dropdown = React.memo(
                     onArrowLeftKey(event, true);
                     break;
 
-                case 'Escape':
                 case 'Enter':
                 case 'NumpadEnter':
                     onEnterKey(event);
                     event.preventDefault();
                     break;
 
+                case 'Escape':
+                    onEscapeKey(event);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
## Defect Fixes
- fix: #7828

<br/>

## How To Resolve
### Issue Summary
1. The dropdown is in a filterable state.
2. A user types a keyword (e.g., au).
3. Then hovers the mouse or keyArrowDown over an item (e.g., Australia).
4. The user focuses the filter input again.
5. **Issue: When pressing Escape, the hovered item gets selected instead of closing the overlay.**

<br/>

### Expected Behavior
- In version 10.4.0, pressing Escape simply closes the overlay without selecting any item:
- Related commit: https://github.com/primefaces/primereact/commit/5c6b96ede6c0e4968dacf17d4a86286ff62e8e3e
- Relevant logic:

```js
const onFilterInputKeyDown = (event) => {
    switch (event.code) {
        ...
        case 'Escape':
        case 'Enter':
            hide(); // Expected: Close the dropdown
            event.preventDefault();
            break;
        ...
    }
};

const hide = () => {
    setOverlayVisibleState(false);
};
```

<br/>

### Root Cause
- Since [this PR](https://github.com/primefaces/primereact/commit/e72986d20e04eb0c58f46d0d61e509f7159bfad0#diff-77bb67ba04eade513f7d567224e97228b77e3d3fef12270deb95955b3d582eb5), the Escape key no longer triggers `hide()`, but instead calls `onEnterKey()` — the logic used for selecting items.

```js
const onFilterInputKeyDown = (event) => {
    switch (event.code) {
        ...
        case 'Escape':
        case 'Enter':
            onEnterKey(); // Causes item selection even on Escape
            event.preventDefault();
            break;
        ...
    }
};

const onEnterKey = (event) => {
    if (!overlayVisibleState) {
        setFocusedOptionIndex(-1);
        onArrowDownKey(event);
    } else {
        if (focusedOptionIndex !== -1) {
            onOptionSelect(event, visibleOptions[focusedOptionIndex]);
        }
    }
    event.preventDefault();
};
```

<br/>

### Fix Applied
- To restore the expected behavior (as in version 10.4.0), 
- I updated the logic so that pressing Escape triggers a `onEscapeKey()`, instead of calling `onEnterKey()`.

```js
const onFilterInputKeyDown = (event) => {
    switch (event.code) {
        ...
        case 'Enter':
            onEnterKey();
            event.preventDefault();
            break;
        case 'Escape':
            onEscapeKey(); // ✅ Fixed behavior
            break;
        ...
    }
};
```

<br/>

### Test Results
> Before Fix: Pressing Escape causes the hovered item to be selected.

|Hovered via mouse|Hovered via keyboard (ArrowDown)|
|---|---|
|<video src="https://github.com/user-attachments/assets/d22b6b9f-59df-4b16-805c-8e18290069c7" />|<video src="https://github.com/user-attachments/assets/19a57db8-fe2e-46ec-ab98-ee121932b0f7"/>|


<br/>

> After Fix: Pressing Escape correctly closes the overlay without selecting any item.


|Hovered via mouse|Hovered via keyboard (ArrowDown)|
|---|---|
|<video src="https://github.com/user-attachments/assets/3c7aeb84-ac50-4ae4-8c8d-d9830e8185c4" />|<video src="https://github.com/user-attachments/assets/aaa8c1a6-09c2-4823-bb68-2585bdd10b8a"/>|











