### PR TITLE
fix(datatable): restore state after locale initialization

### DIFF
--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -83,6 +83,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
     const columnSortFunction = React.useRef(null);
     const columnField = React.useRef(null);
     const filterTimeout = React.useRef(null);
+    const restoredRef = React.useRef(false);
 
     if (props.rows !== d_rowsState && !props.onPage) {
         setRowsState(props.rows);
@@ -341,16 +342,18 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             }
 
             if (restoredState.filters) {
-                setD_filtersState(cloneFilters(restoredState.filters));
+                const clonedFilters = cloneFilters(restoredState.filters);
+
+                setD_filtersState(clonedFilters);
 
                 if (props.onFilter) {
                     props.onFilter(
                         createEvent({
-                            filters: restoredState.filters
+                            filters: clonedFilters
                         })
                     );
                 } else {
-                    setFiltersState(cloneFilters(restoredState.filters));
+                    setFiltersState(clonedFilters);
                 }
             }
 
@@ -1507,16 +1510,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             elementRef.current.setAttribute(attributeSelector.current, '');
         }
 
-        //setFiltersState(cloneFilters(props.filters)); // Github #4248
         setD_filtersState(cloneFilters(props.filters));
-
-        if (isStateful()) {
-            restoreState();
-
-            if (props.resizableColumns) {
-                restoreColumnWidths();
-            }
-        }
     });
 
     useUpdateEffect(() => {
@@ -1528,6 +1522,18 @@ export const DataTable = React.forwardRef((inProps, ref) => {
             destroyResponsiveStyle();
         };
     }, [props.breakpoint]);
+
+    useUpdateEffect(() => {
+        if (!restoredRef.current && isStateful()) {
+            restoredRef.current = true;
+
+            restoreState();
+
+            if (props.resizableColumns) {
+                restoreColumnWidths();
+            }
+        }
+    }, [context?.locale]);
 
     useUpdateEffect(() => {
         const filters = cloneFilters(props.filters);

--- a/components/lib/datatable/DataTable.js
+++ b/components/lib/datatable/DataTable.js
@@ -1533,7 +1533,7 @@ export const DataTable = React.forwardRef((inProps, ref) => {
                 restoreColumnWidths();
             }
         }
-    }, [context?.locale]);
+    }, [context]);
 
     useUpdateEffect(() => {
         const filters = cloneFilters(props.filters);


### PR DESCRIPTION
**Description**

- This PR fixes an issue where localized filter match mode labels were not applied when stateStorage is enabled in DataTable.
- The root cause was that table state restoration was happening before the locale was available, causing filters to be initialized with default (English) strings.

**What’s changed**

1. Delayed restoreState() until PrimeReactContext.locale is ready.
2. Ensured state restoration runs only once using a ref guard.
3. Kept mount logic clean (no timeouts or double filter mutations).
4. Column widths continue to restore as before.

**Result**

- [x] Localized filter labels now work correctly with stateStorage.
- [x] No behavioral regressions for existing stateful tables.
- [x] Fix follows existing PrimeReact lifecycle patterns.

**Related Issue**

- Fixes #8478
- Fixed #8478 