### PR TITLE
fix: #7877 Dropdown - add missing typescript definition for filterClearIcon pt

### DIFF
--- a/components/lib/dropdown/dropdown.d.ts
+++ b/components/lib/dropdown/dropdown.d.ts
@@ -77,6 +77,10 @@ export interface DropdownPassThroughOptions {
      */
     filterIcon?: DropdownPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
     /**
+     * Uses to pass attributes to the filter clear icon's DOM element.
+     */
+    filterClearIcon?: DropdownPassThroughType<React.SVGProps<SVGSVGElement> | React.HTMLAttributes<HTMLSpanElement>>;
+    /**
      * Uses to pass attributes to the wrapper's DOM element.
      */
     wrapper?: DropdownPassThroughType<React.HTMLAttributes<HTMLDivElement>>;


### PR DESCRIPTION
Fix  #7877 

https://github.com/primefaces/primereact/issues/7877