### PR TITLE
fix(#8026): Add missing FilterMatchMode notIn

### DIFF
--- a/components/lib/api/FilterMatchMode.js
+++ b/components/lib/api/FilterMatchMode.js
@@ -6,6 +6,7 @@ export const FilterMatchMode = Object.freeze({
     EQUALS: 'equals',
     NOT_EQUALS: 'notEquals',
     IN: 'in',
+    NOT_IN: 'notIn',
     LESS_THAN: 'lt',
     LESS_THAN_OR_EQUAL_TO: 'lte',
     GREATER_THAN: 'gt',


### PR DESCRIPTION
Add the missing enumeration case `notIn` to the FilterMatchMode JavaScript definition.

Fixes #8026 
