### PR TITLE
Datatable: Fix memoization does not consider column body functions

### DIFF
--- a/components/lib/datatable/BodyCell.js
+++ b/components/lib/datatable/BodyCell.js
@@ -704,6 +704,7 @@ export const BodyCell = React.memo(
     },
     (prevProps, nextProps) => {
         if (nextProps.cellMemo === false) return false;
+        if (ColumnBase.getCProp(prevProps.column, 'body') !== ColumnBase.getCProp(nextProps.column, 'body')) return false;
 
         const memoProps = nextProps.cellMemoProps;
         const keysToCompare = Array.isArray(memoProps) && memoProps.every((prop) => typeof prop === 'string') ? memoProps : defaultKeysToCompare;


### PR DESCRIPTION
Fixes #8079.

This pull request fixes the issue that the DataTable cell memoization currently does not check whether column body functions were changed. Column body functions may include additional implicit dependencies that lead to incorrect memoization decisions if not checked, see #8079. 

In the example in #8079 the event handler `onColumnVisibilityChange` (which is referenced inside of the column body function) is redefined with every data change, but not propagated to all cells if they are deemed to be not affected by only comparing old and new `rowData`. Because of that, when a user clicks on a checkbox, the old (memoized) event handler is called that operates on outdated data, causing unexpected behavior.