### PR TITLE
Docs: Clarify locale precedence when using PrimeReactProvider

### DIFF
--- a/components/doc/configuration/locale/setuplocaledoc.js
+++ b/components/doc/configuration/locale/setuplocaledoc.js
@@ -31,25 +31,27 @@ export default function MyApp({ Component }) {
                 </p>
 
                 <p>
-                    When <b>PrimeReactProvider</b> is used, it becomes the primary source of locale
-                    configuration for all PrimeReact components.
+                    When <b>PrimeReactProvider</b> is used, it becomes the primary source of locale configuration for all PrimeReact components.
                 </p>
 
                 <h5>Locale Precedence</h5>
-                <p>
-                    Locale resolution follows the order below:
-                </p>
+                <p>Locale resolution follows the order below:</p>
                 <ul>
-                    <li><code>locale</code> prop defined on a component</li>
-                    <li><code>PrimeReactProvider</code> (<code>context.locale</code>)</li>
-                    <li>Global <code>PrimeReact.locale</code> set via <code>locale()</code></li>
+                    <li>
+                        <code>locale</code> prop defined on a component
+                    </li>
+                    <li>
+                        <code>PrimeReactProvider</code> (<code>context.locale</code>)
+                    </li>
+                    <li>
+                        Global <code>PrimeReact.locale</code> set via <code>locale()</code>
+                    </li>
                     <li>Browser locale</li>
                 </ul>
 
                 <p>
                     This means that once <b>PrimeReactProvider</b> is present, calling
-                    <code> locale()</code> alone is not sufficient. The locale must be provided
-                    explicitly through the provider.
+                    <code> locale()</code> alone is not sufficient. The locale must be provided explicitly through the provider.
                 </p>
             </DocSectionText>
 


### PR DESCRIPTION
### Description

This PR clarifies locale resolution behavior when using `PrimeReactProvider`.

It documents the locale precedence order and explains why calling `locale()` alone
does not override the provider locale once a context is present.

### Motivation

This resolves confusion discussed in #8349, where components (notably InputNumber)
appeared to ignore the global locale when wrapped with `PrimeReactProvider`.

### Changes
- Documented locale precedence order
- Clarified PrimeReactProvider as the primary locale source
- Added an explicit provider-based locale example

Fixes #8349 (InputNumber: Respect Global Locale)