### PR TITLE
Fix Calendar displaying value when controlled state is not updated

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -70,13 +70,6 @@ export const Calendar = React.memo(
         const [yearOptions, setYearOptions] = React.useState([]);
 
         const previousValue = usePrevious(props.value);
-
-        React.useEffect(() => {
-            if (props.value !== previousValue) {
-                updateInputfieldRef.current && updateInputfieldRef.current(props.value);
-            }
-        }, [props.value, previousValue]);
-
         const visible = props.inline || (props.onVisibleChange ? props.visible : overlayVisibleState);
         const attributeSelector = UniqueComponentId();
         const panelId = idState + '_panel';
@@ -3044,6 +3037,12 @@ export const Calendar = React.memo(
         React.useEffect(() => {
             ObjectUtils.combinedRefs(inputRef, props.inputRef);
         }, [inputRef, props.inputRef]);
+
+        React.useEffect(() => {
+            if (props.value !== previousValue) {
+                updateInputfieldRef.current && updateInputfieldRef.current(props.value);
+            }
+        }, [props.value, previousValue]);
 
         useMountEffect(() => {
             let viewDate = getViewDate(props.viewDate);


### PR DESCRIPTION
### Fix: Calendar displays incorrect value when controlled value is not updated

#### Problem
When the Calendar component is used as a controlled component, it updates its input field optimistically on date selection.  
If the parent component intentionally does not update the `value` in `onChange` (e.g. user cancels a confirmation dialog), the input temporarily displays an incorrect date.

#### Solution
- Removed optimistic input updates on date selection
- Ensured the input value is always derived from `props.value`
- Input now updates only when the external value actually changes

This restores proper controlled component behavior and fixes issue #7428.

#### Reproducer
https://codesandbox.io/p/sandbox/primereact-calendar-displays-incorrect-value-if-new-value-was-not-applied-in-onchange-sw2547

Calendar: incorrect value is displayed #7428