### PR TITLE
perf: memoize icon, label, and badge rendering in Button component to prevent unnecessary re-renders

### DIFF
--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -107,9 +107,9 @@ export const Button = React.memo(
         };
         const size = sizeMapping[props.size];
 
-        const icon = createIcon();
-        const label = createLabel();
-        const badge = createBadge();
+        const icon = React.useMemo(() => createIcon(), [props.icon, props.loading, props.iconPos, props.label, props.loadingIcon]);
+        const label = React.useMemo(() => createLabel(), [props.label, props.children]);
+        const badge = React.useMemo(() => createBadge(), [props.badge, props.badgeClassName, props.unstyled]);
         const defaultAriaLabel = props.label ? props.label + (props.badge ? ' ' + props.badge : '') : props['aria-label'];
 
         const rootProps = mergeProps(


### PR DESCRIPTION
Closes #8526 

### Defect Fixes
This PR improves the performance of the Button component by memoizing the results of createIcon, createLabel, and createBadge.

Currently, these helper functions are executed on every render, even when their dependent props do not change. This may lead to unnecessary recalculations in scenarios where the Button component re-renders frequently.

💡 Changes
Wrapped createIcon, createLabel, and createBadge with React.useMemo
Added appropriate dependency arrays based on relevant props
