### PR TITLE
Fix #8052 year not updated with viewDate changes

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -3390,7 +3390,6 @@ export const Calendar = React.memo(
         const createTitleYearElement = (metaYear) => {
             const viewDate = getViewDate();
             const viewYear = viewDate.getFullYear();
-            const displayYear = props.numberOfMonths > 1 || props.yearNavigator ? metaYear : currentYear;
 
             if (props.yearNavigator) {
                 let yearOptions = [];
@@ -3416,7 +3415,7 @@ export const Calendar = React.memo(
                     {
                         className: cx('select'),
                         onChange: (e) => onYearDropdownChange(e, e.target.value),
-                        value: displayYear
+                        value: metaYear
                     },
                     ptm('select')
                 );
@@ -3468,7 +3467,7 @@ export const Calendar = React.memo(
                 ptm('yearTitle')
             );
 
-            return currentView !== 'year' && <button {...yearTitleProps}>{displayYear}</button>;
+            return currentView !== 'year' && <button {...yearTitleProps}>{metaYear}</button>;
         };
 
         const createTitleDecadeElement = () => {


### PR DESCRIPTION
Fix #8052 
Fix #8258
The issue occurred when we set the view date and deleted the input field. The currentYear variable retained the old value (in this case, 2000).😶‍🌫️
https://github.com/primefaces/primereact/blob/d57bbb7e4f57371e133668b42db3dc1435191f10/components/lib/calendar/Calendar.js#L3391-L3393
I adjusted displayYear to use metaYear, which fixes the issue, and the yearNavigator works correctly. However, if we modify the value of InputRef.current.value in a way that it cannot be parsed as a Date, the rendering will fall back to using ViewDate as the parameter.😺
