### PR TITLE
Fix: ToggleButton accessibility attributes

### DIFF
--- a/components/lib/togglebutton/ToggleButton.js
+++ b/components/lib/togglebutton/ToggleButton.js
@@ -125,7 +125,8 @@ export const ToggleButton = React.memo(
                 readOnly: props.readonly,
                 value: props.checked,
                 checked: props.checked,
-                'aria-label': label
+                'aria-label': props['aria-label'],
+                'aria-labelledby': props['aria-labelledby']
             },
             ptm('input')
         );


### PR DESCRIPTION
Fix #8021 

Fixes -

1. Added `aria-label` and `aria-labelledby` from `props` to the `ToggleButton` input for accessible naming. 
2. Removed `role` and `aria-pressed `from the `input` element, as they are not applicable to `type="checkbox"` and can create conflicting semantics.