### PR TITLE
Fix: Unique id for MultiState checkbox

### DIFF
--- a/components/lib/multistatecheckbox/MultiStateCheckbox.js
+++ b/components/lib/multistatecheckbox/MultiStateCheckbox.js
@@ -4,7 +4,7 @@ import { Checkbox } from '../checkbox/Checkbox';
 import { useHandleStyle } from '../componentbase/ComponentBase';
 import { useMergeProps, useMountEffect } from '../hooks/Hooks';
 import { Tooltip } from '../tooltip/Tooltip';
-import { classNames, DomHandler, IconUtils, ObjectUtils } from '../utils/Utils';
+import { classNames, DomHandler, IconUtils, ObjectUtils, UniqueComponentId } from '../utils/Utils';
 import { MultiStateCheckboxBase } from './MultiStateCheckboxBase';
 
 export const MultiStateCheckbox = React.memo(
@@ -167,9 +167,12 @@ export const MultiStateCheckbox = React.memo(
             ptm('root')
         );
 
+        const inputId = React.useMemo(() => props.id || UniqueComponentId(), [props.id]);
+
         const checkboxProps = mergeProps(
             {
-                id: props.id + '_checkbox',
+                id: inputId + '_checkbox',
+                inputId: props.inputId || inputId + '_multistatecheckbox',
                 className: cx('checkbox'),
                 style: sx('checkbox', { selectedOption }),
                 tabIndex: props.tabIndex,


### PR DESCRIPTION
Fix #8293 

Provided a default inputId (uniquely generated incase if user didn't provide) to the underlying checkbox component to prevent the main issue.
Also fixed: Provided a default unique component id incase if the props.id is not provided by the user to avoid null in main id.

<img width="398" height="234" alt="image" src="https://github.com/user-attachments/assets/1459e23a-e967-422a-bbd0-0316ee91364c" />
