### PR TITLE
fix: prevent MultiSelect overlay from closing on drag-end events orig…

### DIFF
--- a/components/lib/multiselect/MultiSelect.js
+++ b/components/lib/multiselect/MultiSelect.js
@@ -32,6 +32,7 @@ export const MultiSelect = React.memo(
         const labelContainerRef = React.useRef(null);
         const overlayRef = React.useRef(null);
         const labelRef = React.useRef(null);
+        const mousedownInsideOverlay = React.useRef(false);
         const hasFilter = filterState && filterState.trim().length > 0;
         const empty = ObjectUtils.isEmpty(props.value);
         const equalityKey = props.optionValue ? null : props.dataKey;
@@ -46,15 +47,38 @@ export const MultiSelect = React.memo(
         const { ptm, cx, sx, isUnstyled } = MultiSelectBase.setMetaData(metaData);
 
         useHandleStyle(MultiSelectBase.css.styles, isUnstyled, { name: 'multiselect' });
+        const onOverlayMouseDown = React.useCallback((event) => {
+            mousedownInsideOverlay.current =
+                (overlayRef.current && overlayRef.current.contains(event.target)) ||
+                (elementRef.current && elementRef.current.contains(event.target));
+        }, []);
+
+        React.useEffect(() => {
+            if (overlayVisibleState) {
+                document.addEventListener('mousedown', onOverlayMouseDown);
+            } else {
+                document.removeEventListener('mousedown', onOverlayMouseDown);
+                mousedownInsideOverlay.current = false;
+            }
+
+            return () => {
+                document.removeEventListener('mousedown', onOverlayMouseDown);
+            };
+        }, [overlayVisibleState, onOverlayMouseDown]);
+
         const [bindOverlayListener, unbindOverlayListener] = useOverlayListener({
             target: elementRef,
             overlay: overlayRef,
             listener: (event, { type, valid }) => {
                 if (valid) {
                     if (type === 'outside') {
-                        if (!isClearClicked(event) && !isSelectAllClicked(event)) {
+                        // Ignore clicks that are the tail end of a drag that started inside
+                        // the overlay (e.g. text-selection in the filter input).
+                        if (!mousedownInsideOverlay.current && !isClearClicked(event) && !isSelectAllClicked(event)) {
                             hide();
                         }
+
+                        mousedownInsideOverlay.current = false;
                     } else if (context.hideOverlaysOnDocumentScrolling) {
                         hide();
                     } else if (!DomHandler.isDocument(event.target)) {


### PR DESCRIPTION
### Defect Fixes

Fixes #8517 

**Describe the bug:**
When using `MultiSelect` with filtering enabled, if a user clicks and drags to select text inside the filter input, and then releases the mouse outside the panel boundary, the overlay unexpectedly closes. This makes normal text-selection behavior feel broken because the panel is dismissed even though the interaction started inside the multiselect component.

**Expected behavior:**
The overlay should remain open. Releasing the mouse outside after starting a text-selection or drag interaction inside the `MultiSelect` component should not be treated as an outside dismiss action.

**Solution:**
Implemented a `mousedownInsideOverlay` ref to track where the `mousedown` event originated. Added a `document` `mousedown` listener (active only while the overlay is visible) to set this flag if the target is within the `MultiSelect` trigger or overlay. In the `useOverlayListener`'s outside-click handler, we now ignore the dismiss action if the preceding `mousedown` originated inside the component, preventing unintended closures during drag-and-drop or text-selection gestures.