### PR TITLE
fix(calendar): prevent rejection of input entry when date is within m…

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -205,7 +205,7 @@ export const Calendar = React.memo(
             let isValid = true;
 
             if (isSingleSelection()) {
-                if (!(isSelectable(value.getDate(), value.getMonth(), value.getFullYear(), false) && isSelectableTime(value))) {
+                if (!(isSelectable(value.getDate(), value.getMonth(), value.getFullYear(), false) && (!props.showTime || isSelectableTime(value)))) {
                     isValid = false;
                 }
             } else if (value.every((v) => isSelectable(v.getDate(), v.getMonth(), v.getFullYear(), false) && isSelectableTime(v))) {
@@ -2315,11 +2315,13 @@ export const Calendar = React.memo(
                     if (props.minDate.getMinutes() > value.getMinutes()) {
                         validMin = false;
                     } else if (props.minDate.getMinutes() === value.getMinutes()) {
-                        if (props.minDate.getSeconds() > value.getSeconds()) {
-                            validMin = false;
-                        } else if (props.minDate.getSeconds() === value.getSeconds()) {
-                            if (props.minDate.getMilliseconds() > value.getMilliseconds()) {
+                        if (props.showSeconds) {
+                            if (props.minDate.getSeconds() > value.getSeconds()) {
                                 validMin = false;
+                            } else if (props.minDate.getSeconds() === value.getSeconds()) {
+                                if (!props.showMillisec || props.minDate.getMilliseconds() > value.getMilliseconds()) {
+                                    validMin = false;
+                                }
                             }
                         }
                     }
@@ -2333,11 +2335,13 @@ export const Calendar = React.memo(
                     if (props.maxDate.getMinutes() < value.getMinutes()) {
                         validMax = false;
                     } else if (props.maxDate.getMinutes() === value.getMinutes()) {
-                        if (props.maxDate.getSeconds() < value.getSeconds()) {
-                            validMax = false;
-                        } else if (props.maxDate.getSeconds() === value.getSeconds()) {
-                            if (props.maxDate.getMilliseconds() < value.getMilliseconds()) {
+                        if (props.showSeconds) {
+                            if (props.maxDate.getSeconds() < value.getSeconds()) {
                                 validMax = false;
+                            } else if (props.maxDate.getSeconds() === value.getSeconds()) {
+                                if (!props.showMillisec || props.maxDate.getMilliseconds() < value.getMilliseconds()) {
+                                    validMax = false;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### Defect Fixes
- fix #8304

#### Issue
- When a date is entered manually into the input field, it is rejected and the field clears itself, even though the same date can be selected via the picker and is within the valid range.
- This occurs because the time portion of the date (hour, minutes, seconds, milliseconds) is validated, even though it is neither visible nor relevant in this context.

#### Solution
- Adjusted the validation logic for manually entered dates. 

#### Result / Test Cases
- Verified that manually entering the *minimum date* into the input field is now accepted.
- Verified that manual entries at both *min* and *max* dates are allowed as expected.

All above scenarios have been tested and work correctly.
