### PR TITLE
fix Tree keyboard navigation when item expands #8066

### DIFF
--- a/components/lib/tree/UITreeNode.js
+++ b/components/lib/tree/UITreeNode.js
@@ -430,13 +430,13 @@ export const UITreeNode = React.memo((props) => {
     };
 
     const onArrowRight = (event) => {
-        if (isLeaf || expanded) {
+        if (isLeaf) {
             return;
         }
 
         event.currentTarget.tabIndex = -1;
 
-        expand(event, true);
+        expand(event, expanded);
     };
 
     const onArrowLeft = (event) => {


### PR DESCRIPTION
According to my understanding, the [ARIA requirements](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/) say that, when the node is closed, pressing RIGHT should open the children, but not change focus. 

Currently, pressing RIGHT open the children and changes focus to the first child.

Issue:  #8066

**Generated**: 
This pull request modifies the behavior of the `onArrowRight` function in the `UITreeNode` component to improve handling of tree node expansion.

Key changes in tree node behavior:

* [`components/lib/tree/UITreeNode.js`](diffhunk://#diff-54e22c623d60c2f02035d9621049e7d57f7673967b080e37c0ae6179feff6266L433-R439): Updated the `onArrowRight` function to ensure that the `expand` method respects the current `expanded` state, and removed the condition that checked for `expanded` before returning early.
