### PR TITLE
fix: MenuItem onClick handler not triggering when clicking on items

### DIFF
--- a/components/lib/menu/Menu.js
+++ b/components/lib/menu/Menu.js
@@ -421,6 +421,7 @@ export const Menu = React.memo(
                 {
                     id: key,
                     className: classNames(item.className, cx('menuitem', { focused: focusedOptionIndex === key })),
+                    onClick: (event) => onItemClick(event, item, key),
                     style: sx('menuitem', { item }),
                     role: 'menuitem',
                     'aria-label': item.label,


### PR DESCRIPTION
Fix #7979 

This PR adds the onClick handler to the anchor elements via the menuitemProps object. By attaching the click handler directly to the element being clicked, we ensure that all click events are properly captured and processed.

