### PR TITLE
fix(orderlist): preserve original order when moving multi-selected items

### DIFF
--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -69,9 +69,15 @@ export const OrderList = React.memo(
             if (selected) {
                 newSelection = metaKey ? selectionState.filter((_, i) => i !== selectedIndex) : [value];
             } else {
-                newSelection = metaKey ? [...selectionState, value] : [value];
-            }
+                if (metaKey) {
+                    const merged = [...selectionState, value];
 
+                    // sort selection by original list order
+                    newSelection = merged.sort((a, b) => props.value.indexOf(a) - props.value.indexOf(b));
+                } else {
+                    newSelection = [value];
+                }
+            }
             setSelectionState(newSelection);
         };
 

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -71,7 +71,7 @@ export const OrderList = React.memo(
             } else {
                 if (metaKey) {
                     const merged = [...selectionState, value];
-                    
+
                     newSelection = merged.sort((a, b) => props.value.indexOf(a) - props.value.indexOf(b));
                 } else {
                     newSelection = [value];

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -71,6 +71,7 @@ export const OrderList = React.memo(
             } else {
                 if (metaKey) {
                     const merged = [...selectionState, value];
+                    
                     newSelection = merged.sort((a, b) => props.value.indexOf(a) - props.value.indexOf(b));
                 } else {
                     newSelection = [value];

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -71,8 +71,9 @@ export const OrderList = React.memo(
             } else {
                 if (metaKey) {
                     const merged = [...selectionState, value];
+                    const list = props.value || [];
 
-                    newSelection = merged.sort((a, b) => props.value.indexOf(a) - props.value.indexOf(b));
+                    newSelection = merged.sort((a, b) => list.indexOf(a) - list.indexOf(b));
                 } else {
                     newSelection = [value];
                 }

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -76,7 +76,7 @@ export const OrderList = React.memo(
                     newSelection = [value];
                 }
             }
-            
+
             setSelectionState(newSelection);
         };
 

--- a/components/lib/orderlist/OrderList.js
+++ b/components/lib/orderlist/OrderList.js
@@ -71,13 +71,12 @@ export const OrderList = React.memo(
             } else {
                 if (metaKey) {
                     const merged = [...selectionState, value];
-
-                    // sort selection by original list order
                     newSelection = merged.sort((a, b) => props.value.indexOf(a) - props.value.indexOf(b));
                 } else {
                     newSelection = [value];
                 }
             }
+            
             setSelectionState(newSelection);
         };
 


### PR DESCRIPTION
**Defect Fix**

This PR addresses a multi-selection ordering issue in OrderList where items selected out of sequence (e.g., Ctrl-click) were reordered incorrectly when moved to the top or bottom.

**Summary of changes:**

Normalize multi-selection by sorting selected items based on their original list index before reorder operations.
Ensures selected items always retain their visual order regardless of selection sequence.

**Notes**

This is a focused UX bug fix with no API changes.
Only components/orderlist/OrderList.js is affected.
Behavior now matches user expectations and native list reordering patterns.

Fixes: #8496
Fixed:#8496
Fixes: #8495
Fixed:#8495

(Duplicate due to ci error)