### PR TITLE
fix(HeaderCell): improve left positioning logic for frozen multi-row scenarios

### DIFF
--- a/components/lib/datatable/HeaderCell.js
+++ b/components/lib/datatable/HeaderCell.js
@@ -152,8 +152,6 @@ export const HeaderCell = React.memo((props) => {
                             left = candidate.offsetLeft + DomHandler.getOuterWidth(candidate) - scrollLeft;
                         }
                     }
-
-                    elementRef.current.style.left = left + 'px';
                 }
 
                 styleObject.left = left + 'px';


### PR DESCRIPTION
## 🗒️ Description
- This PR fixes #8320 
- Inside the **DataTable** component more than two columns with a `headerColumnGroup` causes errors and crash

## 🛠️ Changes
- Fixed column-freezing errors beyond the second column in **DataTable** while improving **left positioning logic** for **multi-row frozen headers**

## 🧪 How to Test
1. Open a DataTable configured with a `headerColumnGroup`
2. Try freezing:
   - The first and second columns → ✅ should work as before  
   - The third and subsequent columns → ✅ should now work without errors
   - Multi-row columns → ✅ should now work without errors

## 📸 Screenshots / Demo
[https://github.com/user-attachments/assets/040bc82b-4c02-49b9-9bb0-fc0191adf766](https://github.com/user-attachments/assets/040bc82b-4c02-49b9-9bb0-fc0191adf766)
