### PR TITLE
perf(button): memoize icon, label and badge rendering

### DIFF
--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -60,16 +60,7 @@ export const Button = React.memo(
             const iconValue = props.loading ? props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin /> : props.icon;
 
             return IconUtils.getJSXIcon(iconValue, { ...iconsProps }, { props });
-        }, [
-            props.icon,
-            props.loading,
-            props.iconPos,
-            props.loadingIcon,
-            props.label,
-            mergeProps,
-            ptm,
-            cx
-        ]);
+        }, [props.icon, props.loading, props.iconPos, props.loadingIcon, props.label, mergeProps, ptm, cx]);
 
         const label = React.useMemo(() => {
             const labelProps = mergeProps(
@@ -83,16 +74,8 @@ export const Button = React.memo(
                 return <span {...labelProps}>{props.label}</span>;
             }
 
-            return !props.children && !props.label && (
-                <span {...labelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} />
-            );
-        }, [
-            props.label,
-            props.children,
-            mergeProps,
-            ptm,
-            cx
-        ]);
+            return !props.children && !props.label && <span {...labelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} />;
+        }, [props.label, props.children, mergeProps, ptm, cx]);
 
         const badge = React.useMemo(() => {
             if (props.badge) {
@@ -110,14 +93,7 @@ export const Button = React.memo(
             }
 
             return null;
-        }, [
-            props.badge,
-            props.badgeClassName,
-            props.unstyled,
-            mergeProps,
-            ptm,
-            metaData
-        ]);
+        }, [props.badge, props.badgeClassName, props.unstyled, mergeProps, ptm, metaData]);
 
         // ✅ AFTER hooks (important)
         if (props.visible === false) {
@@ -134,9 +110,7 @@ export const Button = React.memo(
 
         const size = sizeMapping[props.size];
 
-        const defaultAriaLabel = props.label
-            ? props.label + (props.badge ? ' ' + props.badge : '')
-            : props['aria-label'];
+        const defaultAriaLabel = props.label ? props.label + (props.badge ? ' ' + props.badge : '') : props['aria-label'];
 
         const rootProps = mergeProps(
             {
@@ -159,14 +133,7 @@ export const Button = React.memo(
                     {badge}
                     <Ripple />
                 </button>
-                {hasTooltip && (
-                    <Tooltip
-                        target={elementRef}
-                        content={props.tooltip}
-                        pt={ptm('tooltip')}
-                        {...props.tooltipOptions}
-                    />
-                )}
+                {hasTooltip && <Tooltip target={elementRef} content={props.tooltip} pt={ptm('tooltip')} {...props.tooltipOptions} />}
             </>
         );
     })

--- a/components/lib/button/Button.js
+++ b/components/lib/button/Button.js
@@ -34,11 +34,7 @@ export const Button = React.memo(
             ObjectUtils.combinedRefs(elementRef, ref);
         }, [elementRef, ref]);
 
-        if (props.visible === false) {
-            return null;
-        }
-
-        const createIcon = () => {
+        const icon = React.useMemo(() => {
             let className = classNames('p-button-icon p-c', {
                 [`p-button-icon-${props.iconPos}`]: props.label
             });
@@ -61,12 +57,21 @@ export const Button = React.memo(
                 ptm('loadingIcon')
             );
 
-            const icon = props.loading ? props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin /> : props.icon;
+            const iconValue = props.loading ? props.loadingIcon || <SpinnerIcon {...loadingIconProps} spin /> : props.icon;
 
-            return IconUtils.getJSXIcon(icon, { ...iconsProps }, { props });
-        };
+            return IconUtils.getJSXIcon(iconValue, { ...iconsProps }, { props });
+        }, [
+            props.icon,
+            props.loading,
+            props.iconPos,
+            props.loadingIcon,
+            props.label,
+            mergeProps,
+            ptm,
+            cx
+        ]);
 
-        const createLabel = () => {
+        const label = React.useMemo(() => {
             const labelProps = mergeProps(
                 {
                     className: cx('label')
@@ -78,10 +83,18 @@ export const Button = React.memo(
                 return <span {...labelProps}>{props.label}</span>;
             }
 
-            return !props.children && !props.label && <span {...labelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} />;
-        };
+            return !props.children && !props.label && (
+                <span {...labelProps} dangerouslySetInnerHTML={{ __html: '&nbsp;' }} />
+            );
+        }, [
+            props.label,
+            props.children,
+            mergeProps,
+            ptm,
+            cx
+        ]);
 
-        const createBadge = () => {
+        const badge = React.useMemo(() => {
             if (props.badge) {
                 const badgeProps = mergeProps(
                     {
@@ -97,20 +110,33 @@ export const Button = React.memo(
             }
 
             return null;
-        };
+        }, [
+            props.badge,
+            props.badgeClassName,
+            props.unstyled,
+            mergeProps,
+            ptm,
+            metaData
+        ]);
+
+        // ✅ AFTER hooks (important)
+        if (props.visible === false) {
+            return null;
+        }
 
         const showTooltip = !disabled || (props.tooltipOptions && props.tooltipOptions.showOnDisabled);
         const hasTooltip = ObjectUtils.isNotEmpty(props.tooltip) && showTooltip;
+
         const sizeMapping = {
             large: 'lg',
             small: 'sm'
         };
+
         const size = sizeMapping[props.size];
 
-        const icon = createIcon();
-        const label = createLabel();
-        const badge = createBadge();
-        const defaultAriaLabel = props.label ? props.label + (props.badge ? ' ' + props.badge : '') : props['aria-label'];
+        const defaultAriaLabel = props.label
+            ? props.label + (props.badge ? ' ' + props.badge : '')
+            : props['aria-label'];
 
         const rootProps = mergeProps(
             {
@@ -133,7 +159,14 @@ export const Button = React.memo(
                     {badge}
                     <Ripple />
                 </button>
-                {hasTooltip && <Tooltip target={elementRef} content={props.tooltip} pt={ptm('tooltip')} {...props.tooltipOptions} />}
+                {hasTooltip && (
+                    <Tooltip
+                        target={elementRef}
+                        content={props.tooltip}
+                        pt={ptm('tooltip')}
+                        {...props.tooltipOptions}
+                    />
+                )}
             </>
         );
     })


### PR DESCRIPTION
Closes #8526
## Summary

This PR improves the performance of the Button component by memoizing the rendering of icon, label, and badge using `React.useMemo`.

## Changes

- Memoized icon, label, and badge computations
- Inlined helper logic to avoid hook dependency warnings
- Ensured hooks are not conditionally called
- Added proper dependency arrays

## Benefits

- Reduces unnecessary computations during re-renders
- Improves performance in high-frequency rendering scenarios (e.g., lists, forms)
- Aligns with React performance best practices
- No breaking changes

## Testing

- Verified button rendering with:
  - icon changes
  - loading state
  - label updates
  - badge updates
- Ensured no UI regressions

##  Notes

This change maintains full backward compatibility and does not alter the public API.