### PR TITLE
Calendar: Restore Seconds & Millisecond support

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2747,7 +2747,7 @@ export const Calendar = React.memo(
 
             if (props.timeOnly) {
                 date = new Date();
-                const match = text.match(/(\d{1,2}:\d{2})(?:\s?(AM|PM))?/i);
+                const match = text.match(/(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)\s?(AM|PM)?/i);
 
                 if (match) {
                     populateTime(date, match[1], match[2]);
@@ -2755,8 +2755,8 @@ export const Calendar = React.memo(
                     return null;
                 }
             } else if (props.showTime) {
-                const time12 = /(\d{1,2}:\d{2})\s?(AM|PM)/i;
-                const time24 = /(\d{1,2}:\d{2})$/;
+                const time12 = /(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)\s?(AM|PM)/i;
+                const time24 = /(\d{1,2}:\d{2}(?::\d{2})?(?:\.\d{1,3})?)$/;
 
                 let match, datePart, timePart, ampm;
 


### PR DESCRIPTION
### Defect Fixes
Follow-up to #7675
I realized that I forgot to handle the showSeconds and showMillisec cases. The regex now covers all combinations. Sorry for the oversight!

Also:
Should we allow users to enter times without leading zeros (e.g., 8:22)?
Currently, that doesn’t work. I have a separate PR ready in case we decide to support it. In my experience, users often enter times without leading zeros.
