### PR TITLE
api: improve typing of locale option key in exported keyed locale functions

### DIFF
--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -720,7 +720,7 @@ export declare function addLocale(locale: string, options: LocaleOptions): void;
  * @param {*} value - Option value.
  * @param {string} locale - Locale string.
  */
-export declare function updateLocaleOption(key: keyof LocaleOptions, value: any, locale: string): void;
+export declare function updateLocaleOption<Key extends keyof LocaleOptions>(key: Key, value: LocaleOptions[Key], locale: string): void;
 /**
  * Changes the option values of a locale.
  * @param {LocaleOptions} options - Locale options.

--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -720,7 +720,8 @@ export declare function addLocale(locale: string, options: LocaleOptions): void;
  * @param {*} value - Option value.
  * @param {string} locale - Locale string.
  */
-export declare function updateLocaleOption<Key extends keyof LocaleOptions>(key: Key, value: LocaleOptions[Key], locale: string): void;
+export declare function updateLocaleOption<Key extends keyof LocaleOptions>(key: Key, value: Key extends keyof LocaleOptions ? LocaleOptions[Key] : any, locale: string): void;
+export declare function updateLocaleOption<Key extends string>(key: Key, value: Key extends keyof LocaleOptions ? LocaleOptions[Key] : any, locale: string): void;
 /**
  * Changes the option values of a locale.
  * @param {LocaleOptions} options - Locale options.

--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -733,7 +733,8 @@ export declare function updateLocaleOptions(options: object, locale: string): vo
  * @param {string} key - Option key.
  * @param {string} locale - Locale string.
  */
-export declare function localeOption(key: keyof LocaleOptions, locale: string): any;
+export declare function localeOption<Key extends keyof LocaleOptions>(key: Key, locale: string): LocaleOptions[Key];
+export declare function localeOption(key: string, locale: string): any;
 /**
  * Returns the values of locale options.
  * @param {string} locale - Locale string.

--- a/components/lib/api/api.d.ts
+++ b/components/lib/api/api.d.ts
@@ -720,7 +720,7 @@ export declare function addLocale(locale: string, options: LocaleOptions): void;
  * @param {*} value - Option value.
  * @param {string} locale - Locale string.
  */
-export declare function updateLocaleOption(key: string, value: any, locale: string): void;
+export declare function updateLocaleOption(key: keyof LocaleOptions, value: any, locale: string): void;
 /**
  * Changes the option values of a locale.
  * @param {LocaleOptions} options - Locale options.
@@ -732,7 +732,7 @@ export declare function updateLocaleOptions(options: object, locale: string): vo
  * @param {string} key - Option key.
  * @param {string} locale - Locale string.
  */
-export declare function localeOption(key: string, locale: string): any;
+export declare function localeOption(key: keyof LocaleOptions, locale: string): any;
 /**
  * Returns the values of locale options.
  * @param {string} locale - Locale string.


### PR DESCRIPTION
As suggested by the title, this PR enhance the type definition of locale functions that has the key of `LocaleOptions` as function string parameter. With this, typescript is able to suggest auto complete and help ensure type correctness.

**Potential type-error in consuming code** (nothing in runtime)  
As this improve type strictness, this change might cause code that doesn't conform to the types to result in TypeError. The overloads should prevent against this, but typescript code that previously compile might error _where it actually matters_.