### PR TITLE
fix(button): make icon inside Button clickable in OrderList itemTemplate (#8145)

### DIFF
--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -45,7 +45,8 @@ export const Button = React.memo(
 
             const iconsProps = mergeProps(
                 {
-                    className: cx('icon')
+                    className: cx('icon'),
+                    style: { pointerEvents: 'none' }
                 },
                 ptm('icon')
             );

--- a/components/lib/card/__snapshots__/Card.spec.js.snap
+++ b/components/lib/card/__snapshots__/Card.spec.js.snap
@@ -56,6 +56,7 @@ exports[`Card advanced 1`] = `
             <span
               class="p-button-icon p-c p-button-icon-left pi pi-check"
               data-pc-section="icon"
+              style="pointer-events: none;"
             />
             <span
               class="p-button-label p-c"
@@ -73,6 +74,7 @@ exports[`Card advanced 1`] = `
             <span
               class="p-button-icon p-c p-button-icon-left pi pi-times"
               data-pc-section="icon"
+              style="pointer-events: none;"
             />
             <span
               class="p-button-label p-c"


### PR DESCRIPTION
Fixes #8145

**Root Cause:**  
When using a Button inside an OrderList itemTemplate, only the area outside the icon was clickable. This was because the icon element inside the Button was intercepting pointer events, so clicks on the icon did not bubble up to the button element.

**Solution:**  
I set `pointer-events: none` on the icon element (`.p-button-icon`) inside the Button component. This ensures that all clicks on the icon are passed through to the button, making the entire button (including the icon) clickable.

**Change Details:**  
- Added `style: { pointerEvents: 'none' }` to the icon props in the Button component.

This change makes the Button's `onClick` handler fire regardless of where the user clicks inside the button, including directly on the icon.
