### PR TITLE
fix(menubar): clicking submenu header inside dropdown

### DIFF
--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -42,10 +42,12 @@ export const Menubar = React.memo(
         const [bindOutsideClickListener, unbindOutsideClickListener] = useEventListener({
             type: 'click',
             listener: (event) => {
-                const isOutsideButton = menuButtonRef.current && !menuButtonRef.current.contains(event.target);
+                if (isOutsideClicked(event)) {
+                    const isOutsideContainer = elementRef.current && !elementRef.current.contains(event.target);
 
-                if (isOutsideButton) {
-                    hide();
+                    if (isOutsideContainer) {
+                        hide();
+                    }
                 }
             },
             options: { capture: true }
@@ -96,6 +98,10 @@ export const Menubar = React.memo(
 
         const menuButtonKeydown = (event) => {
             (event.code === 'Enter' || event.code === 'NumpadEnter' || event.code === 'Space') && toggle(event);
+        };
+
+        const isOutsideClicked = (event) => {
+            return rootMenuRef.current !== event.target && !rootMenuRef.current.contains(event.target) && menuButtonRef.current !== event.target && !menuButtonRef.current.contains(event.target);
         };
 
         const getItemProp = (item, name) => {


### PR DESCRIPTION
### Defect Fixes
- fix #7931
- fix #8169 
- fix #8074

#### Issue
- There was a breaking change.
- The main issue was that clicking on another MenuBar component didn't close Menu itself.
- Setting `options: { capture: true }` fixes the issue however there was another change that caused any click outside button to close the whole menu.

#### Solution:
- Reverting breaking part while keeping the `options: { capture: true }` fixes both the old issue and the new one.

#### Result / Test Cases:
- Click on a submenu header and menu shouldn't close.
- While menu is open click another MenuBar component and menu closes.

Above cases are tested and working correctly.