### PR TITLE
fix:#8099:DataTable: dissapearing values when clicking quickly

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -367,6 +367,9 @@ export const Cell = (props) => {
             OverlayService.off('overlay-click', overlayEventListener.current);
             overlayEventListener.current = null;
         }
+        if (editingRowDataStateRef.current) {
+            editingRowDataStateRef.current = null;
+        }
     });
 
     const createLoading = () => {

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -122,7 +122,6 @@ export const Cell = (props) => {
             unbindDocumentClickListener();
             OverlayService.off('overlay-click', overlayEventListener.current);
             overlayEventListener.current = null;
-            editingRowDataStateRef.current = null;
             selfClick.current = false;
         }, 1);
     };

--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -367,6 +367,7 @@ export const Cell = (props) => {
             OverlayService.off('overlay-click', overlayEventListener.current);
             overlayEventListener.current = null;
         }
+
         if (editingRowDataStateRef.current) {
             editingRowDataStateRef.current = null;
         }


### PR DESCRIPTION
Fix #8099 