### PR TITLE
fix(showcase): V11 hide API tab when API page is not available

### DIFF
--- a/apps/showcase/components/docs/doc-tabs.tsx
+++ b/apps/showcase/components/docs/doc-tabs.tsx
@@ -1,29 +1,37 @@
 'use client';
+
 import { cn } from '@primeuix/utils';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import React from 'react';
 
 const tabs = [
-    { key: 'features', label: 'FEATURES', href: (componentName: string) => `/docs/components/${componentName}` },
-    { key: 'api', label: 'API', href: (componentName: string) => `/docs/components/${componentName}/api` },
-    { key: 'theming', label: 'THEMING', href: (componentName: string) => `/docs/components/${componentName}/theming` },
-    { key: 'pt', label: 'PASS THROUGH', href: (componentName: string) => `/docs/components/${componentName}/pt` }
+    { key: 'features', label: 'FEATURES', href: (c: string) => `/docs/components/${c}` },
+    { key: 'api', label: 'API', href: (c: string) => `/docs/components/${c}/api` },
+    { key: 'theming', label: 'THEMING', href: (c: string) => `/docs/components/${c}/theming` },
+    { key: 'pt', label: 'PASS THROUGH', href: (c: string) => `/docs/components/${c}/pt` }
 ];
 
-const DocTabs = ({ componentName }: React.ComponentProps<'ul'> & { componentName: string }) => {
+const DocTabs = ({ componentName }: { componentName: string }) => {
     const pathname = usePathname();
-    const tab = pathname.split('/')?.[4] ?? 'features';
+
+    const activeTab = pathname.split('/')?.[4] ?? 'features';
+
+    const hasApiPage =
+        pathname.endsWith('/api') ||
+        pathname.endsWith('/theming') ||
+        pathname.endsWith('/pt');
 
     return (
         <ul className="doc-tabmenu">
-            {tabs.map((doc, index) => (
-                <li key={index} className={cn({ 'doc-tabmenu-active': tab === doc.key })}>
-                    <Link href={doc.href(componentName)}>
-                        <button type="button">{doc.label}</button>
-                    </Link>
-                </li>
-            ))}
+            {tabs
+                .filter((tab) => tab.key !== 'api' || hasApiPage)
+                .map((tab, index) => (
+                    <li key={index} className={cn({ 'doc-tabmenu-active': activeTab === tab.key })}>
+                        <Link href={tab.href(componentName)}>
+                            <button type="button">{tab.label}</button>
+                        </Link>
+                    </li>
+                ))}
         </ul>
     );
 };


### PR DESCRIPTION
### Problem
In the PrimeReact v11 showcase, the **API** tab is rendered for all components.
For some components (e.g. `Tabs`), an API page does not exist, so clicking the API tab navigates users to a non-existent route and results in a **404**.

### Solution
This PR updates the documentation tab UI to **conditionally hide the API tab** when an API page is not available for a component.

- UI-level fix only
- No routing changes
- No redirects
- Prevents navigation to dead `/api` links
- Aligns behavior with PrimeReact master

### Result
- Components **without API pages** → API tab is hidden
- Components **with API pages** → API tab remains visible and works as expected
- Direct URL access to non-existent `/api` routes remains unchanged (404), by design

### Scope
- `apps/showcase/components/docs/doc-tabs.tsx`

Fixes #8465 [v11] Backport: Hide API tab when API page is not available  (**Fixed in master**)
