### PR TITLE
fix(OverlayPanel): outside-click dismiss not working when cssTransition=false

### DIFF
--- a/components/lib/overlaypanel/OverlayPanel.js
+++ b/components/lib/overlaypanel/OverlayPanel.js
@@ -137,14 +137,31 @@ export const OverlayPanel = React.forwardRef((inProps, ref) => {
         align();
     };
 
+    let bindOverlayTimer = null;
+
     const onEntered = () => {
-        bindOverlayListener();
+        cancelOverlayBind();
+        /**
+         * With cssTransition=false, onEntered may run synchronously before visibleState updates, causing the outside-click listener not to bind.
+         * Fix: defer the binding to the next tick so it runs with the latest state (when=true). (issue: #8183)
+         */
+        bindOverlayTimer = setTimeout(() => {
+            bindOverlayListener();
+        });
 
         props.onShow && props.onShow();
     };
 
     const onExit = () => {
+        cancelOverlayBind();
         unbindOverlayListener();
+    };
+
+    const cancelOverlayBind = () => {
+        if (bindOverlayTimer) {
+            clearTimeout(bindOverlayTimer);
+            bindOverlayTimer = null;
+        }
     };
 
     const onExited = () => {


### PR DESCRIPTION
## Defect Fixes
- fix: #8183 

<br />

## How To Resolve

### (1) Issue (Behavior)
- With `cssTransition: false`, opening OverlayPanel and clicking outside does not dismiss it.
- Consequently `hide()` isn’t invoked and onExit/onExited never run.

### (2) Root Cause

- In the disabled transition path, CSSTransition fires onEnter/…/onEntered synchronously on the same tick as in changes.
- OverlayPanel binds the outside-click listener inside `onEntered`, but `useOverlayListener({ when: visibleState })` may still “see” the previous when=false value due to render/effect timing.

→ The bind becomes a no-op (or is immediately unbound), so outside clicks never reach `hide()`.

### (3) Fix (This PR)
- Defer the binding to the next tick so it runs with the updated `visibleState` (i.e., when=true).
- Add a guard and cancellation to avoid late binding during rapid toggle/close.
- Also clear the timer when unbinding (onExit, hide, unmount).

```js
    let bindOverlayTimer = null;

    const onEntered = () => {
        cancelOverlayBind();
        /**
         * With cssTransition=false, onEntered may run synchronously before visibleState updates, causing the outside-click listener not to bind.
         * Fix: defer the binding to the next tick so it runs with the latest state (when=true). (issue: #8183)
         */
        bindOverlayTimer = setTimeout(() => {
            bindOverlayListener();
        });

        props.onShow && props.onShow();
    };

    const onExit = () => {
        cancelOverlayBind();
        unbindOverlayListener();
    };

    const cancelOverlayBind = () => {
        if (bindOverlayTimer) {
            clearTimeout(bindOverlayTimer);
            bindOverlayTimer = null;
        }
    };
```

<br/>

* _Impact/Risk: Minimal. Binding is delayed by one tick only; behavior with transitions enabled is unchanged. Timer cleanup prevents leaks and duplicate listeners._


<br/>


### (4) Test
> cssTransition = false

|before|after|
|---|---|
|||

<br/>

> cssTransition = true

|before|after|
|---|---|
|||