### PR TITLE
Handle null case for processedItem in Menubar.js

### DIFF
--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -281,7 +281,7 @@ export const Menubar = React.memo(
 
         const onArrowUpKey = (event) => {
             const processedItem = visibleItems[focusedItemInfo.index];
-            const root = ObjectUtils.isEmpty(processedItem.parent);
+            const root = processedItem ? ObjectUtils.isEmpty(processedItem.parent) : null;
 
             if (root) {
                 const grouped = isProccessedItemGroup(processedItem);


### PR DESCRIPTION
### Defect Fixes

Fix #8328

This fixes https://github.com/primefaces/primereact/issues/8328 by adding a null check to the up arrow key handler. This null check is already present in the handlers for the down, left, and right arrow keys.