### PR TITLE
fix: prevent Enter key from clearing selection when no option focused

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -513,7 +513,7 @@ export const Dropdown = React.memo(
                     hide();
                     resetFilter();
                     updateEditableLabel(selectedOption);
-                    
+
                     return;
                 }
 

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -500,9 +500,25 @@ export const Dropdown = React.memo(
                 setFocusedOptionIndex(-1);
                 onArrowDownKey(event);
             } else {
-                if (focusedOptionIndex !== -1) {
-                    onOptionSelect(event, visibleOptions[focusedOptionIndex]);
+                if (focusedOptionIndex === -1) {
+                    event.preventDefault();
+
+                    return;
                 }
+
+                const focusedOption = visibleOptions[focusedOptionIndex];
+                const optionValue = getOptionValue(focusedOption);
+
+                if (optionValue == null || optionValue == undefined) {
+                    hide();
+                    resetFilter();
+                    updateEditableLabel(selectedOption);
+                    event.preventDefault();
+
+                    return;
+                }
+
+                onOptionSelect(event, focusedOption);
             }
 
             event.preventDefault();

--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -496,13 +496,13 @@ export const Dropdown = React.memo(
         };
 
         const onEnterKey = (event) => {
+            event.preventDefault();
+
             if (!overlayVisibleState) {
                 setFocusedOptionIndex(-1);
                 onArrowDownKey(event);
             } else {
                 if (focusedOptionIndex === -1) {
-                    event.preventDefault();
-
                     return;
                 }
 
@@ -513,15 +513,12 @@ export const Dropdown = React.memo(
                     hide();
                     resetFilter();
                     updateEditableLabel(selectedOption);
-                    event.preventDefault();
-
+                    
                     return;
                 }
 
                 onOptionSelect(event, focusedOption);
             }
-
-            event.preventDefault();
         };
 
         const onEscapeKey = (event) => {


### PR DESCRIPTION
This PR fixes #7850 