### PR TITLE
fix: #8341, MenuBar: Up and down arrow key navigation not working with dropdown items in MenuBar

### DIFF
--- a/components/lib/menubar/Menubar.js
+++ b/components/lib/menubar/Menubar.js
@@ -559,7 +559,7 @@ export const Menubar = React.memo(
 
         useUpdateEffect(() => {
             if (focusTrigger) {
-                const itemIndex = focusedItemInfo.index !== -1 ? findNextItemIndex(focusedItemInfo.index) : reverseTrigger.current ? findLastItemIndex() : findFirstFocusedItemIndex();
+                const itemIndex = focusedItemInfo.index !== -1 ? findNextItemIndex(focusedItemInfo.index) : reverseTrigger.current ? findLastItemIndex() : findFirstItemIndex();
 
                 changeFocusedItemIndex(itemIndex);
                 reverseTrigger.current = false;


### PR DESCRIPTION
fix: #8341, MenuBar: Up and down arrow key navigation not working with dropdown items in MenuBar

Go to https://primereact.org/menubar/#basic
Click on a menu item with dropdown, say 'Projects'
Try to navigate using arrow keys, either UP arrow key or Down arrow key.
The focus is not pointing to the items in sub menu and navigation is not working.

The focus should point to the items in sub menu and user should be able to navigate using arrow keys.



