### PR TITLE
Fix Menu popup hover flicker

### DIFF
--- a/public/themes/arya-green/theme.css
+++ b/public/themes/arya-green/theme.css
@@ -1537,6 +1537,9 @@
     border-radius: 3px;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
   }
+  .p-menu .p-menuitem-link {
+    transition: none;
+  }
   .p-mention-panel .p-mention-items {
     padding: 0.5rem 0;
   }


### PR DESCRIPTION
### Fix Menu popup hover flicker

#### Description
Popup Menu items had a visible hover delay when moving rapidly between items.
This was caused by inherited CSS transitions on `.p-menuitem-link`, which led
to overlapping hover-in / hover-out animations and resulted in visual glitches.

#### Solution
Disable transitions specifically for popup Menu items by adding an explicit
rule for `.p-menu .p-menuitem-link`.

This ensures hover styles are applied immediately, eliminating flicker and
improving UX consistency.

#### Scope of Change
- CSS-only change
- Scoped strictly to popup Menu (`.p-menu`)
- No impact on Menubar, MegaMenu, or other navigation components
- No API or behavior changes

#### Verification
- Reproduced the issue locally using the Menu → Popup demo
- Verified hover behavior by moving quickly between items
- Confirmed via DevTools that `transition: none` is applied to
  `.p-menuitem-link`

Fixes #7506 (Menu: Visual glitches in hovering effect)