### PR TITLE
Dropdown: keep input focus when hovering options to match MultiSelect behavior

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -406,6 +406,7 @@ export const Dropdown = React.memo(
             if (focusedOptionIndex !== index) {
                 setFocusedOptionIndex(index);
                 scrollInView(event);
+
                 if (props.selectOnFocus) {
                     onOptionSelect(event, visibleOptions[index], false);
                 }


### PR DESCRIPTION
### Defect Fixes
Fixes an issue where the Dropdown component loses focus on its input field when hovering over options in the panel.
This behavior is inconsistent with MultiSelect, which retains the input focus, providing a smoother UX especially for filtering.

The fix removes the explicit call to focus the hovered item (focusOnItem), aligning the behavior with MultiSelect so that the input keeps focus, allowing users to continue typing while hovering options.

Linked issue: #8142

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
