### PR TITLE
fix: prevent unnecessary state updates in Tooltip by checking for value changes

### DIFF
--- a/components/lib/tooltip/Tooltip.js
+++ b/components/lib/tooltip/Tooltip.js
@@ -463,8 +463,14 @@ export const Tooltip = React.memo(
                 const position = getPosition(currentTargetRef.current);
                 const classname = getTargetOption(currentTargetRef.current, 'classname');
 
-                setPositionState(position);
-                setClassNameState(classname);
+                if (position !== positionState) {
+                    setPositionState(position);
+                }
+
+                if (classname !== classNameState) {
+                    setClassNameState(classname);
+                }
+
                 updateTooltipState(position);
 
                 bindWindowResizeListener();


### PR DESCRIPTION
### Defect Fixes / Small Enhancements

Fixes #8524 

**Describe the changes:**
In the `Tooltip` component, the `setPositionState` and `setClassNameState` functions within the `useUpdateEffect` hook were being invoked unconditionally every time the tooltip became visible. 

Although React internals typically bail out of re-renders when the new state precisely matches the old state, invoking the setters unconditionally still incurs slight overhead by adding unnecessary calls to React's state update queue. 

This PR implements a minor micro-optimization by adding explicit `if` checks:
```javascript
if (position !== positionState) {
    setPositionState(position);
}

if (classname !== classNameState) {
    setClassNameState(classname);
}
