### PR TITLE
fix(Tree): only toggle 'filter' expanded keys when the filter is used

### DIFF
--- a/components/lib/tree/Tree.js
+++ b/components/lib/tree/Tree.js
@@ -343,13 +343,13 @@ export const Tree = React.memo(
                         filteredNodes.current.push(copyNode);
                     }
                 }
+                
+                onToggle({
+                    originalEvent: null,
+                    value: currentFilterExpandedKeys.current,
+                    navigateFocusToChild: false
+                });
             }
-
-            onToggle({
-                originalEvent: null,
-                value: currentFilterExpandedKeys.current,
-                navigateFocusToChild: false
-            });
 
             currentFilterExpandedKeys.current = {};
             forceRender((x) => !x);


### PR DESCRIPTION
Fixes #8408 