### PR TITLE
DataTable: Fix current implementation of overlay handling in cell edit mode

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -176,7 +176,7 @@ export const Cell = (props) => {
     };
 
     const onClick = (event) => {
-        props.onClick(event, getCellCallbackParams(event), isEditable(), editingState, setEditingState, selfClick, props.column, bindDocumentClickListener, overlayEventListener);
+        props.onClick(event, getCellCallbackParams(event), isEditable(), editingState, setEditingState, selfClick, props.column, bindDocumentClickListener, overlayEventListener, isOutsideClicked);
     };
 
     const onMouseDown = (event) => {

--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -534,7 +534,7 @@ export const BodyRow = React.memo((props) => {
         }
     }, []);
 
-    const onCellClick = (event, params, isEditable, editingState, setEditingState, selfClick, column, bindDocumentClickListener, overlayEventListener) => {
+    const onCellClick = (event, params, isEditable, editingState, setEditingState, selfClick, column, bindDocumentClickListener, overlayEventListener, isOutsideClicked) => {
         if (props.editMode !== 'row' && isEditable && !editingState && (props.selectOnEdit || (!props.selectOnEdit && props.isRowSelected))) {
             selfClick.current = true;
 


### PR DESCRIPTION
### Defect Fixes
Fixes #7405 
This also resolves the overlay issue by ensuring isOutsideClicked is passed to BodyRow.onCellClick.

Note: While debugging, I noticed that in link mode, some shared modules like OverlayService get bundled multiple times due to the current Rollup config. This led to unexpected behavior until I applied a local workaround to force a shared instance.
