### PR TITLE
fix(Carousel): V11 Fix CSS variable collision

### DIFF
--- a/packages/headless/src/carousel/useCarousel.ts
+++ b/packages/headless/src/carousel/useCarousel.ts
@@ -396,12 +396,12 @@ export const useCarousel = withHeadless({
             overscrollBehaviorY: props.orientation === 'horizontal' ? '' : 'contain',
             display: 'flex',
             flexDirection: props.orientation === 'horizontal' ? '' : 'column',
-            '--spacing': props.spacing + 'px',
-            gap: 'var(--spacing)'
+            '--spacing-items': props.spacing + 'px',
+            gap: props.spacing + 'px'
         } as React.CSSProperties;
 
         const slidesPerPage = props.slidesPerPage && props.slidesPerPage > 0 ? props.slidesPerPage : 1;
-        const basis = props.autoSize ? 'auto' : `calc(100% /${slidesPerPage} - var(--spacing) * (${slidesPerPage} - 1) / ${slidesPerPage})`;
+        const basis = props.autoSize ? 'auto' : `calc(100% /${slidesPerPage} - var(--spacing-items) * (${slidesPerPage} - 1) / ${slidesPerPage})`;
 
         const itemStyles = {
             scrollSnapAlign: props.align,


### PR DESCRIPTION
There is a small issue introduced in the refactor of the Carousel in v11-alpha-9 that breaks the content inside of Carousel's items. In file `useCarousel.ts` some styles are set. One of them is the gap with the spacing prop, that is correct. The problem is that it uses the `--spacing` variable and overwrites it with the gap. This variable is used below and works well.

The issue comes with the content, as `--spacing` is overwritten all the tailwind gaps use the new value (16px by default) breaking the content layout.

This PR fixes the issue #8445 .
