### PR TITLE
Dropdown: show emptyMessage when Dropdown with VirtualScroller has no data

### DIFF
--- a/components/lib/dropdown/DropdownPanel.js
+++ b/components/lib/dropdown/DropdownPanel.js
@@ -254,8 +254,9 @@ export const DropdownPanel = React.memo(
                         onLazyLoad: (event) => props.virtualScrollerOptions.onLazyLoad({ ...event, ...{ filter: props.filterValue } }),
                         itemTemplate: (item, options) => item && createItem(item, options.index, options),
                         contentTemplate: (options) => {
+                            const children = options.children || [];
                             const emptyMessage = props.hasFilter ? props.emptyFilterMessage : props.emptyMessage;
-                            const content = isEmptyFilter ? createEmptyMessage(emptyMessage) : options.children;
+                            const content = isEmptyFilter || children?.length === 0 ? createEmptyMessage(emptyMessage) : children;
                             const listProps = mergeProps(
                                 {
                                     ref: options.contentRef,


### PR DESCRIPTION
fix: show emptyMessage when Dropdown with VirtualScroller has no data

### Defect Fixes
Fix Dropdown with VirtualScrollerOptions to show `emptyMessage` when there is no data, even if not filtering.

Previously, if VirtualScroller was used and there were no options, it would render nothing instead of the empty message. Now it properly shows the `emptyMessage` when options are empty.

This ensures consistent UX with and without VirtualScroller.

Fix #4193 
Fix #4194

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
