### PR TITLE
Carousel: Fix initial position for circular

### DIFF
--- a/components/lib/carousel/Carousel.js
+++ b/components/lib/carousel/Carousel.js
@@ -422,7 +422,17 @@ export const Carousel = React.memo(
 
             if (!carouselStyle.current) {
                 calculatePosition();
-                changePosition(totalShiftedItemsState);
+
+                // Workaround: force correct initial position for circular
+                if (isCircular) {
+                    const initialPosition = -1 * numVisibleState;
+
+                    setTotalShiftedItemsState(initialPosition);
+                    changePosition(initialPosition);
+                } else {
+                    changePosition(totalShiftedItemsState);
+                }
+
                 bindWindowResizeListener();
             }
         });


### PR DESCRIPTION
### Defect Fixes
Carousel did not start with the "first" items visible in circular/autoplay mode. 
Fix #3985
