### PR TITLE
fix: FileUpload component now removes files with single click

### DIFF
--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -126,7 +126,9 @@ export const FileUpload = React.memo(
             for (let i = 0; i < selectedFiles.length; i++) {
                 let file = selectedFiles[i];
 
-                if (!isFileSelected(file) && validate(file)) {
+                const shouldAddFile = props.multiple ? !isFileSelected(file) && validate(file) : validate(file);
+
+                if (shouldAddFile) {
                     file.objectURL = window.URL.createObjectURL(file);
 
                     currentFiles.push(file);
@@ -139,7 +141,7 @@ export const FileUpload = React.memo(
                 upload(currentFiles);
             }
 
-            if (props.onSelect) { 
+            if (props.onSelect) {
                 props.onSelect({ originalEvent: event, files: currentFiles });
             }
 

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -125,7 +125,6 @@ export const FileUpload = React.memo(
 
             for (let i = 0; i < selectedFiles.length; i++) {
                 let file = selectedFiles[i];
-
                 const shouldAddFile = props.multiple ? !isFileSelected(file) && validate(file) : validate(file);
 
                 if (shouldAddFile) {

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -145,7 +145,9 @@ export const FileUpload = React.memo(
             }
 
             clearInput();
+            
             setFocusedState(false);
+
             if (props.mode === 'basic' && currentFiles.length > 0) {
                 fileInputRef.current.style.display = 'none';
             }

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -145,7 +145,7 @@ export const FileUpload = React.memo(
             }
 
             clearInput();
-            
+
             setFocusedState(false);
 
             if (props.mode === 'basic' && currentFiles.length > 0) {

--- a/components/lib/fileupload/FileUpload.js
+++ b/components/lib/fileupload/FileUpload.js
@@ -125,9 +125,8 @@ export const FileUpload = React.memo(
 
             for (let i = 0; i < selectedFiles.length; i++) {
                 let file = selectedFiles[i];
-                const shouldAddFile = props.multiple ? !isFileSelected(file) && validate(file) : validate(file);
 
-                if (shouldAddFile) {
+                if (!isFileSelected(file) && validate(file)) {
                     file.objectURL = window.URL.createObjectURL(file);
 
                     currentFiles.push(file);
@@ -140,12 +139,12 @@ export const FileUpload = React.memo(
                 upload(currentFiles);
             }
 
-            if (props.onSelect) {
+            if (props.onSelect) { 
                 props.onSelect({ originalEvent: event, files: currentFiles });
             }
 
             clearInput();
-
+            setFocusedState(false);
             if (props.mode === 'basic' && currentFiles.length > 0) {
                 fileInputRef.current.style.display = 'none';
             }


### PR DESCRIPTION

Fixes #8033 

the FileUpload component required double-clicking on the remove icon to delete a file. The first click was only removing focus from the choose button instead of performing the removal action.
now managing focus state properly after file selection, the component now correctly removes files with a single click on the remove icon.