### PR TITLE
Fix: forward autoComplete prop to input-based components

### DIFF
--- a/components/lib/inputmask/InputMask.js
+++ b/components/lib/inputmask/InputMask.js
@@ -634,6 +634,7 @@ export const InputMask = React.memo(
             <InputText
                 ref={elementRef}
                 autoFocus={props.autoFocus}
+                autoComplete={props.autoComplete}
                 id={props.id}
                 type={props.type}
                 name={props.name}

--- a/components/lib/inputtext/InputText.js
+++ b/components/lib/inputtext/InputText.js
@@ -81,6 +81,7 @@ export const InputText = React.memo(
         const rootProps = mergeProps(
             {
                 className: classNames(props.className, cx('root', { context, isFilled })),
+                autoComplete: props.autoComplete,
                 onBeforeInput: onBeforeInput,
                 onInput: onInput,
                 onKeyDown: onKeyDown,

--- a/components/lib/inputtextarea/InputTextarea.js
+++ b/components/lib/inputtextarea/InputTextarea.js
@@ -139,6 +139,7 @@ export const InputTextarea = React.memo(
             {
                 ref: elementRef,
                 className: classNames(props.className, cx('root', { context, isFilled })),
+                autoComplete: props.autoComplete,
                 onFocus: onFocus,
                 onBlur: onBlur,
                 onKeyUp: onKeyUp,

--- a/components/lib/password/Password.js
+++ b/components/lib/password/Password.js
@@ -461,6 +461,7 @@ export const Password = React.memo(
             {
                 ref: inputRef,
                 id: props.inputId,
+                autoComplete: props.autoComplete,
                 ...inputProps,
                 className: classNames(props.inputClassName, cx('input')),
                 onBlur: onBlur,


### PR DESCRIPTION
### Summary
- Forwards the `autoComplete` prop to underlying native input elements
- Resolves browser DOM warnings related to missing autocomplete attributes
- Improves accessibility without introducing defaults or breaking changes

### Affected Components
- InputText
- InputMask
- Password
- InputTextarea

Fixes #8151 [DOM Warning] Input elements rendered by PrimeReact lack autocomplete attributes (e.g., "username", "tel")