### PR TITLE
fix: resolve jspdf and jspdf-autotable dependency conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
     "name": "primereact",
-    "version": "10.9.7",
+    "version": "10.9.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "primereact",
-            "version": "10.9.7",
+            "version": "10.9.8",
             "dependencies": {
                 "@docsearch/react": "3.9.0",
                 "chart.js": "4.5.0",
                 "file-saver": "2.0.5",
                 "fs-extra": "^11.3.2",
                 "jspdf": "4.0.0",
-                "jspdf-autotable": "5.0.2",
+                "jspdf-autotable": "^5.0.8",
                 "next": "12.3.7",
                 "path": "^0.12.7",
                 "primeflex": "3.3.1",
@@ -11654,12 +11654,12 @@
             }
         },
         "node_modules/jspdf-autotable": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
-            "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.8.tgz",
+            "integrity": "sha512-Hy05N86yBO7CXBrnSLOge7i1ZYpKH2DjQ94iybaP7vBhSInjvRBgDc99ngKzSbSO8Jc98ZCally8I6n0tj2RJQ==",
             "license": "MIT",
             "peerDependencies": {
-                "jspdf": "^2 || ^3"
+                "jspdf": "^2 || ^3 || ^4"
             }
         },
         "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "file-saver": "2.0.5",
         "fs-extra": "^11.3.2",
         "jspdf": "4.0.0",
-        "jspdf-autotable": "5.0.2",
+        "jspdf-autotable": "^5.0.8",
         "next": "12.3.7",
         "path": "^0.12.7",
         "primeflex": "3.3.1",


### PR DESCRIPTION
## Description

Fixes #8537

This PR updates the `jspdf-autotable` dependency to a newer version that supports `jspdf v4`.

Previously, running:

```bash
npm install
```

after cloning the repository resulted in an `ERESOLVE unable to resolve dependency tree` error because an older `jspdf-autotable` version was being resolved with `jspdf v4`.

Changes:

* Updated `jspdf-autotable` dependency version
* Resolved dependency conflict with `jspdf v4`
* Repository can now be installed without using `--force` or `--legacy-peer-deps`

## Testing

Verified by:

1. Cloning the repository
2. Running:

```bash
npm install
```

