### PR TITLE
add min width for progress bar value

### DIFF
--- a/components/lib/progressbar/ProgressBarBase.js
+++ b/components/lib/progressbar/ProgressBarBase.js
@@ -25,6 +25,7 @@ const styles = `
       align-items: center;
       justify-content: center;
       overflow: hidden;
+      min-width: max-content;
   }
   
   .p-progressbar-determinate .p-progressbar-label {


### PR DESCRIPTION
Fix #8472

### The issue
Progress bar value becomes unreadable when value is too low %.

### The fix
set min width of progress bar determinate to 'max-content', so that value can be seen.
<img width="1174" height="661" alt="Screenshot 2026-01-13 at 13 46 49" src="https://github.com/user-attachments/assets/6c1feb3a-f285-48c0-aec1-a86bc6a9b7c9" />

