### PR TITLE
fix: #8353, SpeedDial Linear invisible div overlay even when menu closed

### DIFF
--- a/components/lib/speeddial/SpeedDialBase.js
+++ b/components/lib/speeddial/SpeedDialBase.js
@@ -72,6 +72,10 @@ const styles = `
         pointer-events: auto;
     }
 
+    .p-speeddial:not(.p-speeddial-opened) .p-speeddial-list {
+        display: none;
+    }
+
     .p-speeddial-opened .p-speeddial-item {
         transform: scale(1);
         opacity: 1;


### PR DESCRIPTION
fix: #8353, SpeedDial Linear invisible div overlay even when menu closed


When the SpeedDial type is set to linear, there is an "invisible" div that prevents user interaction with controls underneath, even when the menu is closed. Other types do not have this issue (circle, semi-circle, etc...).

Visit the doc page for SpeedDial and scroll down to the Linear section
Click on the top SpeedDial and notice how all of the buttons have the hover effect and are clickable
Click on the bottom SpeedDial - the top two buttons will not have the hover effect, and clicking will close the menu instead of performing the action ofthe corresponding button
Right click adjacent to the SpeedDial in the direction of the menu and click inspect to see the div for the entire SpeedDial instead of whatever is underneath

Expected - 

Clicking adjacent to a linear SpeedDial in the direction of the menu should activate the corresponding element and not be blocked by the SpeedDial div