### PR TITLE
MultiSelect: add filterInputKeyDown to filterTemplate options for consistency with Dropdown

### DIFF
--- a/components/lib/multiselect/MultiSelectHeader.js
+++ b/components/lib/multiselect/MultiSelectHeader.js
@@ -90,6 +90,7 @@ export const MultiSelectHeader = React.memo((props) => {
                     element: content,
                     filterOptions: filterOptions,
                     onFilter: onFilter,
+                    filterInputKeyDown: props.onFilterKeyDown,
                     filterIconClassName: props.filterIconClassName,
                     props
                 };


### PR DESCRIPTION
### Defect Fixes
This PR fixes an inconsistency between `Dropdown` and `MultiSelect` components regarding custom `filterTemplate` behavior.
In `Dropdown`, the `options` passed to `filterTemplate` include a `filterInputKeyDown` handler, allowing users to press ArrowDown and navigate to the first list item via keyboard.
In `MultiSelect`, this handler was missing, making it impossible to replicate the same UX.
This PR adds `filterInputKeyDown` to the `filterTemplate` options in `MultiSelect`, matching the behavior and improving keyboard accessibility.
Linked issue: #8152

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
