### PR TITLE
fix (Galleria): ensure transition enter lifecycle runs on first render

### DIFF
--- a/components/lib/galleria/Galleria.js
+++ b/components/lib/galleria/Galleria.js
@@ -317,6 +317,7 @@ export const Galleria = React.memo(
                         timeout: { enter: 150, exit: 150 },
                         options: props.transitionOptions,
                         unmountOnExit: true,
+                        appear: true,
                         onEnter,
                         onEntering,
                         onEntered,


### PR DESCRIPTION
## Defect Fixes
- fix: #7450 


### Cause
- The Galleria component is only mounted when `props.value` is non-empty (`return ObjectUtils.isNotEmpty(props.value) && createGalleria()`), so it doesn’t exist in the DOM until data arrives.
- By default, `CSSTransition` only runs its enter lifecycle when its `in` prop changes from false to true, so the initial mount skips `onEntering`, causing the overlay callbacks never to fire on first show.


### Solution
- Add the `appear: true` flag to the transition props so that the enter lifecycle always runs on the first mount:

```diff
const transitionProps = mergeProps(
  {
    classNames: cx('transition'),
    in: visibleState,
    timeout: { enter: 150, exit: 150 },
+   appear: true,          // ensure onEnter/onEntering run on initial mount
     ...
  },
  ptm('transition')
);
```


### Test

<details>
  <summary>Sample Code</summary>
  
```js
import { Galleria } from '@/components/lib/galleria/Galleria';
import { useRef, useState } from 'react';

export function BasicDoc() {
    const [galleriaImages, setGalleriaImages] = useState([]);
    const [galleriaImagesActiveIndex, setGalleriaImagesActiveIndex] = useState(0);
    const galleriaRef = useRef(null);
    const galleriaItemTemplate = (item) => (
        <img
            src={item}
            alt=""
            style={{
                maxWidth: '100vw',
                display: 'block',
                padding: '0 10px',
                maxHeight: '90vh'
            }}
        />
    );
    const galleriaThumbnailTemplate = (item) => <img src={item} alt="" style={{ height: '100px', marginLeft: '10px' }} />;

    return (
        <>
            <button
                type="button"
                onClick={() => {
                    setGalleriaImages(['https://picsum.photos/200/200', 'https://picsum.photos/300/300', 'https://picsum.photos/200/300', 'https://picsum.photos/300/200']);
                    setGalleriaImagesActiveIndex(0);

                    galleriaRef.current?.show();
                }}
            >
                Not Working Version
            </button>

            <Galleria
                ref={galleriaRef}
                value={galleriaImages}
                item={galleriaItemTemplate}
                thumbnail={galleriaThumbnailTemplate}
                fullScreen
                showThumbnails={false}
                activeIndex={galleriaImagesActiveIndex}
                onItemChange={(e) => setGalleriaImagesActiveIndex(e.index)}
                circular
                showItemNavigators
                showThumbnailNavigators={false}
            />
        </>
    );
}

```

</details>



> before: when opening the popup, the overlay was not rendered


https://github.com/user-attachments/assets/8fb461b7-290f-4b9a-bbb6-d74651b44a78

<br/>

> after: when opening the popup, the overlay is rendered


https://github.com/user-attachments/assets/9d819029-c08d-4394-abd1-431060483272



