### PR TITLE
Fix #7894: AutoComplete/Chips do not allow removeItem in readonly

### DIFF
--- a/components/lib/autocomplete/AutoComplete.js
+++ b/components/lib/autocomplete/AutoComplete.js
@@ -252,6 +252,10 @@ export const AutoComplete = React.memo(
         };
 
         const removeItem = (event, index) => {
+            if (props.disabled || props.readOnly) {
+                return;
+            }
+
             const removedValue = props.value[index];
             const newValue = props.value.filter((_, i) => index !== i);
 

--- a/components/lib/chips/Chips.js
+++ b/components/lib/chips/Chips.js
@@ -30,7 +30,7 @@ export const Chips = React.memo(
         const inputRef = React.useRef(props.inputRef);
 
         const removeItem = (event, index) => {
-            if (props.disabled && props.readOnly) {
+            if (props.disabled || props.readOnly) {
                 return;
             }
 


### PR DESCRIPTION
Fix #7894: AutoComplete/Chips do not allow removeItem in readonly