### PR TITLE
fix(Chip/Menu): prevent Event Misbehavior When Clicking Chip Delete Button Inside Menu

### DIFF
--- a/components/lib/chip/Chip.js
+++ b/components/lib/chip/Chip.js
@@ -30,6 +30,7 @@ export const Chip = React.memo(
             let result = true;
 
             if (props.onRemove) {
+                event.stopPropagation();
                 result = props.onRemove({
                     originalEvent: event,
                     value: props.label || props.image || props.icon

--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -123,6 +123,10 @@ export const Menu = React.memo(
         };
 
         const onListBlur = (event) => {
+            const { currentTarget, relatedTarget } = event;
+
+            if (relatedTarget && currentTarget.contains(relatedTarget)) return;
+
             setFocused(false);
             setFocusedOptionIndex(-1);
             props.onBlur && props.onBlur(event);


### PR DESCRIPTION
## Defect Fixes
- fix: #7912 

<br/>

## How To Resolve
### 1. Problem Scenario 
1. Click the Button.
2. The Menu pops up.
3. Click the Chip component’s delete (“x”) button inside the Menu.
4. Unexpected Behavior: The onRemove callback does not fire on the first click; it only triggers on the third click.

<br/>

### 2. Root Cause
- When the `<ul>` menu list has focus and the user clicks its internal delete `<button>`, focus shifts from the list to the button.
- Browser-native events:
	- `blur` (on the list) — does not bubble.
	- `focus` (on the button) — does not bubble.

- React’s Synthetic Events:
	- React listens globally for `focusout`/`focusin` and maps them to the onBlur/onFocus SyntheticEvents, which do bubble.
	- The Synthetic onBlur is dispatched up the component tree, causing the menu list’s onBlur handler to run.
	- As a result, the menu’s blur logic runs immediately upon clicking the delete button, 
	- preventing the onRemove logic from completing as intended.

<br/>

### 3. Solution
**3‑1. Stop Click Propagation in Chip’s onRemove**
```js
const close = (event) => {
  let result = true;

  if (props.onRemove) {
    event.stopPropagation(); // Prevents the click from bubbling up to the menu
    result = props.onRemove({
      originalEvent: event,
      value: props.label || props.image || props.icon
    });
  }

  if (result !== false) {
    setVisibleState(false);
  }
};
```

<br/>

**3‑2. Guard Against Internal Focus Moves in Menu’s onBlur**

```js
const onListBlur = (event: React.FocusEvent<HTMLUListElement>) => {
  const { currentTarget, relatedTarget } = event;

  // If focus moved to another element _inside_ the list, ignore
  if (relatedTarget && currentTarget.contains(relatedTarget as Node)) {
    return;
  }

  // Otherwise (focus left the list entirely), run blur logic
  setFocused(false);
  setFocusedOptionIndex(-1);
  props.onBlur?.(event);
};

```

> Plus. Explanation of currentTarget vs. relatedTarget

Situation | currentTarget (Event Host) | relatedTarget (New Focus Target) | Description
-- | -- | -- | --
Focus moves within the list (e.g. list → button) | `<ul>` | `<button>` | Focus stayed inside the menu; ignore blur.
Focus moves out of the list (e.g. list → other input) | `<ul> `| `<input>` (or another element) | Focus left the list; close the menu.
Focus goes to the browser UI (e.g. address bar, DevTools) | `<ul>` | null | Focus left the document; close the menu.

- `currentTarget`: the element on which the event handler is registered (the `<ul>` menu list).
- `relatedTarget`: for blur events, the element receiving focus next (or null if focus leaves the document).


<br/>

### Test

<details>
  <summary>sample test code</summary>

```js
import { Menu } from '@/components/lib/menu/Menu';
import { Toast } from '@/components/lib/toast/Toast';
import { Chip } from '@/components/lib/chip/Chip';
import { Button } from '@/components/lib/button/Button';
import { useRef } from 'react';

export function BasicDoc() {
    const menuLeft = useRef(null);
    const toast = useRef(null);
    const items = [
        {
            items: [
                {
                    label: 'Refresh',
                    icon: 'pi pi-refresh'
                },
                {
                    template: () => {
                        return (
                            <>
                                <p onClick={() => alert('text is clicked')}>text click</p>
                                <Chip
                                    label="chip click"
                                    removable
                                    onRemove={() => {
                                        console.log('chip remove');
                                        alert('triggers for the 3rd click');
                                        return true;
                                    }}
                                />
                            </>
                        );
                    }
                }
            ]
        }
    ];

    return (
        <div className="card flex justify-content-center">
            <Toast ref={toast}></Toast>
            <Menu model={items} popup ref={menuLeft} id="popup_menu_left" />
            <Button label="Show Left" icon="pi pi-align-left" className="mr-2" onClick={(event) => menuLeft.current.toggle(event)} aria-controls="popup_menu_left" aria-haspopup />
        </div>
    );
}

```
</details>


> Before: You had to click the delete button three times for onRemove to fire.

https://github.com/user-attachments/assets/5203912b-183a-44a8-996f-4f9df85de2cc




<br/>

> After: onRemove fires on the very first click of the delete button.




https://github.com/user-attachments/assets/08bde037-1c9f-4f9f-ab91-d8e8038f6afa

