### PR TITLE
Stepper: Missing unstyled example in theming section

### DIFF
--- a/components/doc/stepper/theming/unstyleddoc.js
+++ b/components/doc/stepper/theming/unstyleddoc.js
@@ -1,0 +1,36 @@
+import { DocSectionCode } from '@/components/doc/common/docsectioncode';
+import { DocSectionText } from '@/components/doc/common/docsectiontext';
+
+export const UnstyledDoc = (props) => {
+    const code = {
+        basic: `
+<Stepper ref={stepperRef}>
+    <StepperPanel header="Step 1">
+        <p>Content of Step 1</p>
+        <Button label="Next" onClick={() => stepperRef.current.nextCallback()} />
+    </StepperPanel>
+    <StepperPanel header="Step 2">
+        <p>Content of Step 2</p>
+        <Button label="Back" onClick={() => stepperRef.current.prevCallback()} className="mr-2" />
+        <Button label="Next" onClick={() => stepperRef.current.nextCallback()} />
+    </StepperPanel>
+    <StepperPanel header="Step 3">
+        <p>Content of Step 3</p>
+        <Button label="Back" onClick={() => stepperRef.current.prevCallback()} />
+    </StepperPanel>
+</Stepper>
+        `
+    };
+
+    return (
+        <>
+            <DocSectionText {...props}>
+                <p>
+                    Theming is implemented with <strong>pass-through properties</strong> in unstyled mode.
+                    This allows you to apply your own styling or integrate with Tailwind.
+                </p>
+            </DocSectionText>
+            <DocSectionCode code={code} hideToggleCode import hideStackBlitz />
+        </>
+    );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "primereact",
-    "version": "10.9.6",
+    "version": "10.9.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "primereact",
-            "version": "10.9.6",
+            "version": "10.9.7",
             "dependencies": {
                 "@docsearch/react": "3.9.0",
                 "chart.js": "4.5.0",

--- a/pages/stepper/index.js
+++ b/pages/stepper/index.js
@@ -6,6 +6,7 @@ import { ImportDoc } from '@/components/doc/stepper/importdoc';
 import { LinearDoc } from '@/components/doc/stepper/lineardoc';
 import { Wireframe } from '@/components/doc/stepper/pt/wireframe';
 import { StyledDoc } from '@/components/doc/stepper/theming/styleddoc';
+import { UnstyledDoc } from '@/components/doc/stepper/theming/unstyleddoc';
 import { TailwindDoc } from '@/components/doc/stepper/theming/tailwinddoc';
 import { VerticalDoc } from '@/components/doc/stepper/verticaldoc';
 import { HeaderDoc } from '@/components/doc/stepper/headerdoc';
@@ -70,14 +71,12 @@ const StepperDemo = () => {
         {
             id: 'unstyled',
             label: 'Unstyled',
-            description: 'Theming is implemented with the pass through properties in unstyled mode.',
-            children: [
-                {
-                    id: 'tailwind',
-                    label: 'Tailwind',
-                    component: TailwindDoc
-                }
-            ]
+            component: UnstyledDoc
+        },
+        {
+            id: 'tailwind',
+            label: 'Tailwind',
+            component: TailwindDoc
         }
     ];
 


### PR DESCRIPTION
Fixes #6758

### Description
This PR adds a missing **Unstyled example** for the Stepper component in the theming section of the documentation.  

Previously, the Stepper page did not include an unstyled demo, whereas most other components already had unstyled examples to guide developers using Tailwind CSS or custom styling.  

The new example demonstrates how to use the Stepper in **unstyled mode**, making it consistent with the documentation of other components.

### Changes
- Added `unstyleddoc.js` under `components/doc/stepper/theming/`.
- Updated `StepperDemo` to include `UnstyledDoc` in `themingDocs`.
- Ensured consistency with existing theming docs (`StyledDoc`, `TailwindDoc`).
- Example showcases `pt` (pass-through) usage for unstyled theming.

### Screenshots
<img width="1889" height="1018" alt="Screenshot 2025-08-20 225930" src="https://github.com/user-attachments/assets/aeacd02a-8c6f-41c9-928a-1940c969ad6c" />

### Notes for Reviewers
- This is a **documentation-only change**; no impact on core Stepper functionality.
- Aligns Stepper docs with other components that already include unstyled examples.

