### PR TITLE
fix(InputNumber): decide prefix suffix using formatToParts

### DIFF
--- a/components/lib/inputnumber/InputNumber.js
+++ b/components/lib/inputnumber/InputNumber.js
@@ -134,7 +134,15 @@ export const InputNumber = React.memo(
             } else {
                 const formatter = new Intl.NumberFormat(_locale, { style: props.mode, currency: props.currency, currencyDisplay: props.currencyDisplay });
 
-                prefixChar.current = formatter.format(1).split('1')[0];
+                // Use formatToParts instead of split('1') so that locales with
+                // non-ASCII numerals (e.g. Bengali ১) are handled correctly.
+                const parts = formatter.formatToParts(1);
+                const integerIndex = parts.findIndex((p) => p.type === 'integer');
+
+                prefixChar.current = parts
+                    .slice(0, integerIndex)
+                    .map((p) => p.value)
+                    .join('');
             }
 
             return new RegExp(`${escapeRegExp(prefixChar.current || '')}`, 'g');
@@ -153,7 +161,15 @@ export const InputNumber = React.memo(
                     roundingMode: props.roundingMode
                 });
 
-                suffixChar.current = formatter.format(1).split('1')[1];
+                // Use formatToParts instead of split('1') so that locales with
+                // non-ASCII numerals (e.g. Bengali ১) are handled correctly.
+                const parts = formatter.formatToParts(1);
+                const integerIndex = parts.findIndex((p) => p.type === 'integer');
+
+                suffixChar.current = parts
+                    .slice(integerIndex + 1)
+                    .map((p) => p.value)
+                    .join('');
             }
 
             return new RegExp(`${escapeRegExp(suffixChar.current || '')}`, 'g');


### PR DESCRIPTION
Fix: #8521 

### Problem: 
- In locale bn, typing first digit 1 (displayed as ১) can produce event.value = null on first input.

### Root cause:
- Prefix extraction logic relies on splitting formatted 1 by ASCII 1, which fails for locales using non-ASCII digits.

### Repro:
- Render InputNumber with locale bn and allowEmpty true
- Focus empty input
- Type 1
- Observe onValueChange gives null for first keystroke

### Expected:
- First keystroke should produce numeric value 1

### Proposed fix:
- Avoid ASCII-only split logic in prefix detection
- Derive prefix/suffix using formatToParts and the integer/decimal parts, which is locale-safe for non-Latin numerals