### PR TITLE
fix(MultiStateCheckbox): add missing invalid and variant props to TypeScript Interface

### DIFF
--- a/components/lib/multistatecheckbox/multistatecheckbox.d.ts
+++ b/components/lib/multistatecheckbox/multistatecheckbox.d.ts
@@ -243,7 +243,7 @@ export interface MultiStateCheckboxProps extends Omit<React.DetailedHTMLProps<Re
      * @defaultValue false
      */
     unstyled?: boolean;
-        /**
+    /**
      * When present, it specifies that the component has invalid state style.
      * @defaultValue false
      */


### PR DESCRIPTION
Fixes #8085 