### PR TITLE
Dropdown: onClick is called twice #7941

### DIFF
--- a/components/lib/dropdown/DropdownBase.js
+++ b/components/lib/dropdown/DropdownBase.js
@@ -200,6 +200,7 @@ export const DropdownBase = ComponentBase.extend({
         name: null,
         onBlur: null,
         onChange: null,
+        onClick: null,
         onContextMenu: null,
         onFilter: null,
         onFocus: null,


### PR DESCRIPTION
### Defect Fixes
Fixes #7941

This is happening because onClick is not listed in the default props. Which makes it part of otherProps and gets duplicated in mergeProps. I added it to defaultProps.
```js
const otherProps = DropdownBase.getOtherProps(props);
```
```js
const getOtherProps = (props) => ObjectUtils.getDiffProps(props, defaultProps);
```
```js
const rootProps = mergeProps(
            {
                id: props.id,
                ref: elementRef,
                className: classNames(props.className, cx('root', { context, focusedState, overlayVisibleState })),
                style: props.style,
                onClick: (e) => onClick(e),
                onMouseDown: props.onMouseDown,
                onContextMenu: props.onContextMenu,
                onFocus: onFocus,
                'data-p-disabled': props.disabled,
                'data-p-focus': focusedState,
                'aria-activedescendant': focusedState ? `dropdownItem_${focusedOptionIndex}` : undefined
            },
            otherProps, //props.onClick is included here too
            ptm('root')
        );
```


A side note:
The Stackblitz Project https://stackblitz.com/edit/vitejs-vite-daiajq?file=src%2FApp.tsx is broken, it works with this devDependencies:
```json
  "devDependencies": {
    "@types/react": "^18.2.0",
    "@types/react-dom": "^18.2.0",
    "@vitejs/plugin-react": "^4.4.1",
    "globals": "^16.0.0",
    "vite": "^6.3.2"
  }
```