### PR TITLE
fix(datatable, cell): consistency when multiple frozen columns exist …

### DIFF
--- a/components/lib/datatable/BodyRow.js
+++ b/components/lib/datatable/BodyRow.js
@@ -512,7 +512,7 @@ export const BodyRow = React.memo((props) => {
                 let next = elementRef.current && elementRef.current.nextElementSibling;
 
                 if (next && next.classList.contains('p-frozen-column')) {
-                    right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
+                    right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0); 
                 }
 
                 styleObject.right = right + 'px';
@@ -520,8 +520,14 @@ export const BodyRow = React.memo((props) => {
                 let left = 0;
                 let prev = elementRef.current && elementRef.current.previousElementSibling;
 
-                if (prev && prev.classList.contains('p-frozen-column')) {
-                    left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                while (prev) {
+                    if (prev.classList.contains('p-frozen-column')) {
+                        left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                        elementRef.current.style.left = left + 'px';
+                        break;
+                    }
+
+                    prev = prev.previousElementSibling;
                 }
 
                 styleObject.left = left + 'px';

--- a/components/lib/datatable/FooterCell.js
+++ b/components/lib/datatable/FooterCell.js
@@ -45,7 +45,7 @@ export const FooterCell = React.memo((props) => {
 
             if (align === 'right') {
                 let right = 0;
-                let next = elementRef.current.nextElementSibling;
+                let next = elementRef.current && elementRef.current.nextElementSibling;
 
                 if (next && next.classList.contains('p-frozen-column')) {
                     right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
@@ -54,10 +54,16 @@ export const FooterCell = React.memo((props) => {
                 styleObject.right = right + 'px';
             } else {
                 let left = 0;
-                let prev = elementRef.current.previousElementSibling;
+                let prev = elementRef.current && elementRef.current.previousElementSibling;
 
-                if (prev && prev.classList.contains('p-frozen-column')) {
-                    left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                while (prev) {
+                    if (prev && prev.classList.contains('p-frozen-column')) {
+                        left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                        elementRef.current.style.left = left + 'px';
+                        break;
+                    }
+
+                    prev = prev.previousElementSibling;
                 }
 
                 styleObject.left = left + 'px';

--- a/components/lib/datatable/HeaderCell.js
+++ b/components/lib/datatable/HeaderCell.js
@@ -106,7 +106,7 @@ export const HeaderCell = React.memo((props) => {
 
             if (align === 'right') {
                 let right = 0;
-                let next = elementRef.current.nextElementSibling;
+                let next = elementRef.current && elementRef.current.nextElementSibling;
 
                 if (next && next.classList.contains('p-frozen-column')) {
                     right = DomHandler.getOuterWidth(next) + parseFloat(next.style.right || 0);
@@ -115,10 +115,16 @@ export const HeaderCell = React.memo((props) => {
                 styleObject.right = right + 'px';
             } else {
                 let left = 0;
-                let prev = elementRef.current.previousElementSibling;
+                let prev = elementRef.current && elementRef.current.previousElementSibling;
 
-                if (prev && prev.classList.contains('p-frozen-column')) {
-                    left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                while (prev) {
+                    if (prev && prev.classList.contains('p-frozen-column')) {
+                        left = DomHandler.getOuterWidth(prev) + parseFloat(prev.style.left || 0);
+                        elementRef.current.style.left = left + 'px';
+                        break;
+                    }
+
+                    prev = prev.previousElementSibling;
                 }
 
                 styleObject.left = left + 'px';


### PR DESCRIPTION
### Defect Fixes
- fix #8107 

#### Issue
- There was a performance update which caused `prev.style.left` to be inaccessible during cell initialization.
- This issue caused cells and headers to behave differently as cells are initialized with a different algorithm since performance update.
- The alignment only checked previous cell while ignoring if there were gaps in between frozen cells.

#### Solution
- Set `element.current.style.left` manually while initializing so we can access it from the next cell initialization.
- Create a loop to detect gaps in between frozen cells and align correctly.

#### Result / Test Cases
- When there are multiple frozen cells next to each other they align properly.
- When there are gaps in between cells they align next to the previous frozen cell.

Above cases are tested and working correctly for **left aligned** frozen cases.


