### PR TITLE
Fix #7892: CascadeSelect loading/loadingIcon typescript def

### DIFF
--- a/components/lib/cascadeselect/cascadeselect.d.ts
+++ b/components/lib/cascadeselect/cascadeselect.d.ts
@@ -282,6 +282,15 @@ export interface CascadeSelectProps extends Omit<React.DetailedHTMLProps<React.I
      */
     scrollHeight?: string | undefined;
     /**
+     * Display loading icon.
+     * @defaultValue false
+     */
+    loading?: boolean | undefined;
+    /**
+     * Name of the loading icon or JSX.Element for loading icon.
+     */
+    loadingIcon?: IconType<CascadeSelectProps> | undefined;
+    /**
      * Callback to invoke on value change
      * @param {CascadeSelectChangeEvent} event - Custom change event
      */


### PR DESCRIPTION
Fix #7892: CascadeSelect loading/loadingIcon typescript def