### PR TITLE
Fix: InputNumber - use decimal separator based on locale

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -555,6 +555,11 @@ export const InputNumber = React.memo(
                     let char = event.key;
 
                     if (char) {
+                        // get decimal separator in current locale
+                        if (char === '.') {
+                            char = _decimalSeparator.current;
+                        }
+
                         const _isDecimalSign = isDecimalSign(char);
                         const _isMinusSign = isMinusSign(char);
 


### PR DESCRIPTION
Fix #7809

In locales where the comma (,) is used as the decimal separator, user keyboard input remains unaffected, meaning users will still press the (.) key for decimal input.
To ensure correct locale handling, this update introduces normalization at the keypress level — whenever the (.) key is detected, it is programmatically mapped to the locale-specific decimal separator (retrieved from _decimalSeparator.current).

This ensures consistent behavior across different locales without affecting user input patterns.

