### PR TITLE
fix: #7881, AutoComplete, Dropdown: added missing onOverlayHide prop for panels AutoComplete, Dropdown

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -785,6 +785,7 @@ export const AutoComplete = React.memo(
                         listId={listId}
                         onItemClick={selectItem}
                         selectedItem={selectedItem}
+                        onOverlayHide={hide}
                         onClick={onPanelClick}
                         getOptionGroupLabel={getOptionGroupLabel}
                         getOptionGroupChildren={getOptionGroupChildren}

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1248,6 +1248,7 @@ export const Dropdown = React.memo(
                         in={overlayVisibleState}
                         isOptionDisabled={isOptionDisabled}
                         isSelected={isSelected}
+                        onOverlayHide={hide}
                         onClick={onPanelClick}
                         onEnter={onOverlayEnter}
                         onEntered={onOverlayEntered}


### PR DESCRIPTION
fix: #7881, In the panelFooterTemplate function, the hide() method is not being called as expected. This prevents the panel footer from being properly hidden when required.