### PR TITLE
fix: #7935, FileUpload: Uploaded file name is not trimmed when files with larger filenames are uploaded.

### DIFF
--- a/components/doc/common/apidoc/index.json
+++ b/components/doc/common/apidoc/index.json
@@ -25097,6 +25097,14 @@
                             "description": "Width of the image thumbnail in pixels."
                         },
                         {
+                            "name": "filenameTruncateLength",
+                            "optional": true,
+                            "readonly": false,
+                            "type": "number",
+                            "default": "40",
+                            "description": "Length of the maximum file name characters that can be displayed."
+                        },
+                        {
                             "name": "progressBarTemplate",
                             "optional": true,
                             "readonly": false,

--- a/components/lib/fileupload/FileUploadBase.js
+++ b/components/lib/fileupload/FileUploadBase.js
@@ -104,6 +104,7 @@ export const FileUploadBase = ComponentBase.extend({
         className: null,
         withCredentials: false,
         previewWidth: 50,
+        filenameTruncateLength: 40,
         chooseLabel: null,
         selectedFileLabel: null,
         uploadLabel: null,

--- a/components/lib/fileupload/fileupload.d.ts
+++ b/components/lib/fileupload/fileupload.d.ts
@@ -498,6 +498,11 @@ interface FileUploadProps {
      */
     previewWidth?: number | undefined;
     /**
+     * Length of the maximum file name characters that can be displayed.
+     * @defaultValue 40
+     */
+    filenameTruncateLength?: number | undefined;
+    /**
      * Label of the choose button. Defaults to global value in Locale configuration.
      */
     chooseLabel?: string | undefined;


### PR DESCRIPTION
fix: #7935, FileUpload: Uploaded file name is not trimmed when files with larger filenames are uploaded.

After fix - 
On hovering, tooltip will be displayed as shown.

<img width="728" alt="image" src="https://github.com/user-attachments/assets/17ba2ae3-ca46-4fc5-81d9-87ebc77d8900" />
