### PR TITLE
fix(Calendar): prevent auto-refocus on single selection mode (#8302)

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1679,7 +1679,9 @@ export const Calendar = React.memo(
                 setTimeout(() => {
                     hide('dateselect');
 
-                    reFocusInputField();
+                    if (props.selectionMode !== 'single') {
+                        reFocusInputField();
+                    }
                 }, 100);
 
                 if (touchUIMask.current) {


### PR DESCRIPTION
Fixes [#8302](https://github.com/primefaces/primereact/issues/8302)

Cause: In single selection mode, when a date is selected, the overlay closes but the input field is immediately refocused with reFocusInputField(). This prevents reopening the calendar by clicking the input again.

Implementation: Updated onDateSelect to conditionally skip the refocus when selectionMode === 'single'.


```
- reFocusInputField();
+ if (props.selectionMode !== 'single') {
+     reFocusInputField();
+ }

```

Result:

✅ Single selection mode → panel closes without auto-refocus, allowing the user to reopen the calendar by clicking the input.

✅ Range / multiple selection modes → auto-refocus remains, preserving accessibility.

@Coderxrohan
