### PR TITLE
fix(datatable): prevent stale closures when cellMemo is enabled

### DIFF
--- a/components/lib/datatable/DataTableBase.js
+++ b/components/lib/datatable/DataTableBase.js
@@ -432,7 +432,7 @@ export const DataTableBase = ComponentBase.extend({
         breakpoint: '960px',
         cellClassName: null,
         cellMemo: true,
-        cellMemoProps: ['rowData', 'field', 'allowCellSelection', 'isCellSelected', 'editMode', 'index', 'tabIndex', 'editing', 'expanded', 'editingMeta', 'frozenCol', 'alignFrozenCol'],
+        cellMemoProps: ['rowData', 'field', 'allowCellSelection', 'isCellSelected', 'editMode', 'rowIndex', 'tabIndex', 'editing', 'expanded', 'editingMeta', 'frozenCol', 'alignFrozenCol'],
         cellMemoPropsDepth: 1,
         cellSelection: false,
         checkIcon: null,


### PR DESCRIPTION
### Problem
When `cellMemo` is enabled, memoized DataTable cells are not re-rendered for
existing rows when new rows are added, which can lead to stale closures in
`body` event handlers.

### Solution
This change replaces `index` with `rowIndex` in `cellMemoProps`, ensuring
memoized cells are refreshed when row structure changes, while preserving
existing memoization behavior.

### Notes
- Minimal and isolated change
- No public API changes
- Verified via reproduction and code inspection
- Full `build:package` was not run on Windows due to missing generated assets (`components/libicons`)

Fixes #8450 ( PrimeReact Datatable cellMemo causes stale closures in event handlers )
