### PR TITLE
fix: bug in onSpaceKey with shift selection in PickList

### DIFF
--- a/components/lib/picklist/PickList.js
+++ b/components/lib/picklist/PickList.js
@@ -434,12 +434,15 @@ export const PickList = React.memo(
                 const focusedItem = DomHandler.findSingle(listElement, `[data-pc-section="item"][id=${focusedOptionIndex}]`);
                 const matchedOptionIndex = [...items].findIndex((item) => item === focusedItem);
 
-                selection = [...listItems].slice(Math.min(selectedItemIndex, matchedOptionIndex), Math.max(selectedItemIndex, matchedOptionIndex) + 1);
+                const rangeSelection = [...listItems].slice(
+                    Math.min(selectedItemIndex, matchedOptionIndex),
+                    Math.max(selectedItemIndex, matchedOptionIndex) + 1
+                );
 
                 if (isSource) {
-                    onSelectionChange({ originalEvent: event, value: selection }, 'sourceSelection', props.onSourceSelectionChange);
+                    onSelectionChange({ originalEvent: event, value: rangeSelection }, 'sourceSelection', props.onSourceSelectionChange);
                 } else {
-                    onSelectionChange({ originalEvent: event, value: selection }, 'targetSelection', props.onTargetSelectionChange);
+                    onSelectionChange({ originalEvent: event, value: rangeSelection }, 'targetSelection', props.onTargetSelectionChange);
                 }
             } else {
                 onEnterKey(event, type);


### PR DESCRIPTION
Closes PR #8272.

## PR Summary
This small PR handles a bug in onSpaceKey with shift selection in PickList. 

### Steps to reproduce the behavior

I have prepared a minimal demo:
```
import React, { useState, useMemo } from "react";
import { PickList } from "primereact/picklist";

export default function VirtualScrollDemo() {
  const allItems = useMemo(
    () =>
      Array.from({ length: 30 }, (_, i) => ({
        id: i + 1,
        name: `City #${i + 1}`,
      })),
    []
  );

  const [source, setSource] = useState(allItems.slice(0, 20));
  const [target, setTarget] = useState(allItems.slice(20));

  const onChange = (e) => {
    setSource(e.source);
    setTarget(e.target);
  };

  const itemTemplate = (item) => <div>{item.name}</div>;

  return (
    <div className="card" style={{ maxWidth: 900, margin: "2rem auto" }}>
      <h3>PickList – Keyboard Accessibility Demo</h3>
      <PickList
        dataKey="id"
        source={source}
        target={target}
        itemTemplate={itemTemplate}
        onChange={onChange}
        sourceHeader="Available"
        targetHeader="Selected"
        showSourceControls
        showTargetControls
        showSourceFilter
        showTargetFilter
        filterBy="name"
        metaKeySelection={false}
        breakpoint="768px"
        sourceStyle={{ height: "20rem" }}
        targetStyle={{ height: "20rem" }}
      />
    </div>
  );
}
```

1. Run the demo.
2. Focus the left (Available) list.
3. Select one item with Enter or Space.
4. Move focus with the arrow keys to another item further down.
5. Press Shift + Space to select a range.

It will fail with runtime errors.