### PR TITLE
Fix #8357: Calendar closes correctly on scroll

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -82,7 +82,7 @@ export const Calendar = React.memo(
                         if (!isOverlayClicked.current && !isNavIconClicked(event.target)) {
                             hide('outside');
                         }
-                    } else if (context.hideOverlaysOnDocumentScrolling) {
+                    } else if ((context && context.hideOverlaysOnDocumentScrolling) || PrimeReact.hideOverlaysOnDocumentScrolling) {
                         hide();
                     } else if (!DomHandler.isDocument(event.target)) {
                         alignOverlay();

--- a/package.json
+++ b/package.json
@@ -85,5 +85,6 @@
     },
     "engines": {
         "node": ">=18"
-    }
+    },
+    "packageManager": "yarn@4.10.3+sha512.c38cafb5c7bb273f3926d04e55e1d8c9dfa7d9c3ea1f36a4868fa028b9e5f72298f0b7f401ad5eb921749eb012eb1c3bb74bf7503df3ee43fd600d14a018266f"
 }


### PR DESCRIPTION
This PR fixes the issue where the Calendar popup does not close when the page is scrolled [(issue #8357)](https://github.com/primefaces/primereact/issues/8357). Previously, scrolling the page would leave the calendar popup open, sometimes causing it to move incorrectly and trigger JS errors.

Changes:
Added logic to close the calendar popup when the user scrolls the page.
Ensured that the scroll listener is properly attached and removed to avoid memory leaks.
Testing / Reproduction:
Run the showcase app (npm run dev).
Open the Calendar component.
Scroll the page — the calendar popup should now close immediately.
Screenshots / Before & After:
Before fix: [View](https://drive.google.com/file/d/1yn2UyWkpcDHitsw7aiQWigmwt_m8Zg8Q/view?usp=share_link)
After fix: [View](https://drive.google.com/file/d/1NqLHeHN5oD_3Nzf7yoY6pZCp0OfCR307/view?usp=share_link)

Issue Reference:
Closes #8357