### PR TITLE
Fix: Display value and clear icon in Dropdown when options are empty

### DIFF
--- a/components/lib/dropdown/Dropdown.js
+++ b/components/lib/dropdown/Dropdown.js
@@ -1100,7 +1100,8 @@ export const Dropdown = React.memo(
                 return <input {...inputProps} />;
             }
 
-            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, selectedOption, props) : label || props.placeholder || props.emptyMessage || <>&nbsp;</>;
+            const templateValue = selectedOption || props.value;
+            const content = props.valueTemplate ? ObjectUtils.getJSXElement(props.valueTemplate, templateValue, props) : label || props.placeholder || props.emptyMessage || <>&nbsp;</>;
             const inputProps = mergeProps(
                 {
                     ref: inputRef,
@@ -1121,7 +1122,7 @@ export const Dropdown = React.memo(
         };
 
         const createClearIcon = () => {
-            if (props.value != null && props.showClear && !props.disabled && !ObjectUtils.isEmpty(props.options)) {
+            if (props.value != null && props.showClear && !props.disabled) {
                 const clearIconProps = mergeProps(
                     {
                         className: cx('clearIcon'),

--- a/components/lib/dropdown/DropdownBase.js
+++ b/components/lib/dropdown/DropdownBase.js
@@ -18,7 +18,7 @@ const classes = {
             ? 'p-dropdown-label p-inputtext'
             : classNames('p-dropdown-label p-inputtext', {
                   'p-placeholder': label === null && props.placeholder,
-                  'p-dropdown-label-empty': label === null && !props.placeholder
+                  'p-dropdown-label-empty': label === null && !props.placeholder && !props.value
               }),
     trigger: 'p-dropdown-trigger',
     emptyMessage: 'p-dropdown-empty-message',


### PR DESCRIPTION
For #8269 

# Changes
1. Added a new fallback value in rendering of content which takes the value from props.value incase the selectedOption is not present, as highlighted in issue.
2. Removed the empty options value check. 

<img width="594" height="251" alt="image" src="https://github.com/user-attachments/assets/967aacf7-0faa-4438-ad59-d6aee02b822d" />
