### PR TITLE
fix(tree): trigger re-render when filter and onChange in Tree component

### DIFF
--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -21,6 +21,7 @@ export const Tree = React.memo(
         const filteredNodes = React.useRef([]);
         const dragState = React.useRef(null);
         const filterChanged = React.useRef(false);
+        const [, forceRender] = React.useState(false);
 
         const filteredValue = props.onFilterValueChange ? props.filterValue : filterValueState;
         const isFiltering = props.filter && filteredValue;
@@ -351,6 +352,7 @@ export const Tree = React.memo(
             });
 
             currentFilterExpandedKeys.current = {};
+            forceRender((x) => !x);
             filterChanged.current = false;
         };
 


### PR DESCRIPTION
### Defect Fixes:

Fix #8381

#### Issue:

When the `Tree` component is configured with both the `filter={true}` prop and an `onToggle` callback, updates made to the tree nodes (e.g., changes to their expanded/collapsed state or content) are not reflected in the immediately subsequent render. The correct state only appears in the render cycle following that.

#### Solution:

1.  Introduced a new internal state variable, `forceRender`.
2.  The value of `forceRender` is toggled (set to its negative/opposite boolean value) whenever the tree's filter criteria change.
3.  This state change forces the component to re-render, ensuring the latest node data is displayed immediately.

#### Result / Testing:

- Changes to the tree nodes' state (e.g., toggling a node) now render correctly and **immediately** in the same render cycle.

https://github.com/user-attachments/assets/9a179f5a-5791-4bd7-a3cd-21ca1be6acb5

All specified cases were tested and are confirmed to be working correctly.
