### PR TITLE
fix(DataTable): debounce global filter in Customers demo to improve performance

### DIFF
--- a/components/doc/datatable/samples/customersdoc.js
+++ b/components/doc/datatable/samples/customersdoc.js
@@ -49,14 +49,14 @@ export const CustomersDoc = (props) => {
     const [statuses] = useState(['unqualified', 'qualified', 'new', 'negotiation', 'renewal']);
 
     useEffect(() => {
-    setFilters((prevFilters) => ({
-        ...prevFilters,
-        global: {
-            ...prevFilters.global,
-            value: debouncedGlobalFilterValue
-        }
-    }));
-}, [debouncedGlobalFilterValue]);
+        setFilters((prevFilters) => ({
+            ...prevFilters,
+            global: {
+                ...prevFilters.global,
+                value: debouncedGlobalFilterValue
+            }
+        }));
+    }, [debouncedGlobalFilterValue]);
 
     const getSeverity = (status) => {
         switch (status) {
@@ -102,7 +102,7 @@ export const CustomersDoc = (props) => {
     };
 
     const onGlobalFilterChange = (e) => {
-    setGlobalFilterValue(e.target.value);
+        setGlobalFilterValue(e.target.value);
     };
 
     const renderHeader = () => {


### PR DESCRIPTION
### Problem
Typing in the global filter of the Customers DataTable demo causes noticeable lag when row count is increased (e.g. 50+ rows), as filters are updated on every keystroke, triggering full table re-renders.

### Solution
Applied `useDebounce` to the global filter input and moved filter updates into a debounced effect so filtering only runs after typing pauses.

### Impact
- Smooth typing for larger datasets
- No behavior change to filtering logic
- Demo now reflects recommended performance best practices

### Testing
- Verified locally with 50+ rows
- Confirmed reduced re-renders using React Profiler

Fixes: #8460 (DataTable demo: noticeable lag and whole-table re-renders when increasing rows (demo reproduction))