### PR TITLE
fix: #8343, PanelMenu: Up and down arrow key navigation not working with dropdown items in PanelMenu

### DIFF
--- a/components/lib/panelmenu/PanelMenuList.js
+++ b/components/lib/panelmenu/PanelMenuList.js
@@ -52,7 +52,7 @@ export const PanelMenuList = React.memo((props) => {
         if (ObjectUtils.isEmpty(focusedItem)) {
             setTimeout(() => {
                 const firstItem = findFirstItem();
-                
+
                 if (firstItem) {
                     setFocusedItem(firstItem);
                 }


### PR DESCRIPTION
fix: #8343, PanelMenu: Up and down arrow key navigation not working with dropdown items in PanelMenu

Go to https://primereact.org/panelmenu/#basic
Click on a menu item with dropdown or arrow key, say 'Files'
Try to navigate using arrow keys, either UP arrow key or Down arrow key.
The focus is not pointing to the items in sub menu and navigation is not working.
I checked PrimeNg and PrimeVue and this navigation is working perfectly there but not in PrimeReact.

Expected behavior
The focus should point to the items in sub menu and user should be able to navigate using arrow keys.

A similar fix was done for #8341 (#8342 )