### PR TITLE
Expose `processedData` in `DataTable`

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1597,7 +1597,8 @@ export const DataTable = React.forwardRef((inProps, ref) => {
         setSortMeta: (sorts) => setMultiSortMetaState(sorts),
         getElement: () => elementRef.current,
         getTable: () => tableRef.current,
-        getVirtualScroller: () => virtualScrollerRef.current
+        getVirtualScroller: () => virtualScrollerRef.current,
+        getProcessedData: () => processedData()
     }));
 
     const createLoader = () => {

--- a/components/lib/datatable/datatable.d.ts
+++ b/components/lib/datatable/datatable.d.ts
@@ -2061,4 +2061,9 @@ export declare class DataTable<TValue extends DataTableValueArray> extends React
      * @return {VirtualScroller | null} Virtual scroller instance
      */
     public getVirtualScroller(): VirtualScroller | null;
+    /**
+     * Used to get the processed data.
+     * @return {TValue} sorted and filtered data
+     */
+    public getProcessedData(): TValue;
 }


### PR DESCRIPTION
This PR exposes the `processedData()` method in the `DataTable` component.

The purpose of this change is to enable the implementation of custom export functionality that respects the currently applied filters. Currently, the built-in `exportCSV()` method uses `processedData()` internally to retrieve filtered and sorted data. By making this method accessible, custom exporters can achieve the same behavior and maintain consistency with the built-in export logic.

Old but still relevant discussion here: https://github.com/orgs/primefaces/discussions/23