### PR TITLE
fix: datatable row checkbox visibility on landing page

### DIFF
--- a/styles/layout/landing/_themes.scss
+++ b/styles/layout/landing/_themes.scss
@@ -3,4 +3,13 @@
         width: 1250px;
         box-shadow: var(--home-card-shadow);
     }
+
+    .p-checkbox.p-highlight .p-checkbox-box {
+        border-color: var(--primary-color, #06b6d4) !important;
+        background: var(--primary-color, #06b6d4) !important;
+        
+        .p-checkbox-icon {
+            color: var(--primary-color-text, #ffffff) !important;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #8545 

### Problem
On the PrimeReact landing page, the DataTable in the "Themes" section has selectable rows, but clicking the checkboxes does not show the active/checked state (the background color and checkmark are missing). 


### What changes
* Added a localized CSS patch to `styles/layout/landing/_themes.scss`.

### Screenshots
## Before
https://github.com/user-attachments/assets/f5e7c182-3c27-4474-a446-cab275578462

## After
https://github.com/user-attachments/assets/5f59c507-1741-4f05-9ac7-40fd86227622



