### PR TITLE
Fix #8202: Dropdown & MultiSelect prevent option focus on reopen when autoOptionFocus is false

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -788,7 +788,7 @@ export const Dropdown = React.memo(
         };
 
         const show = () => {
-            setFocusedOptionIndex(focusedOptionIndex !== -1 ? focusedOptionIndex : props.autoOptionFocus ? findFirstFocusedOptionIndex() : props.editable ? -1 : findSelectedOptionIndex());
+            setFocusedOptionIndex(focusedOptionIndex !== -1 ? focusedOptionIndex : props.autoOptionFocus ? findFirstFocusedOptionIndex() : -1);
             setOverlayVisibleState(true);
         };
 

--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -527,7 +527,7 @@ export const MultiSelect = React.memo(
 
         const show = () => {
             setOverlayVisibleState(true);
-            setFocusedOptionIndex(focusedOptionIndex !== -1 ? focusedOptionIndex : props.autoOptionFocus ? findFirstFocusedOptionIndex() : findSelectedOptionIndex());
+            setFocusedOptionIndex(focusedOptionIndex !== -1 ? focusedOptionIndex : props.autoOptionFocus ? findFirstFocusedOptionIndex() : -1);
             DomHandler.focus(inputRef.current);
         };
 


### PR DESCRIPTION
### Defect Fixes
This PR fixes an issue in `Dropdown` and `MultiSelect` where an option receives focus after reopening the panel, even when `autoOptionFocus={false}` 

Fix #8202.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
