### PR TITLE
Fix #5975

### DIFF
--- a/components/lib/slider/Slider.js
+++ b/components/lib/slider/Slider.js
@@ -20,7 +20,7 @@ export const Slider = React.memo(
         const barWidth = React.useRef(0);
         const barHeight = React.useRef(0);
         const touchId = React.useRef();
-        const value = props.range ? props.value ?? [props.min, props.max] : props.value ?? props.min ?? 0;
+        const value = props.range ? (props.value ?? [props.min, props.max]) : (props.value ?? props.min ?? 0);
         const horizontal = props.orientation === 'horizontal';
         const vertical = props.orientation === 'vertical';
 


### PR DESCRIPTION
* Since version 10.3.0, a condition has been added to prevent submenus from activating on hover when in “popup” mode (commit 5615c89a0621867f8072c78738b091afe3436e2b). I don't really understand why this constraint exists. But removing it resolves issue #5975 and aligns with PrimeVue's behaviour.

* little format fix in Slider.js

Fix #5975
